### PR TITLE
fix: v2.5.3 - Fix multiple issues and add database cluster support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ dist-ssr
 packages/server/data/*.db
 packages/server/data/*.db-shm
 packages/server/data/*.db-wal
+data/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v2.5.3] - 2026-01-15
+
+### Fixed
+
+- **Metrics Page Auto-Refresh**: Fixed metrics page not automatically refreshing when ClickHouse connection is switched. Metrics now automatically update when switching connections via the connection selector.
+- **SQLite RBAC Migration**: Fixed SQLite syntax error during RBAC initialization caused by reserved keyword 'table' in `rbac_user_favorites` and `rbac_user_recent_items` tables. Column names are now properly quoted in SQLite migrations.
+- **Explorer Auto-Refresh**: Fixed Explorer tab not automatically refreshing when connection changes. Explorer now listens to connection change events and automatically fetches databases and tables from the newly selected connection.
+- **Database Creation with ON CLUSTER**: Fixed database creation to properly support `ON CLUSTER` statements for distributed ClickHouse setups. Removed incorrect condition that prevented cluster creation from working.
+
+### Security
+
+- **Hono Framework**: Upgraded Hono from 4.11.3 to 4.11.4 to address security vulnerability.
+
+### Added
+
+- **Database Cluster Support**: Added cluster selection UI to database creation dialog, matching table creation functionality. Users can now create databases on distributed ClickHouse clusters through the UI.
+
+### Changed
+
+- **Database Creation API**: Updated `CreateDatabase` component to use `createDatabase` API function instead of direct query execution, ensuring proper cluster parameter handling.
+
 ## [v2.5.2] - 2026-01-15
 
 ### Added

--- a/bun.lock
+++ b/bun.lock
@@ -85,7 +85,7 @@
         "@clickhouse/client": "^1.16.0",
         "@hono/zod-validator": "^0.7.6",
         "drizzle-orm": "^0.38.3",
-        "hono": "^4.11.3",
+        "hono": "^4.11.4",
         "jose": "^5.9.6",
         "node-sql-parser": "^5.3.13",
         "postgres": "^3.4.5",
@@ -821,7 +821,7 @@
 
     "highlight.js": ["highlight.js@11.11.1", "", {}, "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w=="],
 
-    "hono": ["hono@4.11.3", "", {}, "sha512-PmQi306+M/ct/m5s66Hrg+adPnkD5jiO6IjA7WhWw0gSBSo1EcRegwuI1deZ+wd5pzCGynCcn2DprnE4/yEV4w=="],
+    "hono": ["hono@4.11.4", "", {}, "sha512-U7tt8JsyrxSRKspfhtLET79pU8K+tInj5QZXs1jSugO1Vq5dFj3kmZsRldo29mTBfcjDRVRXrEZ6LS63Cog9ZA=="],
 
     "ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
 
@@ -1237,6 +1237,8 @@
 
     "zustand": ["zustand@5.0.9", "", { "peerDependencies": { "@types/react": ">=18.0.0", "immer": ">=9.0.6", "react": ">=18.0.0", "use-sync-external-store": ">=1.2.0" }, "optionalPeers": ["@types/react", "immer", "react", "use-sync-external-store"] }, "sha512-ALBtUj0AfjJt3uNRQoL1tL2tMvj6Gp/6e39dnfT6uzpelGru8v1tPOGBzayOWbPJvujM8JojDk3E1LxeFisBNg=="],
 
+    "@chouseui/server/@types/bun": ["@types/bun@1.3.6", "", { "dependencies": { "bun-types": "1.3.6" } }, "sha512-uWCv6FO/8LcpREhenN1d1b6fcspAB+cefwD7uti8C8VffIv0Um08TKMn98FynpTiU38+y2dUO55T11NgDt8VAA=="],
+
     "@chouseui/server/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
     "@esbuild-kit/core-utils/esbuild": ["esbuild@0.18.20", "", { "optionalDependencies": { "@esbuild/android-arm": "0.18.20", "@esbuild/android-arm64": "0.18.20", "@esbuild/android-x64": "0.18.20", "@esbuild/darwin-arm64": "0.18.20", "@esbuild/darwin-x64": "0.18.20", "@esbuild/freebsd-arm64": "0.18.20", "@esbuild/freebsd-x64": "0.18.20", "@esbuild/linux-arm": "0.18.20", "@esbuild/linux-arm64": "0.18.20", "@esbuild/linux-ia32": "0.18.20", "@esbuild/linux-loong64": "0.18.20", "@esbuild/linux-mips64el": "0.18.20", "@esbuild/linux-ppc64": "0.18.20", "@esbuild/linux-riscv64": "0.18.20", "@esbuild/linux-s390x": "0.18.20", "@esbuild/linux-x64": "0.18.20", "@esbuild/netbsd-x64": "0.18.20", "@esbuild/openbsd-x64": "0.18.20", "@esbuild/sunos-x64": "0.18.20", "@esbuild/win32-arm64": "0.18.20", "@esbuild/win32-ia32": "0.18.20", "@esbuild/win32-x64": "0.18.20" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA=="],
@@ -1292,6 +1294,8 @@
     "prop-types/react-is": ["react-is@16.13.1", "", {}, "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="],
 
     "strip-literal/js-tokens": ["js-tokens@9.0.1", "", {}, "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ=="],
+
+    "@chouseui/server/@types/bun/bun-types": ["bun-types@1.3.6", "", { "dependencies": { "@types/node": "*" } }, "sha512-OlFwHcnNV99r//9v5IIOgQ9Uk37gZqrNMCcqEaExdkVq3Avwqok1bJFmvGMCkCE0FqzdY8VMOZpfpR3lwI+CsQ=="],
 
     "@esbuild-kit/core-utils/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.18.20", "", { "os": "android", "cpu": "arm" }, "sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw=="],
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "chouseui",
   "private": true,
   "author": "",
-  "version": "2.5.2",
+  "version": "2.5.3",
   "license": "Apache-2.0",
   "type": "module",
   "workspaces": [

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -19,7 +19,7 @@
     "@clickhouse/client": "^1.16.0",
     "@hono/zod-validator": "^0.7.6",
     "drizzle-orm": "^0.38.3",
-    "hono": "^4.11.3",
+    "hono": "^4.11.4",
     "jose": "^5.9.6",
     "node-sql-parser": "^5.3.13",
     "postgres": "^3.4.5",

--- a/packages/server/src/rbac/db/migrations.ts
+++ b/packages/server/src/rbac/db/migrations.ts
@@ -375,9 +375,9 @@ const MIGRATIONS: Migration[] = [
             id TEXT PRIMARY KEY NOT NULL,
             user_id TEXT NOT NULL REFERENCES rbac_users(id) ON DELETE CASCADE,
             database TEXT NOT NULL,
-            table TEXT,
+            "table" TEXT,
             created_at INTEGER NOT NULL DEFAULT (unixepoch()),
-            UNIQUE(user_id, database, table)
+            UNIQUE(user_id, database, "table")
           )
         `);
 
@@ -389,9 +389,9 @@ const MIGRATIONS: Migration[] = [
             id TEXT PRIMARY KEY NOT NULL,
             user_id TEXT NOT NULL REFERENCES rbac_users(id) ON DELETE CASCADE,
             database TEXT NOT NULL,
-            table TEXT,
+            "table" TEXT,
             accessed_at INTEGER NOT NULL DEFAULT (unixepoch()),
-            UNIQUE(user_id, database, table)
+            UNIQUE(user_id, database, "table")
           )
         `);
 
@@ -779,9 +779,9 @@ async function createSqliteSchemaFromDrizzle(db: SqliteDb): Promise<void> {
       id TEXT PRIMARY KEY NOT NULL,
       user_id TEXT NOT NULL REFERENCES rbac_users(id) ON DELETE CASCADE,
       database TEXT NOT NULL,
-      table TEXT,
+      "table" TEXT,
       created_at INTEGER NOT NULL DEFAULT (unixepoch()),
-      UNIQUE(user_id, database, table)
+      UNIQUE(user_id, database, "table")
     )
   `);
 
@@ -793,9 +793,9 @@ async function createSqliteSchemaFromDrizzle(db: SqliteDb): Promise<void> {
       id TEXT PRIMARY KEY NOT NULL,
       user_id TEXT NOT NULL REFERENCES rbac_users(id) ON DELETE CASCADE,
       database TEXT NOT NULL,
-      table TEXT,
+      "table" TEXT,
       accessed_at INTEGER NOT NULL DEFAULT (unixepoch()),
-      UNIQUE(user_id, database, table)
+      UNIQUE(user_id, database, "table")
     )
   `);
 

--- a/packages/server/src/routes/explorer.ts
+++ b/packages/server/src/routes/explorer.ts
@@ -187,7 +187,7 @@ explorer.post(
 
     let query = `CREATE DATABASE IF NOT EXISTS ${name}`;
     
-    if (cluster && session.connectionConfig.database) {
+    if (cluster) {
       query += ` ON CLUSTER ${cluster}`;
     }
     

--- a/src/components/common/ConnectionSelector.tsx
+++ b/src/components/common/ConnectionSelector.tsx
@@ -229,6 +229,8 @@ export default function ConnectionSelector({
       queryClient.invalidateQueries({ queryKey: ['systemStats'] });
       queryClient.invalidateQueries({ queryKey: ['recentQueries'] });
       queryClient.invalidateQueries({ queryKey: ['queryLogs'] });
+      queryClient.invalidateQueries({ queryKey: ['metrics'] });
+      queryClient.invalidateQueries({ queryKey: ['productionMetrics'] });
 
       // Trigger a refresh of data by dispatching a custom event
       window.dispatchEvent(new CustomEvent('clickhouse:connected', { detail: result }));

--- a/src/features/explorer/components/DataExplorer.tsx
+++ b/src/features/explorer/components/DataExplorer.tsx
@@ -221,6 +221,16 @@ const DatabaseExplorer: React.FC = () => {
     return () => resizeObserver.disconnect();
   }, []);
 
+  // Listen for connection changes and refresh databases
+  useEffect(() => {
+    const handleConnectionChange = () => {
+      refreshDatabases();
+    };
+    
+    window.addEventListener('clickhouse:connected', handleConnectionChange);
+    return () => window.removeEventListener('clickhouse:connected', handleConnectionChange);
+  }, [refreshDatabases]);
+
   return (
     <div ref={containerRef} className="flex flex-col h-full bg-gradient-to-b from-white/[0.02] to-transparent">
       {/* Header */}

