### PR TITLE
fix(rbac): handle Drizzle-wrapped SQLite errors in migrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [v2.12.10] - 2026-04-01
+
+### Fixed
+
+- **Migration startup crash (#195)**: The RBAC migration system crashed on startup when SQLite columns added in a previous run already existed. Drizzle ORM wraps the native `bun:sqlite` error into a `DrizzleError` where the original `"duplicate column name: …"` message is placed in `error.cause.message`, not `error.message`. The catch blocks across migrations 1.2.1, 1.11.0, 1.15.0, 1.17.0, and 1.17.1 checked only `error.message`, so the guard never matched and the error was re-thrown — preventing the app from starting on any upgrade that had already partially applied those migrations. Similarly, the UNIQUE constraint guard in migration 1.2.2 had the same gap. Introduced `isDuplicateColumnError` and `isUniqueConstraintError` helpers that inspect both `error.message` and `error.cause?.message`, ensuring all six affected catch blocks correctly skip already-existing columns and constraints.
+
 ## [v2.12.9] - 2026-03-02
 
 ### Added

--- a/packages/server/src/rbac/db/migrations.ts
+++ b/packages/server/src/rbac/db/migrations.ts
@@ -47,6 +47,31 @@ export interface MigrationResult {
 export const APP_VERSION = '1.17.1';
 
 // ============================================
+// Error Helpers
+// Drizzle ORM wraps underlying DB errors inside a DrizzleError where
+// the original message is in error.cause.message, not error.message.
+// These helpers check both levels so migrations can reliably detect
+// duplicate column and unique constraint violations.
+// ============================================
+
+function isDuplicateColumnError(error: unknown): boolean {
+  if (!error || typeof error !== 'object') return false;
+  const err = error as { message?: string; cause?: { message?: string } };
+  const msg = err.message ?? '';
+  const causeMsg = err.cause?.message ?? '';
+  return msg.includes('duplicate column') || causeMsg.includes('duplicate column');
+}
+
+function isUniqueConstraintError(error: unknown): boolean {
+  if (!error || typeof error !== 'object') return false;
+  const err = error as { message?: string; cause?: { message?: string } };
+  const msg = err.message ?? '';
+  const causeMsg = err.cause?.message ?? '';
+  const check = (m: string) => m.includes('UNIQUE') || m.includes('unique');
+  return check(msg) || check(causeMsg);
+}
+
+// ============================================
 // Migration Registry
 // ============================================
 
@@ -212,9 +237,10 @@ const MIGRATIONS: Migration[] = [
             ADD COLUMN auth_type TEXT
           `);
           logger.info({ module: 'RBAC', phase: 'migration' },'[Migration 1.2.1] Added auth_type column to SQLite metadata table');
-        } catch (error: any) {
+        } catch (error: unknown) {
           // Column might already exist, which is fine
-          if (error?.message?.includes('duplicate column')) {
+          // (Drizzle wraps the underlying error in error.cause, so check both)
+          if (isDuplicateColumnError(error)) {
             logger.info({ module: 'RBAC', phase: 'migration' },'[Migration 1.2.1] auth_type column already exists, skipping');
           } else {
             throw error;
@@ -292,9 +318,10 @@ const MIGRATIONS: Migration[] = [
           } else {
             logger.info({ module: 'RBAC', phase: 'migration' },'[Migration 1.2.2] System table access rule already exists');
           }
-        } catch (error: any) {
+        } catch (error: unknown) {
           // Rule might already exist (unique constraint), which is fine
-          if (error?.message?.includes('UNIQUE') || error?.message?.includes('unique')) {
+          // (Drizzle wraps the underlying error in error.cause, so check both)
+          if (isUniqueConstraintError(error)) {
             logger.info({ module: 'RBAC', phase: 'migration' },'[Migration 1.2.2] System table access rule already exists');
           } else {
             logger.warn({ module: 'RBAC', phase: 'migration' },'[Migration 1.2.2] Could not create system table access rule:', error);
@@ -1235,8 +1262,9 @@ const MIGRATIONS: Migration[] = [
               ADD COLUMN ${col} TEXT
             `));
             logger.info({ module: 'RBAC', phase: 'migration' },`[Migration 1.11.0] Added ${col} column to SQLite audit logs table`);
-          } catch (error: any) {
-            if (error?.message?.includes('duplicate column')) {
+          } catch (error: unknown) {
+            // (Drizzle wraps the underlying error in error.cause, so check both)
+            if (isDuplicateColumnError(error)) {
               logger.info({ module: 'RBAC', phase: 'migration' },`[Migration 1.11.0] ${col} column already exists, skipping`);
             } else {
               throw error;
@@ -1644,8 +1672,9 @@ const MIGRATIONS: Migration[] = [
             ALTER TABLE rbac_ai_chat_messages ADD COLUMN chart_spec TEXT
           `);
           logger.info({ module: 'RBAC', phase: 'migration' },'[Migration 1.15.0] Added chart_spec column to SQLite rbac_ai_chat_messages table');
-        } catch (error: any) {
-          if (!error?.message?.includes('duplicate column')) throw error;
+        } catch (error: unknown) {
+          // (Drizzle wraps the underlying error in error.cause, so check both)
+          if (!isDuplicateColumnError(error)) throw error;
           logger.info({ module: 'RBAC', phase: 'migration' },'[Migration 1.15.0] chart_spec column already exists, skipping');
         }
       } else {
@@ -2098,8 +2127,9 @@ const MIGRATIONS: Migration[] = [
           try {
             (db as SqliteDb).run(sql.raw(`ALTER TABLE rbac_audit_logs ADD COLUMN ${col.name} ${col.sqliteType}`));
             logger.info({ module: 'RBAC', phase: 'migration' },`[Migration 1.17.0] Added ${col.name} column (SQLite)`);
-          } catch (error: any) {
-            if (error?.message?.includes('duplicate column')) {
+          } catch (error: unknown) {
+            // (Drizzle wraps the underlying error in error.cause, so check both)
+            if (isDuplicateColumnError(error)) {
               logger.info({ module: 'RBAC', phase: 'migration' },`[Migration 1.17.0] ${col.name} column already exists, skipping`);
             } else {
               throw error;
@@ -2157,8 +2187,9 @@ const MIGRATIONS: Migration[] = [
           try {
             (db as SqliteDb).run(sql.raw(`ALTER TABLE rbac_audit_logs ADD COLUMN ${col.name} ${col.sqliteType}`));
             logger.info({ module: 'RBAC', phase: 'migration' },`[Migration 1.17.1] Added ${col.name} column (SQLite)`);
-          } catch (error: any) {
-            if (error?.message?.includes('duplicate column')) {
+          } catch (error: unknown) {
+            // (Drizzle wraps the underlying error in error.cause, so check both)
+            if (isDuplicateColumnError(error)) {
               logger.info({ module: 'RBAC', phase: 'migration' },`[Migration 1.17.1] ${col.name} column already exists, skipping`);
             } else {
               throw error;


### PR DESCRIPTION
## Description

Fixes a startup crash where the RBAC migration system would fail when columns already existed in the SQLite database. Drizzle ORM wraps underlying SQLite errors into a `DrizzleError`, placing the original message in `error.cause.message` rather than `error.message`. The existing catch blocks only checked `error.message`, so they never matched `"duplicate column"` and incorrectly re-threw the error, crashing the app on every subsequent startup.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issue

Closes #195

## Changes Made

- Added two private helper functions in `migrations.ts`:
  - `isDuplicateColumnError(error)`: checks both `error.message` and `error.cause?.message` for `"duplicate column"` (SQLite)
  - `isUniqueConstraintError(error)`: checks both levels for `"UNIQUE"` / `"unique"`
- Replaced all 6 inline `error?.message?.includes(...)` checks across migrations **1.2.1, 1.2.2, 1.11.0, 1.15.0, 1.17.0, and 1.17.1** with the new helpers
- Upgraded all catch variable types from `error: any` to `error: unknown` per `CODE_CHANGES.md` strict TS rules

## Testing

- [x] I have tested this locally
- [ ] I have added/updated tests
- [x] All existing tests pass

### Test Steps

1. Start the app with an existing SQLite database that already has `username_snapshot` and related columns
2. Observe that previously the app would crash at migration 1.11.0 on startup
3. With this fix, the app starts successfully — migrations skip already-existing columns with an info log

## Checklist

- [x] My code follows the project's code style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly (if applicable)
- [x] My changes generate no new warnings or errors
- [x] I have checked for breaking changes and documented them (if applicable)
- [x] I have tested the changes in the relevant environment (development/production)

## Additional Notes

The `isDuplicateColumnError` helper checks both the top-level `error.message` and `error.cause?.message` because Drizzle's `DrizzleError` stores the native DB error in `cause`. This pattern handles both current and future Drizzle versions gracefully — if Drizzle ever propagates the message directly, both checks still pass.