### PR TITLE
fix: Add backward compatibility for RBAC_ENCRYPTION_SALT

### DIFF
--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -42,8 +42,8 @@ function validateEnvironmentVariables(): void {
       },
       {
         key: "RBAC_ENCRYPTION_SALT",
-        exactLength: 64,
-        description: "32-byte (64 hex characters) salt for key derivation - must be unique and random",
+        minLength: 16,
+        description: "32-byte (64 hex characters) salt for key derivation - must be unique and random (minimum 16 characters, recommended 64)",
       },
     ];
 
@@ -71,6 +71,15 @@ function validateEnvironmentVariables(): void {
       warnings.push(
         "CORS_ORIGIN is set to '*' in production. This allows requests from any origin. " +
         "Consider restricting to specific domains for better security."
+      );
+    }
+    
+    // Warn if RBAC_ENCRYPTION_SALT is shorter than recommended
+    const saltValue = process.env.RBAC_ENCRYPTION_SALT;
+    if (saltValue && saltValue.length < 64) {
+      warnings.push(
+        `RBAC_ENCRYPTION_SALT is ${saltValue.length} characters long (recommended: 64). ` +
+        `Shorter salts will be automatically padded, but using a 64-character salt is recommended for better security.`
       );
     }
   } else {


### PR DESCRIPTION
## Problem

Version 2.6.1 introduced a breaking change requiring `RBAC_ENCRYPTION_SALT` to be exactly 64 characters, which breaks existing production deployments with shorter salt values.

## Solution

This PR implements backward compatibility by:

- ✅ Accepting salts that meet minimum length requirement (16 characters, not exactly 64)
- ✅ Automatically padding shorter salts to recommended length using deterministic method
- ✅ Ensuring existing encrypted passwords remain decryptable
- ✅ Showing warning (not error) when salt is shorter than recommended length in production

## Changes

1. **Validation Update** (`packages/server/src/index.ts`):
   - Changed from `exactLength: 64` to `minLength: 16` for `RBAC_ENCRYPTION_SALT`
   - Added warning when salt is shorter than 64 characters in production

2. **Salt Padding** (`packages/server/src/rbac/services/connections.ts`):
   - Added `padSalt()` function that deterministically pads shorter salts to 64 characters
   - Uses SHA-256 hash of the salt to generate padding, ensuring same salt always produces same padded salt
   - Fixed empty password handling in `decryptPassword()` function

## Testing

- All existing functionality verified
- Backward compatibility maintained for existing encrypted passwords
- Shorter salts (16+ characters) are accepted with warnings

## Priority

**Critical** - Affects production deployments

Fixes #37