--- a/src/pages/Metrics.tsx
+++ b/src/pages/Metrics.tsx
@@ -287,6 +287,17 @@ export default function Metrics() {
     }
   }, [refreshInterval, refetch, refetchProd]);
 
+  // Listen for connection changes and refetch metrics
+  React.useEffect(() => {
+    const handleConnectionChange = () => {
+      refetch();
+      refetchProd();
+    };
+    
+    window.addEventListener('clickhouse:connected', handleConnectionChange);
+    return () => window.removeEventListener('clickhouse:connected', handleConnectionChange);
+  }, [refetch, refetchProd]);
+
   const lastUpdated = dataUpdatedAt ? new Date(dataUpdatedAt).toLocaleTimeString() : "--:--:--";
   const stats = metrics?.currentStats;
 


### PR DESCRIPTION
## Description

This PR fixes multiple bugs and adds database cluster support for v2.5.3 release. All issues have been resolved and the CHANGELOG has been updated.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Related Issues

Closes #10
Closes #13
Closes #14
Closes #15
Closes #16

## Changes Made

### Fixed Issues

1. **Issue #10 - Metrics Page Auto-Refresh**
   - Added query invalidation for metrics queries in `ConnectionSelector.tsx`
   - Added event listener in `Metrics.tsx` to listen for `clickhouse:connected` events
   - Metrics page now automatically refreshes when connection is switched

