### PR TITLE
feat(ai-chat): add inline chart rendering and persistence

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -85,7 +85,7 @@ graph TD
 | **Pages** | `src/pages/` | 11 files | Route-level views: Login, Home, Explorer, Monitoring, Admin, Preferences, Logs, Metrics, LiveQueries, ExplainPopout, NotFound |
 | **Features** | `src/features/` | 5 modules | Domain-specific component groups with their own `components/` dirs |
 | **UI Components** | `src/components/ui/` | 34 files | shadcn/ui primitives: button, dialog, dropdown-menu, tabs, data-table, select, etc. |
-| **Common Components** | `src/components/common/` | 20 files | FloatingDock, Sidebar, ConnectionSelector, ErrorBoundary, PermissionGuard, DiffEditor, etc. |
+| **Common Components** | `src/components/common/` | 22 files | FloatingDock, Sidebar, ConnectionSelector, ErrorBoundary, PermissionGuard, DiffEditor, AiChatBubble, AiChartRenderer, etc. |
 | **Sidebar** | `src/components/sidebar/` | 1 file | UserMenu component |
 | **Hooks** | `src/hooks/` | 8 files | ~40 exported hooks (mostly TanStack Query wrappers) |
 | **Stores** | `src/stores/` | 4 stores | Zustand with `persist` middleware and user-specific storage adapters |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,32 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [v2.11.2] - 2026-02-24
+
+### Added
+
+- **Interactive AI Charts**: The AI Chat Assistant can now render interactive charts inline using Recharts.
+  - **Dynamic Visualizations**: Automatically generates charts from ClickHouse query results when requested by the user.
+  - **16 Chart Types Supported**: Includes Bar, Stacked Bar, Grouped Bar, Horizontal Bar, Line, Multi-line, Area, Stacked Area, Pie, Donut, Scatter, Radar, Treemap, Funnel, Histogram, and Heatmap.
+  - **Smart Data Inference**: Automatically infers X and Y axes from ClickHouse column metadata (e.g., DateTime/String for X-axis, numeric for Y-axis).
+  - **Interactive Tooltips**: Polished chart tooltips with clean formatting, hiding unnecessary series labels for single-series data.
+  - **Responsive Layouts**: Charts automatically take up full bubble width while text-only responses gracefully shrink-to-fit, preventing awkward whitespace.
+- **Chart Persistence**: Charts rendered in the AI chat are now permanently saved to chat history.
+  - Added `chart_spec` column to the `rbac_ai_chat_messages` table via migration `1.15.0`.
+  - Seamlessly restores visualizations when switching threads or reloading the application.
+
+### Changed
+
+- **AI Tooling System Prompt**: Upgraded the AI system prompt with strict rules on when to use `render_chart`, including enforcing mandatory schema checks to prevent hallucinated columns.
+- **SSE Stream Handling**: Extended the Server-Sent Events stream with a new `chart-data` delta type to securely transmit large JSON chart definitions in real-time.
+
+### Fixed
+
+- **BigInt Serialization**: Fixed server crashes when returning ClickHouse aggregation results (`BigInt` counts) by adding a custom JSON replacer.
+- **SSE Buffer Truncation**: Fixed the frontend SSE parser splitting payloads by a single `\n` instead of `\n\n`, which caused large chart JSON payloads to break.
+- **Vite HMR Crashes**: Resolved Hot Module Replacement crashes in `AiChartRenderer.tsx` by cleanly separating pure utility functions into `AiChartUtils.ts`.
+- **Sidebar React Hydration Error**: Fixed an invalid HTML nesting error (`<button>` inside `<button>`) in the `SidebarThreadButton` by refactoring the container to a keyboard-accessible `div[role="button"]`.
+
 ## [v2.11.1] - 2026-02-23
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "chouseui",
   "private": true,
   "author": "daun-gatal",
