### PR TITLE
feat: Add RBAC permission checks for all pages and improve role dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v2.7.3] - 2026-01-18
+
+### Added
+
+- **RBAC Permission Checks for All Pages**: Added proper RBAC permission checks for all application pages:
+  - **Overview/Home Page**: Now requires admin role (consistent with sidebar visibility)
+  - **Logs Page**: Requires `QUERY_HISTORY_VIEW` or `QUERY_HISTORY_VIEW_ALL` permission
+  - **Explorer Page**: Requires `DB_VIEW` or `TABLE_VIEW` permission
+  - **Settings Page**: Requires `SETTINGS_VIEW` permission
+  - All pages now properly enforce RBAC permissions, redirecting unauthorized users appropriately
+
+- **Role Form Dialog Enhancements**: Added Collapse/Expand All button in role creation/editing dialog:
+  - Single toggle button that switches between "Expand All" and "Collapse All" based on current state
+  - Makes it easier to navigate permission categories when managing roles
+  - Button shows appropriate icon (ChevronsDown/ChevronsUp) based on state
+
+### Fixed
+
+- **Duplicate Icon in Alert**: Fixed duplicate AlertCircle icon in "At least one permission is required" alert message. The Alert component already includes an icon based on variant, so the manual icon was removed.
+
 ## [v2.7.2] - 2026-01-18
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "chouseui",
   "private": true,
   "author": "",
-  "version": "2.7.2",
+  "version": "2.7.3",
   "license": "Apache-2.0",
   "type": "module",
   "workspaces": [

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -53,9 +53,9 @@ export default function App() {
               <Route
                 path="/overview"
                 element={
-                  <PrivateRoute>
+                  <AdminRoute>
                     <HomePage />
-                  </PrivateRoute>
+                  </AdminRoute>
                 }
               />
               
@@ -78,9 +78,14 @@ export default function App() {
               <Route
                 path="/logs"
                 element={
-                  <PrivateRoute>
+                  <AdminRoute
+                    requiredPermission={[
+                      RBAC_PERMISSIONS.QUERY_HISTORY_VIEW,
+                      RBAC_PERMISSIONS.QUERY_HISTORY_VIEW_ALL,
+                    ]}
+                  >
                     <LogsPage />
-                  </PrivateRoute>
+                  </AdminRoute>
                 }
               />
               
@@ -88,9 +93,14 @@ export default function App() {
               <Route
                 path="/explorer"
                 element={
-                  <PrivateRoute>
+                  <AdminRoute
+                    requiredPermission={[
+                      RBAC_PERMISSIONS.DB_VIEW,
+                      RBAC_PERMISSIONS.TABLE_VIEW,
+                    ]}
+                  >
                     <ExplorerPage />
-                  </PrivateRoute>
+                  </AdminRoute>
                 }
               />
               
@@ -135,9 +145,9 @@ export default function App() {
               <Route
                 path="/settings"
                 element={
-                  <PrivateRoute>
+                  <AdminRoute requiredPermission={RBAC_PERMISSIONS.SETTINGS_VIEW}>
                     <SettingsPage />
-                  </PrivateRoute>
+                  </AdminRoute>
                 }
               />
               

--- a/src/features/rbac/components/RoleFormDialog.tsx
+++ b/src/features/rbac/components/RoleFormDialog.tsx
@@ -41,6 +41,8 @@ import {
   CheckCircle2,
   Search,
   X,
+  ChevronsDown,
+  ChevronsUp,
 } from 'lucide-react';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 
@@ -269,6 +271,20 @@ export const RoleFormDialog: React.FC<RoleFormDialogProps> = ({
     });
   };
 
+  const handleToggleExpandAll = () => {
+    if (!filteredCategories) return;
+    const categoryKeys = Object.keys(filteredCategories);
+    const allExpanded = categoryKeys.every((key) => expandedCategories.has(key));
+    
+    if (allExpanded) {
+      // Collapse all
+      setExpandedCategories(new Set());
+    } else {
+      // Expand all
+      setExpandedCategories(new Set(categoryKeys));
+    }
+  };
+
   const handleSubmit = () => {
     if (!isValid || !canModify) return;
 
@@ -300,6 +316,10 @@ export const RoleFormDialog: React.FC<RoleFormDialogProps> = ({
   const totalPermissions = Object.values(filteredCategories || {}).flat().length;
   const selectedCount = selectedPermissionIds.size;
   const allSelected = totalPermissions > 0 && selectedCount === totalPermissions;
+  
+  // Determine if all categories are expanded
+  const categoryKeys = filteredCategories ? Object.keys(filteredCategories) : [];
+  const allExpanded = categoryKeys.length > 0 && categoryKeys.every((key) => expandedCategories.has(key));
 
   return (
     <Dialog open={isOpen} onOpenChange={onClose}>
@@ -450,6 +470,28 @@ export const RoleFormDialog: React.FC<RoleFormDialogProps> = ({
                     <Badge variant="outline" className="bg-gradient-to-r from-purple-500/20 to-blue-500/20 border-purple-500/30 text-purple-300">
                       {selectedCount} selected
                     </Badge>
+                  )}
+                  {categoryKeys.length > 0 && (
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="sm"
+                      onClick={handleToggleExpandAll}
+                      className="h-7 text-xs hover:bg-white/10 gap-1.5"
+                      title={allExpanded ? "Collapse all categories" : "Expand all categories"}
+                    >
+                      {allExpanded ? (
+                        <>
+                          <ChevronsUp className="h-3.5 w-3.5" />
+                          Collapse All
+                        </>
+                      ) : (
+                        <>
+                          <ChevronsDown className="h-3.5 w-3.5" />
+                          Expand All
+                        </>
+                      )}
+                    </Button>
                   )}
                   {canModify && totalPermissions > 0 && (
                     <Button
@@ -640,7 +682,6 @@ export const RoleFormDialog: React.FC<RoleFormDialogProps> = ({
                   animate={{ opacity: 1 }}
                 >
                   <Alert variant="destructive" className="border-red-500/30 bg-red-500/10">
-                    <AlertCircle className="h-4 w-4 text-red-400" />
                     <AlertDescription className="text-red-300">
                       At least one permission is required for the role.
                     </AlertDescription>


### PR DESCRIPTION
## Changes

### Added
- **RBAC Permission Checks for All Pages**: Added proper RBAC permission checks for all application pages:
  - **Overview/Home Page**: Now requires admin role (consistent with sidebar visibility)
  - **Logs Page**: Requires `QUERY_HISTORY_VIEW` or `QUERY_HISTORY_VIEW_ALL` permission
  - **Explorer Page**: Requires `DB_VIEW` or `TABLE_VIEW` permission
  - **Settings Page**: Requires `SETTINGS_VIEW` permission
  - All pages now properly enforce RBAC permissions, redirecting unauthorized users appropriately

- **Role Form Dialog Enhancements**: Added Collapse/Expand All button in role creation/editing dialog:
  - Single toggle button that switches between "Expand All" and "Collapse All" based on current state
  - Makes it easier to navigate permission categories when managing roles
  - Button shows appropriate icon (ChevronsDown/ChevronsUp) based on state

### Fixed
- **Duplicate Icon in Alert**: Fixed duplicate AlertCircle icon in "At least one permission is required" alert message. The Alert component already includes an icon based on variant, so the manual icon was removed.

## Version
Bumped to v2.7.3

## Testing
- [x] Verified all pages now check RBAC permissions correctly
- [x] Verified role dialog expand/collapse functionality works
- [x] Verified no duplicate icons in alerts