2. **Issue #13 - Explorer Tab Auto-Refresh**
   - Added event listener in `DataExplorer.tsx` to listen for connection changes
   - Explorer now automatically fetches databases and tables from newly selected connection

3. **Issue #14 - Hono Security Upgrade**
   - Upgraded Hono framework from 4.11.3 to 4.11.4 in `packages/server/package.json`
   - Addresses security vulnerability

4. **Issue #15 - SQLite RBAC Migration Syntax Error**
   - Fixed SQLite syntax error caused by reserved keyword 'table' in `rbac_user_favorites` and `rbac_user_recent_items` tables
   - Added proper quoting for 'table' column in SQLite migrations (`packages/server/src/rbac/db/migrations.ts`)

5. **Issue #16 - Database Creation with ON CLUSTER Support**
   - Fixed backend condition in `packages/server/src/routes/explorer.ts` to remove unnecessary `session.connectionConfig.database` check
   - Added cluster selection UI to `CreateDatabase` component (similar to `CreateTable`)
   - Updated `CreateDatabase` to use `createDatabase` API function instead of direct query execution
   - Added `useClusterNames` hook usage for cluster selection

### Version Update

- Updated version to 2.5.3 in `package.json`
- Updated CHANGELOG.md with all fixes and improvements

## Testing

- [x] I have tested this locally
- [ ] I have added/updated tests
- [x] All existing tests pass

### Test Steps

1. **Metrics Auto-Refresh**: Switch connections using connection selector and verify metrics page refreshes automatically
2. **Explorer Auto-Refresh**: Switch connections and verify explorer tab shows databases from new connection
3. **SQLite Migration**: Test RBAC initialization with SQLite database - should complete without syntax errors
4. **Database Cluster Support**: Create a database with cluster selection enabled - should work correctly
5. **Hono Upgrade**: Verify server starts correctly with new Hono version

## Checklist

- [x] My code follows the project's code style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly (CHANGELOG.md)
- [x] My changes generate no new warnings or errors
- [x] I have checked for breaking changes and documented them (if applicable)
- [x] I have tested the changes in the relevant environment (development)

## Additional Notes

All fixes have been implemented following the existing code patterns and best practices. The changes are backward compatible and do not introduce any breaking changes.