-  "version": "2.11.1",
+  "version": "2.11.2",
   "license": "Apache-2.0",
   "type": "module",
   "workspaces": [

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chouseui/server",
-  "version": "2.11.1",
+  "version": "2.11.2",
   "type": "module",
   "scripts": {
     "dev": "bun run --watch src/index.ts",

--- a/packages/server/src/rbac/schema/postgres.ts
+++ b/packages/server/src/rbac/schema/postgres.ts
@@ -415,6 +415,7 @@ export const aiChatMessages = pgTable('rbac_ai_chat_messages', {
   role: varchar('role', { length: 20 }).notNull(), // 'user' | 'assistant'
   content: text('content').notNull(),
   toolCalls: jsonb('tool_calls').$type<Array<{ name: string; args: Record<string, unknown>; result?: unknown }>>(),
+  chartSpec: jsonb('chart_spec').$type<Record<string, unknown>>(),
   createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
 }, (table) => ({
   threadIdIdx: index('ai_chat_messages_thread_id_idx').on(table.threadId),

--- a/packages/server/src/rbac/schema/sqlite.ts
+++ b/packages/server/src/rbac/schema/sqlite.ts
@@ -415,6 +415,7 @@ export const aiChatMessages = sqliteTable('rbac_ai_chat_messages', {
   role: text('role').notNull(), // 'user' | 'assistant'
   content: text('content').notNull(),
   toolCalls: text('tool_calls', { mode: 'json' }).$type<Array<{ name: string; args: Record<string, unknown>; result?: unknown }>>(),
+  chartSpec: text('chart_spec', { mode: 'json' }).$type<Record<string, unknown>>(),
   createdAt: integer('created_at', { mode: 'timestamp' }).notNull().default(sql`(unixepoch())`),
 }, (table) => ({
   threadIdIdx: index('ai_chat_messages_thread_id_idx').on(table.threadId),

--- a/packages/server/src/services/chatHistory.ts
+++ b/packages/server/src/services/chatHistory.ts
@@ -32,6 +32,7 @@ export interface ChatMessage {
     role: 'user' | 'assistant';
     content: string;
     toolCalls?: Array<{ name: string; args: Record<string, unknown>; result?: unknown }> | null;
+    chartSpec?: Record<string, unknown> | null;
     createdAt: Date;
 }
 
@@ -201,7 +202,8 @@ export async function addMessage(
     threadId: string,
     role: 'user' | 'assistant',
     content: string,
-    toolCalls?: Array<{ name: string; args: Record<string, unknown>; result?: unknown }>
+    toolCalls?: Array<{ name: string; args: Record<string, unknown>; result?: unknown }>,
+    chartSpec?: Record<string, unknown>
 ): Promise<ChatMessage> {
     const db = getDatabase() as AnyDb;
     const schema = getSchema();
@@ -216,6 +218,7 @@ export async function addMessage(
         role,
         content,
         toolCalls: toolCalls || null,
+        chartSpec: chartSpec || null,
         createdAt: now,
     });
 
@@ -231,6 +234,7 @@ export async function addMessage(
         role: role as 'user' | 'assistant',
         content,
         toolCalls: toolCalls || null,
+        chartSpec: chartSpec || null,
         createdAt: now,
     };
 }
@@ -254,6 +258,7 @@ export async function getMessages(threadId: string): Promise<ChatMessage[]> {
         role: m.role as 'user' | 'assistant',
         content: m.content,
         toolCalls: m.toolCalls,
+        chartSpec: m.chartSpec,
         createdAt: m.createdAt instanceof Date ? m.createdAt : new Date(m.createdAt),
     }));
 }

--- a/src/components/common/AiChartRenderer.test.ts
+++ b/src/components/common/AiChartRenderer.test.ts
@@ -1,0 +1,156 @@
+/**
+ * Tests for AiChartRenderer utility functions
+ *
+ * Pure function coverage:
+ *   - isChartSpec(): validates ChartSpec shape
+ *   - resolveYAxes(): normalises yAxis to string[]
+ *   - formatAxisValue(): compacts large numbers
+ *   - buildColorPalette(): returns the correct colour array for each scheme
+ */
+
+import { describe, it, expect } from 'vitest';
+import { isChartSpec, resolveYAxes, formatAxisValue, buildColorPalette } from './AiChartUtils';
+import type { ChartSpec } from '../../api/ai-chat';
+
+// ============================================
+// isChartSpec
+// ============================================
+
+describe('AiChartRenderer / isChartSpec', () => {
+    const valid: ChartSpec = {
+        chartType: 'bar',
+        columns: [{ name: 'engine', type: 'String' }, { name: 'count', type: 'UInt64' }],
+        rows: [{ engine: 'MergeTree', count: 42 }],
+        xAxis: 'engine',
+        yAxis: 'count',
+        colorScheme: 'violet',
+    };
+
+    it('should return true for a valid ChartSpec', () => {
+        expect(isChartSpec(valid)).toBe(true);
+    });
+
+    it('should return true when yAxis is an array', () => {
+        expect(isChartSpec({ ...valid, yAxis: ['count', 'size'] })).toBe(true);
+    });
+
+    it('should return true when optional title is present', () => {
+        expect(isChartSpec({ ...valid, title: 'My Chart' })).toBe(true);
+    });
+
+    it('should return false for null', () => {
+        expect(isChartSpec(null)).toBe(false);
+    });
+
+    it('should return false for a primitive', () => {
+        expect(isChartSpec('string')).toBe(false);
+        expect(isChartSpec(42)).toBe(false);
+    });
+
+    it('should return false when chartType is missing', () => {
+        const { chartType: _, ...withoutType } = valid;
+        expect(isChartSpec(withoutType)).toBe(false);
+    });
+
+    it('should return false when rows is not an array', () => {
+        expect(isChartSpec({ ...valid, rows: null })).toBe(false);
+    });
+
+    it('should return false when columns is not an array', () => {
+        expect(isChartSpec({ ...valid, columns: null })).toBe(false);
+    });
+
+    it('should return false when xAxis is not a string', () => {
+        expect(isChartSpec({ ...valid, xAxis: 123 })).toBe(false);
+    });
+});
+
+// ============================================
+// resolveYAxes
+// ============================================
+
+describe('AiChartRenderer / resolveYAxes', () => {
+    it('should wrap a single string in an array', () => {
+        expect(resolveYAxes('count')).toEqual(['count']);
+    });
+
+    it('should return the array unchanged', () => {
+        expect(resolveYAxes(['count', 'size'])).toEqual(['count', 'size']);
+    });
+
+    it('should handle an empty array', () => {
+        expect(resolveYAxes([])).toEqual([]);
+    });
+});
+
+// ============================================
+// formatAxisValue
+// ============================================
+
+describe('AiChartRenderer / formatAxisValue', () => {
+    it('should leave small numbers unchanged', () => {
+        expect(formatAxisValue(42)).toBe('42');
+        expect(formatAxisValue(0)).toBe('0');
+    });
+
+    it('should format thousands with K', () => {
+        expect(formatAxisValue(1000)).toBe('1K');
+        expect(formatAxisValue(1500)).toBe('1.5K');
+        expect(formatAxisValue(999999)).toBe('1000K');
+    });
+
+    it('should format millions with M', () => {
+        expect(formatAxisValue(1_000_000)).toBe('1M');
+        expect(formatAxisValue(2_500_000)).toBe('2.5M');
+    });
+
+    it('should format billions with B', () => {
+        expect(formatAxisValue(1_000_000_000)).toBe('1B');
+    });
+
+    it('should handle string numbers', () => {
+        expect(formatAxisValue('5000')).toBe('5K');
+    });
+
+    it('should return the original string for non-numeric values', () => {
+        // Non-numeric strings: Number('MergeTree') = NaN, !isFinite(NaN) = true → String(value) = 'MergeTree'
+        expect(formatAxisValue('MergeTree')).toBe('MergeTree');
+    });
+
+    it('should handle negative numbers', () => {
+        expect(formatAxisValue(-2_000)).toBe('-2K');
+    });
+});
+
+// ============================================
+// buildColorPalette
+// ============================================
+
+describe('AiChartRenderer / buildColorPalette', () => {
+    it('should return violet palette for "violet"', () => {
+        const palette = buildColorPalette('violet');
+        expect(Array.isArray(palette)).toBe(true);
+        expect(palette.length).toBeGreaterThan(0);
+        expect(palette[0]).toMatch(/^#/);
+    });
+
+    it('should return different palettes for different schemes', () => {
+        const violet = buildColorPalette('violet');
+        const blue = buildColorPalette('blue');
+        expect(violet[0]).not.toBe(blue[0]);
+    });
+
+    it('should fall back to violet for unknown schemes', () => {
+        const unknown = buildColorPalette('unknown-scheme');
+        const violet = buildColorPalette('violet');
+        expect(unknown).toEqual(violet);
+    });
+
+    const SCHEMES = ['violet', 'blue', 'green', 'orange', 'rainbow'] as const;
+    SCHEMES.forEach((scheme) => {
+        it(`should return a non-empty array for scheme "${scheme}"`, () => {
+            const palette = buildColorPalette(scheme);
+            expect(palette.length).toBeGreaterThan(0);
+        });
+    });
+});

--- a/src/components/common/AiChartRenderer.tsx
+++ b/src/components/common/AiChartRenderer.tsx
@@ -1,0 +1,722 @@
+/**
+ * AiChartRenderer
+ *
+ * Single-responsibility component: renders a ChartSpec produced by the
+ * AI's `render_chart` tool into an interactive Recharts chart.
+ *
+ * Supports 16 chart types:
+ *   bar, horizontal_bar, grouped_bar, stacked_bar,
+ *   line, multi_line, area, stacked_area,
+ *   pie, donut, scatter, radar,
+ *   treemap, funnel, histogram, heatmap
+ */
+
+import React, { useMemo, useRef, useState, useEffect, useCallback } from 'react';
+import type { ChartSpec } from '@/api/ai-chat';
+import {
+    buildColorPalette,
+    resolveYAxes,
+    formatAxisValue,
+    tooltipStyle,
+    tooltipLabelStyle,
+} from './AiChartUtils';
+import {
+    ResponsiveContainer,
+    BarChart,
+    Bar,
+    LineChart,
+    Line,
+    AreaChart,
+    Area,
+    PieChart,
+    Pie,
+    Cell,
+    ScatterChart,
+    Scatter,
+    XAxis,
+    YAxis,
+    CartesianGrid,
+    Tooltip,
+    Legend,
+    RadarChart,
+    Radar,
+    PolarGrid,
+    PolarAngleAxis,
+    PolarRadiusAxis,
+    Treemap,
+    FunnelChart,
+    Funnel,
+    LabelList,
+} from 'recharts';
+
+/**
+ * Measures a container's layout width using offsetWidth (unaffected by CSS transforms).
+ * Recharts' ResponsiveContainer uses getBoundingClientRect() which returns *visual*
+ * dimensions — broken when the chat window applies transform: scale().
+ */
+function useContainerWidth(): [React.RefObject<HTMLDivElement | null>, number] {
+    const ref = useRef<HTMLDivElement | null>(null);
+    const [width, setWidth] = useState(0);
+
+    const measure = useCallback(() => {
+        if (ref.current) setWidth(ref.current.offsetWidth);
+    }, []);
+
+    useEffect(() => {
+        measure();
+        const el = ref.current;
+        if (!el) return;
+        const ro = new ResizeObserver(() => measure());
+        ro.observe(el);
+        return () => ro.disconnect();
+    }, [measure]);
+
+    return [ref, width];
+}
+
+// ============================================
+// Histogram binning helper
+// ============================================
+
+function buildHistogramBins(
+    rows: Record<string, unknown>[],
+    xCol: string,
+    bins = 20
+): { bin: string; count: number }[] {
+    const values = rows
+        .map((r) => Number(r[xCol]))
+        .filter((v) => isFinite(v));
+
+    if (values.length === 0) return [];
+
+    const min = Math.min(...values);
+    const max = Math.max(...values);
+    const step = (max - min) / bins || 1;
+
+    const counts: number[] = Array(bins).fill(0);
+    values.forEach((v) => {
+        const idx = Math.min(Math.floor((v - min) / step), bins - 1);
+        counts[idx]++;
+    });
+
+    return counts.map((count, i) => ({
+        bin: `${formatAxisValue(min + i * step)}–${formatAxisValue(min + (i + 1) * step)}`,
+        count,
+    }));
+}
+
+// ============================================
+// AiChartRenderer
+// ============================================
+
+interface AiChartRendererProps {
+    spec: ChartSpec;
+}
+
+export function AiChartRenderer({ spec }: AiChartRendererProps): React.ReactElement | null {
+    const { chartType, title, rows, xAxis, yAxis, colorScheme } = spec;
+    const [containerRef, containerWidth] = useContainerWidth();
+
+    const palette = useMemo(() => buildColorPalette(colorScheme), [colorScheme]);
+    const yAxes = useMemo(() => resolveYAxes(yAxis), [yAxis]);
+
+    if (!rows || rows.length === 0) {
+        return (
+            <div className="flex items-center justify-center h-24 text-xs text-zinc-500">
+                No data to display
+            </div>
+        );
+    }
+
+    const sharedXAxis = (
+        <XAxis
+            dataKey={xAxis}
+            tick={{ fill: '#71717a', fontSize: 10 }}
+            axisLine={{ stroke: 'rgba(255,255,255,0.06)' }}
+            tickLine={false}
+            tickFormatter={(v: unknown) => {
+                const str = String(v);
+                return str.length > 12 ? str.slice(0, 11) + '…' : str;
+            }}
+        />
+    );
+
+    const sharedYAxis = (
+        <YAxis
+            tick={{ fill: '#71717a', fontSize: 10 }}
+            axisLine={{ stroke: 'rgba(255,255,255,0.06)' }}
+            tickLine={false}
+            tickFormatter={formatAxisValue}
+            width={55}
+        />
+    );
+
+    const sharedGrid = (
+        <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.04)" vertical={false} />
+    );
+
+    const sharedTooltip = (
+        <Tooltip
+            contentStyle={tooltipStyle}
+            labelStyle={tooltipLabelStyle}
+            itemStyle={{ color: '#d4d4d8', fontSize: '11px' }}
+            formatter={(value: unknown, name?: string) => [
+                formatAxisValue(value),
+                yAxes.length > 1 ? (name ?? '') : ''
+            ]}
+            separator={yAxes.length > 1 ? ': ' : ''}
+            cursor={false}
+        />
+    );
+
+    const sharedLegend = yAxes.length > 1 ? (
+        <Legend
+            wrapperStyle={{ fontSize: '10px', color: '#71717a', paddingTop: '8px' }}
+        />
+    ) : null;
+
+    const CHART_HEIGHT = 260;
+
+    // ============================================
+    // Chart rendering per type
+    // ============================================
+
+    let chartElement: React.ReactElement;
+
+    switch (chartType) {
+
+        // ---- BAR ----
+        case 'bar':
+        case 'stacked_bar': {
+            const isStacked = chartType === 'stacked_bar';
+            chartElement = (
+                <BarChart data={rows}>
+                    {sharedGrid}
+                    {sharedXAxis}
+                    {sharedYAxis}
+                    {sharedTooltip}
+                    {sharedLegend}
+                    {yAxes.map((col, i) => (
+                        <Bar
+                            key={col}
+                            dataKey={col}
+                            fill={palette[i % palette.length]}
+                            stackId={isStacked ? 'a' : undefined}
+                            radius={isStacked ? [0, 0, 0, 0] : [3, 3, 0, 0]}
+                            maxBarSize={60}
+                        />
+                    ))}
+                </BarChart>
+            );
+            break;
+        }
+
+        // ---- GROUPED BAR ----
+        case 'grouped_bar': {
+            chartElement = (
+                <BarChart data={rows} barCategoryGap="25%">
+                    {sharedGrid}
+                    {sharedXAxis}
+                    {sharedYAxis}
+                    {sharedTooltip}
+                    {sharedLegend}
+                    {yAxes.map((col, i) => (
+                        <Bar
+                            key={col}
+                            dataKey={col}
+                            fill={palette[i % palette.length]}
+                            radius={[3, 3, 0, 0]}
+                            maxBarSize={40}
+                        />
+                    ))}
+                </BarChart>
+            );
+            break;
+        }
+
+        // ---- HORIZONTAL BAR ----
+        case 'horizontal_bar': {
+            chartElement = (
+                <BarChart data={rows} layout="vertical">
+                    <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.04)" horizontal={false} />
+                    <XAxis
+                        type="number"
+                        tick={{ fill: '#71717a', fontSize: 10 }}
+                        axisLine={{ stroke: 'rgba(255,255,255,0.06)' }}
+                        tickLine={false}
+                        tickFormatter={formatAxisValue}
+                    />
+                    <YAxis
+                        type="category"
+                        dataKey={xAxis}
+                        tick={{ fill: '#71717a', fontSize: 10 }}
+                        axisLine={{ stroke: 'rgba(255,255,255,0.06)' }}
+                        tickLine={false}
+                        width={100}
+                        tickFormatter={(v: unknown) => {
+                            const s = String(v);
+                            return s.length > 14 ? s.slice(0, 13) + '…' : s;
+                        }}
+                    />
+                    {sharedTooltip}
+                    {sharedLegend}
+                    {yAxes.map((col, i) => (
+                        <Bar
+                            key={col}
+                            dataKey={col}
+                            fill={palette[i % palette.length]}
+                            radius={[0, 3, 3, 0]}
+                            maxBarSize={28}
+                        />
+                    ))}
+                </BarChart>
+            );
+            break;
+        }
+
+        // ---- LINE / MULTI-LINE ----
+        case 'line':
+        case 'multi_line': {
+            chartElement = (
+                <LineChart data={rows}>
+                    {sharedGrid}
+                    {sharedXAxis}
+                    {sharedYAxis}
+                    {sharedTooltip}
+                    {sharedLegend}
+                    {yAxes.map((col, i) => (
+                        <Line
+                            key={col}
+                            type="monotone"
+                            dataKey={col}
+                            stroke={palette[i % palette.length]}
+                            strokeWidth={2}
+                            dot={rows.length <= 50}
+                            activeDot={{ r: 4 }}
+                        />
+                    ))}
+                </LineChart>
+            );
+            break;
+        }
+
+        // ---- AREA / STACKED AREA ----
+        case 'area':
+        case 'stacked_area': {
+            const isStacked = chartType === 'stacked_area';
+            chartElement = (
+                <AreaChart data={rows}>
+                    <defs>
+                        {yAxes.map((col, i) => (
+                            <linearGradient key={col} id={`grad-${i}`} x1="0" y1="0" x2="0" y2="1">
+                                <stop offset="5%" stopColor={palette[i % palette.length]} stopOpacity={0.3} />
+                                <stop offset="95%" stopColor={palette[i % palette.length]} stopOpacity={0.02} />
+                            </linearGradient>
+                        ))}
+                    </defs>
+                    {sharedGrid}
+                    {sharedXAxis}
+                    {sharedYAxis}
+                    {sharedTooltip}
+                    {sharedLegend}
+                    {yAxes.map((col, i) => (
+                        <Area
+                            key={col}
+                            type="monotone"
+                            dataKey={col}
+                            stroke={palette[i % palette.length]}
+                            strokeWidth={2}
+                            fill={`url(#grad-${i})`}
+                            stackId={isStacked ? 'a' : undefined}
+                        />
+                    ))}
+                </AreaChart>
+            );
+            break;
+        }
+
+        // ---- PIE ----
+        case 'pie': {
+            const firstY = yAxes[0];
+            const pieData = rows.map((r) => ({
+                name: String(r[xAxis] ?? ''),
+                value: Number(r[firstY] ?? 0),
+            }));
+            chartElement = (
+                <PieChart>
+                    <Pie
+                        data={pieData}
+                        dataKey="value"
+                        nameKey="name"
+                        cx="50%"
+                        cy="50%"
+                        outerRadius={90}
+                        label={(props: { name?: string; percent?: number }) => {
+                            const n = props.name ?? '';
+                            const p = props.percent ?? 0;
+                            const label = n.length > 10 ? n.slice(0, 9) + '\u2026' : n;
+                            return `${label} (${(p * 100).toFixed(1)}%)`;
+                        }}
+                        labelLine={false}
+                    >
+                        {pieData.map((_, i) => (
+                            <Cell key={i} fill={palette[i % palette.length]} />
+                        ))}
+                    </Pie>
+                    <Tooltip
+                        contentStyle={tooltipStyle}
+                        labelStyle={tooltipLabelStyle}
+                        itemStyle={{ color: '#d4d4d8', fontSize: '11px' }}
+                        formatter={(v: unknown) => [formatAxisValue(v), '']}
+                        separator=""
+                    />
+                </PieChart>
+            );
+            break;
+        }
+
+        // ---- DONUT ----
+        case 'donut': {
+            const firstY = yAxes[0];
+            const donutData = rows.map((r) => ({
+                name: String(r[xAxis] ?? ''),
+                value: Number(r[firstY] ?? 0),
+            }));
+            const total = donutData.reduce((s, d) => s + d.value, 0);
+            chartElement = (
+                <PieChart>
+                    <Pie
+                        data={donutData}
+                        dataKey="value"
+                        nameKey="name"
+                        cx="50%"
+                        cy="50%"
+                        innerRadius={55}
+                        outerRadius={90}
+                        paddingAngle={2}
+                    >
+                        {donutData.map((_, i) => (
+                            <Cell key={i} fill={palette[i % palette.length]} />
+                        ))}
+                    </Pie>
+                    <Tooltip
+                        contentStyle={tooltipStyle}
+                        labelStyle={tooltipLabelStyle}
+                        itemStyle={{ color: '#d4d4d8', fontSize: '11px' }}
+                        formatter={(v: unknown) => [formatAxisValue(v), '']}
+                        separator=""
+                    />
+                    <Legend wrapperStyle={{ fontSize: '10px', color: '#71717a', paddingTop: '8px' }} />
+                    {/* Centre label */}
+                    <text
+                        x="50%" y="46%" textAnchor="middle" dominantBaseline="middle"
+                        style={{ fill: '#e4e4e7', fontSize: '16px', fontWeight: 700 }}
+                    >
+                        {formatAxisValue(total)}
+                    </text>
+                    <text
+                        x="50%" y="56%" textAnchor="middle" dominantBaseline="middle"
+                        style={{ fill: '#71717a', fontSize: '10px' }}
+                    >
+                        Total
+                    </text>
+                </PieChart>
+            );
+            break;
+        }
+
+        // ---- SCATTER ----
+        case 'scatter': {
+            const xCol = xAxis;
+            const yCol = yAxes[0];
+            const scatterData = rows.map((r) => ({
+                x: Number(r[xCol] ?? 0),
+                y: Number(r[yCol] ?? 0),
+            }));
+            chartElement = (
+                <ScatterChart>
+                    <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.04)" />
+                    <XAxis
+                        type="number"
+                        dataKey="x"
+                        name={xCol}
+                        tick={{ fill: '#71717a', fontSize: 10 }}
+                        axisLine={{ stroke: 'rgba(255,255,255,0.06)' }}
+                        tickLine={false}
+                        tickFormatter={formatAxisValue}
+                        label={{ value: xCol, position: 'insideBottom', offset: -2, fill: '#71717a', fontSize: 10 }}
+                    />
+                    <YAxis
+                        type="number"
+                        dataKey="y"
+                        name={yCol}
+                        tick={{ fill: '#71717a', fontSize: 10 }}
+                        axisLine={{ stroke: 'rgba(255,255,255,0.06)' }}
+                        tickLine={false}
+                        tickFormatter={formatAxisValue}
+                        width={55}
+                        label={{ value: yCol, angle: -90, position: 'insideLeft', offset: 10, fill: '#71717a', fontSize: 10 }}
+                    />
+                    <Tooltip
+                        cursor={false}
+                        contentStyle={tooltipStyle}
+                        formatter={(v: unknown, name?: string) => [formatAxisValue(v), name ?? '']}
+                    />
+                    <Scatter data={scatterData} fill={palette[0]} opacity={0.75} />
+                </ScatterChart>
+            );
+            break;
+        }
+
+        // ---- RADAR ----
+        case 'radar': {
+            const radarData = rows.slice(0, 50).map((r) => {
+                const entry: Record<string, unknown> = { subject: String(r[xAxis] ?? '') };
+                yAxes.forEach((col) => {
+                    entry[col] = Number(r[col] ?? 0);
+                });
+                return entry;
+            });
+            chartElement = (
+                <RadarChart data={radarData} cx="50%" cy="50%" outerRadius="75%">
+                    <PolarGrid stroke="rgba(255,255,255,0.08)" />
+                    <PolarAngleAxis dataKey="subject" tick={{ fill: '#71717a', fontSize: 10 }} />
+                    <PolarRadiusAxis tick={{ fill: '#71717a', fontSize: 9 }} tickFormatter={formatAxisValue} />
+                    {sharedTooltip}
+                    {yAxes.length > 1 && <Legend wrapperStyle={{ fontSize: '10px', color: '#71717a' }} />}
+                    {yAxes.map((col, i) => (
+                        <Radar
+                            key={col}
+                            name={col}
+                            dataKey={col}
+                            stroke={palette[i % palette.length]}
+                            fill={palette[i % palette.length]}
+                            fillOpacity={0.15}
+                        />
+                    ))}
+                </RadarChart>
+            );
+            break;
+        }
+
+        // ---- TREEMAP ----
+        case 'treemap': {
+            const firstY = yAxes[0];
+            const treemapData = rows.map((r) => ({
+                name: String(r[xAxis] ?? ''),
+                size: Math.max(0, Number(r[firstY] ?? 0)),
+            }));
+            chartElement = (
+                <Treemap
+                    data={treemapData}
+                    dataKey="size"
+                    aspectRatio={4 / 3}
+                    stroke="rgba(0,0,0,0.3)"
+                    content={({ x, y, width, height, name, index }: {
+                        x?: number; y?: number; width?: number; height?: number;
+                        name?: string; index?: number;
+                    }) => {
+                        const _x = x ?? 0;
+                        const _y = y ?? 0;
+                        const _w = width ?? 0;
+                        const _h = height ?? 0;
+                        const color = palette[(index ?? 0) % palette.length];
+                        return (
+                            <g>
+                                <rect x={_x} y={_y} width={_w} height={_h} style={{ fill: color, stroke: 'rgba(0,0,0,0.3)', strokeWidth: 1, fillOpacity: 0.85 }} />
+                                {_w > 40 && _h > 20 && (
+                                    <text
+                                        x={_x + _w / 2} y={_y + _h / 2}
+                                        textAnchor="middle" dominantBaseline="middle"
+                                        style={{ fill: '#fff', fontSize: Math.min(12, _w / 6), fontWeight: 500 }}
+                                    >
+                                        {String(name ?? '').length > 14 ? String(name ?? '').slice(0, 13) + '…' : name}
+                                    </text>
+                                )}
+                            </g>
+                        );
+                    }}
+                >
+                    {treemapData.map((_, i) => (
+                        <Cell key={i} fill={palette[i % palette.length]} />
+                    ))}
+                </Treemap>
+            );
+            break;
+        }
+
+        // ---- FUNNEL ----
+        case 'funnel': {
+            const firstY = yAxes[0];
+            const funnelData = rows.map((r, i) => ({
+                name: String(r[xAxis] ?? ''),
+                value: Math.max(0, Number(r[firstY] ?? 0)),
+                fill: palette[i % palette.length],
+            }));
+            chartElement = (
+                <FunnelChart>
+                    <Tooltip
+                        contentStyle={tooltipStyle}
+                        labelStyle={tooltipLabelStyle}
+                        itemStyle={{ color: '#d4d4d8', fontSize: '11px' }}
+                        formatter={(v: unknown) => [formatAxisValue(v), '']}
+                        separator=""
+                    />
+                    <Funnel dataKey="value" data={funnelData} isAnimationActive>
+                        <LabelList position="right" fill="#a1a1aa" stroke="none" fontSize={10} formatter={(v: unknown) => String(v)} />
+                    </Funnel>
+                </FunnelChart>
+            );
+            break;
+        }
+
+        // ---- HISTOGRAM ----
+        case 'histogram': {
+            const bins = buildHistogramBins(rows, xAxis);
+            chartElement = (
+                <BarChart data={bins} barCategoryGap="2%">
+                    {sharedGrid}
+                    <XAxis
+                        dataKey="bin"
+                        tick={{ fill: '#71717a', fontSize: 9 }}
+                        axisLine={{ stroke: 'rgba(255,255,255,0.06)' }}
+                        tickLine={false}
+                        interval={3}
+                        angle={-35}
+                        textAnchor="end"
+                        height={45}
+                    />
+                    {sharedYAxis}
+                    <Tooltip
+                        contentStyle={tooltipStyle}
+                        labelStyle={tooltipLabelStyle}
+                        formatter={(v: unknown) => [formatAxisValue(v), 'Count']}
+                    />
+                    <Bar dataKey="count" fill={palette[0]} radius={[3, 3, 0, 0]} />
+                </BarChart>
+            );
+            break;
+        }
+
+        // ---- HEATMAP (table-based) ----
+        case 'heatmap': {
+            return <HeatmapTable spec={spec} palette={palette} />;
+        }
+
+        // ---- FALLBACK ----
+        default: {
+            // Unknown chart type — fall back to a simple bar chart
+            chartElement = (
+                <BarChart data={rows}>
+                    {sharedGrid}
+                    {sharedXAxis}
+                    {sharedYAxis}
+                    {sharedTooltip}
+                    <Bar dataKey={yAxes[0]} fill={palette[0]} radius={[3, 3, 0, 0]} maxBarSize={60} />
+                </BarChart>
+            );
+        }
+    }
+
+    // Compute chart width: container width minus horizontal padding (px-2 = 8px * 2)
+    const chartWidth = Math.max(containerWidth - 16, 0);
+    const chartHeight = CHART_HEIGHT - 20;
+
+    return (
+        <div ref={containerRef} className="mt-3 mb-1 rounded-xl border border-white/[0.07] bg-white/[0.02] overflow-hidden min-w-[320px]">
+            {title && (
+                <div className="px-4 pt-3 pb-1 text-xs font-semibold text-zinc-300 border-b border-white/[0.05]">
+                    {title}
+                </div>
+            )}
+            <div className="px-2 pt-3 pb-2" style={{ height: `${CHART_HEIGHT}px` }}>
+                {chartWidth > 0 && (
+                    <ResponsiveContainer width={chartWidth} height={chartHeight}>
+                        {chartElement}
+                    </ResponsiveContainer>
+                )}
+            </div>
+            <div className="px-4 pb-2 flex items-center gap-1.5">
+                <span className="text-[9px] text-zinc-700 uppercase tracking-wider">
+                    {chartType.replace(/_/g, ' ')} · {rows.length.toLocaleString()} rows
+                </span>
+            </div>
+        </div>
+    );
+}
+
+// ============================================
+// Heatmap sub-component (table-based)
+// ============================================
+
+function HeatmapTable({ spec, palette }: { spec: ChartSpec; palette: string[] }): React.ReactElement {
+    const { rows, xAxis, yAxis, title } = spec;
+    const yAxes = resolveYAxes(yAxis);
+
+    // Find numeric range for colour scaling
+    const allValues = rows.flatMap((r) => yAxes.map((col) => Number(r[col] ?? 0)));
+    const min = Math.min(...allValues);
+    const max = Math.max(...allValues);
+    const range = max - min || 1;
+
+    // Map a value in [min,max] to an rgba colour using the first palette colour
+    function cellColor(value: number): string {
+        const intensity = (value - min) / range;
+        // Convert hex colour to rgba with opacity proportional to intensity
+        const hex = palette[0].replace('#', '');
+        const r = parseInt(hex.slice(0, 2), 16);
+        const g = parseInt(hex.slice(2, 4), 16);
+        const b = parseInt(hex.slice(4, 6), 16);
+        return `rgba(${r},${g},${b},${0.1 + intensity * 0.7})`;
+    }
+
+    return (
+        <div className="mt-3 mb-1 rounded-xl border border-white/[0.07] bg-white/[0.02] overflow-hidden">
+            {title && (
+                <div className="px-4 pt-3 pb-1 text-xs font-semibold text-zinc-300 border-b border-white/[0.05]">
+                    {title}
+                </div>
+            )}
+            <div className="overflow-x-auto max-h-[280px] overflow-y-auto p-3">
+                <table className="text-[10px] border-collapse w-full">
+                    <thead>
+                        <tr>
+                            <th className="text-zinc-500 text-left pr-3 pb-1 font-medium whitespace-nowrap">{xAxis}</th>
+                            {yAxes.map((col) => (
+                                <th key={col} className="text-zinc-500 pb-1 font-medium whitespace-nowrap px-2 text-center">{col}</th>
+                            ))}
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {rows.slice(0, 50).map((r, i) => (
+                            <tr key={i}>
+                                <td className="text-zinc-400 pr-3 py-0.5 whitespace-nowrap">
+                                    {String(r[xAxis] ?? '').slice(0, 20)}
+                                </td>
+                                {yAxes.map((col) => {
+                                    const val = Number(r[col] ?? 0);
+                                    return (
+                                        <td
+                                            key={col}
+                                            className="text-center px-2 py-0.5 rounded font-mono"
+                                            style={{ backgroundColor: cellColor(val), color: '#e4e4e7' }}
+                                        >
+                                            {formatAxisValue(val)}
+                                        </td>
+                                    );
+                                })}
+                            </tr>
+                        ))}
+                    </tbody>
+                </table>
+            </div>
+            <div className="px-4 pb-2">
+                <span className="text-[9px] text-zinc-700 uppercase tracking-wider">
+                    heatmap · {rows.length.toLocaleString()} rows
+                </span>
+            </div>
+        </div>
+    );
+}
+
+export default AiChartRenderer;

--- a/src/components/common/AiChartUtils.ts
+++ b/src/components/common/AiChartUtils.ts
@@ -1,0 +1,95 @@
+/**
+ * AiChartUtils
+ *
+ * Support logic for AiChartRenderer, separated from the component
+ * to ensure Vite HMR (Fast Refresh) works correctly.
+ */
+
+import type { ChartSpec } from '@/api/ai-chat';
+
+// ============================================
+// Color Palettes
+// ============================================
+
+export const COLOR_PALETTES: Record<string, string[]> = {
+    violet: ['#8B5CF6', '#A78BFA', '#C4B5FD', '#7C3AED', '#6D28D9', '#5B21B6', '#DDD6FE', '#EDE9FE'],
+    blue: ['#3B82F6', '#60A5FA', '#93C5FD', '#2563EB', '#1D4ED8', '#1E40AF', '#BFDBFE', '#DBEAFE'],
+    green: ['#10B981', '#34D399', '#6EE7B7', '#059669', '#047857', '#065F46', '#A7F3D0', '#D1FAE5'],
+    orange: ['#F59E0B', '#FBBF24', '#FCD34D', '#D97706', '#B45309', '#92400E', '#FDE68A', '#FEF3C7'],
+    rainbow: ['#8B5CF6', '#3B82F6', '#10B981', '#F59E0B', '#EF4444', '#EC4899', '#14B8A6', '#F97316'],
+};
+
+export function getPalette(colorScheme: string): string[] {
+    return COLOR_PALETTES[colorScheme] ?? COLOR_PALETTES.violet;
+}
+
+// ============================================
+// Type guard
+// ============================================
+
+/**
+ * Returns true when the value matches the ChartSpec shape.
+ * Used in tests and as a runtime safety check.
+ */
+export function isChartSpec(value: unknown): value is ChartSpec {
+    if (!value || typeof value !== 'object') return false;
+    const v = value as Record<string, unknown>;
+    return (
+        typeof v.chartType === 'string' &&
+        Array.isArray(v.columns) &&
+        Array.isArray(v.rows) &&
+        typeof v.xAxis === 'string' &&
+        (typeof v.yAxis === 'string' || Array.isArray(v.yAxis)) &&
+        typeof v.colorScheme === 'string'
+    );
+}
+
+// ============================================
+// Axis / data helpers
+// ============================================
+
+/** Normalise yAxis to always be an array of column names */
+export function resolveYAxes(yAxis: string | string[]): string[] {
+    return Array.isArray(yAxis) ? yAxis : [yAxis];
+}
+
+/** Format large numbers compactly (e.g. 1_000_000 → "1M") */
+export function formatAxisValue(value: unknown): string {
+    const num = Number(value);
+    if (!isFinite(num)) return String(value);
+    const fmt = (n: number, divisor: number, suffix: string): string => {
+        const divided = n / divisor;
+        // Use 1 decimal place, but strip trailing .0 for whole numbers
+        return `${parseFloat(divided.toFixed(1))}${suffix}`;
+    };
+    if (Math.abs(num) >= 1_000_000_000) return fmt(num, 1_000_000_000, 'B');
+    if (Math.abs(num) >= 1_000_000) return fmt(num, 1_000_000, 'M');
+    if (Math.abs(num) >= 1_000) return fmt(num, 1_000, 'K');
+    return String(Number(num.toFixed(2)));
+}
+
+/** Build colour palette object for styled label */
+export function buildColorPalette(scheme: string): string[] {
+    return getPalette(scheme);
+}
+
+// ============================================
+// Styles
+// ============================================
+
+type CSSProps = Record<string, string | number>;
+
+export const tooltipStyle: CSSProps = {
+    backgroundColor: 'rgba(0,0,0,0.85)',
+    border: '1px solid rgba(255,255,255,0.08)',
+    borderRadius: '10px',
+    color: '#e4e4e7',
+    fontSize: '11px',
+    backdropFilter: 'blur(8px)',
+};
+
+export const tooltipLabelStyle: CSSProps = {
+    color: '#a1a1aa',
+    marginBottom: '4px',
+    fontWeight: 600,
+};


### PR DESCRIPTION
## Description

Adds interactive chart rendering inside the AI Chat assistant, allowing the AI to visualize ClickHouse data dynamically using a new `render_chart` tool and Recharts. Includes chart persistence to the database so visualizations survive history reloads.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Performance improvement
- [x] Code refactoring
- [ ] Other (please describe):

## Related Issue

Closes #

## Changes Made

- **Interactive AI Charts**: The AI Chat Assistant can now render interactive charts inline using Recharts (16 types supported).
- **Chart Persistence**: Added `chart_spec` column to `rbac_ai_chat_messages` table via migration `1.15.0` to permanently save charts in thread history.
- **AI Tooling System Prompt**: Upgraded AI system rules to enforce schema checks before charting.
- **SSE Stream Handling**: Extended the SSE stream with a `chart-data` delta type for chart spec transmission.
- **Bug Fixes**: Fixed BigInt serialization crashes, SSE buffer truncation for large payloads, Vite HMR crashes involving chart utilities, and a React hydration error in the sidebar.

## Testing

- [x] I have tested this locally
- [x] I have added/updated tests
- [x] All existing tests pass

### Test Steps
1. Open the AI Chat Bubble.
2. Ask "Show me a bar chart of the top tables by size".
3. Verify the chart renders.
4. Refresh the page and open the thread history; verify the chart is restored.

## Screenshots

## Checklist

- [x] My code follows the project's code style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly (if applicable)
- [x] My changes generate no new warnings or errors
- [x] I have checked for breaking changes and documented them (if applicable)
- [x] I have tested the changes in the relevant environment (development/production)

## Additional Notes

