### PR TITLE
docs: update README + landing page for v2.15.1 state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [v2.15.1] - 2026-05-21
+
+Docs + landing-page refresh to match what actually shipped in v2.15.0. No app code changes.
+
+### Changed
+
+- **README** brought current with the v2.15.0 feature set: Query logs now lists **5 sub-views** (added By Redash), the Monitoring section covers the server memory breakdown / top memory-CPU query tables / blocked-task strip / per-replica lag / p50-p95-p99 chips / Memory·CPU·ZooKeeper metrics tabs, Live queries notes CPU time + thread count + sortable columns, and User Experience reflects the shipped **light + dark + Auto-by-time** theme. Added a **Monitoring** row to the "Why CHouse UI" table and listed **CH 24.11** under tested compatibility.
+- **Landing page** (`docs/portfolio`):
+  - New **"What shipped recently"** release-highlight strip above the fold — three hairline-grid cards (light theme / monitoring deep-dive / By Redash) with a staggered scroll reveal, marked by a pulsing `v2.15.0` accent tag.
+  - **Features** gained a **Monitoring & Observability** category (8 items); section reworded to "Six domains". UX "Dark Theme" item → "Light + Dark + Auto"; Responsive item now mentions container-query layouts.
+  - **Highlights** "Live operations" → **"Deep observability"**, reframed around ClickHouse-native monitoring with the no-exporter angle.
+  - **Hero** subtitle now mentions ClickHouse-native monitoring; boot-log version bumped to match the release.
+  - Synced the stale landing CHANGELOG copy (was v2.3.0) from the root so the version badge + changelog section render the latest release.
+
+
 ## [v2.15.0] - 2026-05-20
 
 Phase 3 lands on top of the Monitoring deep-dive from v2.14.0: a full Light mode (with auto-by-time-of-day switching), a memory-pressure story that finally answers "kepakai apa", and a By Redash rollup so DE/Data Platform can map cluster pain back to the saved dashboard query that caused it.

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ CHouse UI provides security and access control features for teams that need:
 | **Access Control** | Full RBAC with granular permissions |
 | **Multi-Connection** | Manage multiple ClickHouse servers |
 | **Audit Trail** | Audit logging |
+| **Monitoring** | ClickHouse-native observability — query logs, memory breakdown, top-resource queries, replica lag, parts/merges, schema lints — no exporter required |
 
 > **Note**: Other ClickHouse tools serve different use cases well. CHouse UI is designed specifically for teams requiring centralized credential management, role-based access control, and audit capabilities.
 
@@ -82,23 +83,28 @@ CHouse UI provides security and access control features for teams that need:
 - **Overview Dashboard** - System stats, recent queries, and quick actions (admin only)
 
 ### 🔬 Monitoring & Observability
-- **Query logs** with four sub-views over `system.query_log`:
+- **Query logs** with five sub-views over `system.query_log`:
   - **Queries** — every execution as a dense table with sortable columns, SQL-keyword tooltip preview, memory-pressure flag (Flame ≥ 25 % / AlertTriangle ≥ 10 % cluster RAM), row checkboxes for side-by-side **Compare**, expanded-row drill-downs for **Profile events** and **Views triggered** (`system.query_views_log`)
   - **Patterns** — `normalizeQuery()` rollup with cumulative cost (Runs / Avg dur / **Total dur** / Max mem / Read rows / Read bytes), default sort Total dur DESC — finds the patterns hogging the most wall-clock time across all repetitions
   - **By table** — `arrayJoin(tables)` per-table rollup with `arrayFilter` push-down so busy clusters return in ~1 s
-  - **Histogram** — distribution of duration / memory / read rows / read bytes across the active window
+  - **By Redash** — groups every Redash-originated query by the `query_id` embedded in its leading SQL comment (`/* … query_id: NNNN … */`), so you can map cluster load back to the saved dashboard query. Runs / Min·Avg·Max·Total duration / Min·Max memory / read rows / read bytes, all sortable
+  - **Histogram** — distribution of duration / memory / read rows / read bytes across the active window, with **p50 / p95 / p99** chips (p99 amber-tinted to flag the tail)
 - **Query timeline chart** — stacked bar / stacked area / line variants, per `query_kind`
-- **Custom time range** — 15 m / 1 h / 6 h / 24 h presets unified with a 2-month range calendar in one popover
+- **Custom time range** — 15 m / 1 h / 6 h / 24 h presets + a Grafana-style drill-down calendar (day → month → year) in one popover
 - **Parts** — `system.part_log` stacked area chart of merges, mutations, downloads, removals + paginated event table
 - **Schema doctor** — Nullable column + oversized integer linter over `system.parts_columns`, ranked by on-disk bytes
-- **Cluster activity** — `system.mutations` + `system.replication_queue` with status chips and auto-refresh
-- **Live queries** — running queries with kill support
-- **Metrics** — 7 sub-tabs (Overview / Performance / Storage / Merges / Errors / System / Network)
+- **Cluster activity** — `system.mutations` + `system.replication_queue` with status chips, a blocked-task indicator strip (long queries / long merges / open mutations / max replica lag), and a per-replica status panel (`system.replicas` lag + queue depth)
+- **Live queries** — running queries with **CPU time + thread count**, sortable by duration / memory / rows / CPU, and kill support. A server-memory pressure strip puts the per-query totals in context (resident / total %)
+- **Metrics** — Overview / Performance / Storage / Merges / Errors / **Memory** / **CPU** / **ZooKeeper** / Network tabs:
+  - **Memory** — server RAM breakdown (RSS attributed to active queries / caches / merges / primary keys / index, vs total), allocator history, and a top-memory-queries table
+  - **CPU** — load avg / threads / pools, CPU mode-split + concurrency charts, and a top-CPU-queries table
+  - **ZooKeeper** — Keeper transactions, traffic, and system-load time-series
 
 ### 🎨 User Experience
-- **Editorial design system** — dark monochrome canvas with ClickHouse-yellow accent, Geist Sans + Geist Mono typography, hairline borders. Light theme on the roadmap (phase 3)
+- **Editorial design system** — ClickHouse-yellow accent, Geist Sans + Geist Mono typography, hairline borders
+- **Light + dark themes** — full light theme with a warm-stone palette and amber-shifted brand, plus an **Auto** mode that switches by local time of day (light 06:00–18:00, dark otherwise). Every chart, table, and pill is theme-aware
 - **Command palette** — ⌘/Ctrl+K opens RBAC-gated quick switcher (recent queries, pages, databases, tables, saved queries, actions, help)
-- **Responsive** — Works on desktop and tablet
+- **Responsive** — works on desktop and tablet; container-query layouts adapt per component, not just per viewport
 - **Connection Selector** - Quick server switching
 - **Keyboard Shortcuts** - Power user support
 
@@ -146,7 +152,7 @@ CHouse UI provides security and access control features for teams that need:
 ### Tested Compatibility
 
 Successfully tested with:
-- **ClickHouse**: Version 25
+- **ClickHouse**: Version 24.11 and 25 (monitoring suite verified end-to-end against a production 24.11 cluster)
 - **PostgreSQL**: Version 18 (for RBAC database)
 - **SQLite**: Version 3.51.0 (via Bun, for RBAC database)
 

--- a/docs/portfolio/public/CHANGELOG.md
+++ b/docs/portfolio/public/CHANGELOG.md
@@ -6,6 +6,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [v2.15.1] - 2026-05-21
+
+Docs + landing-page refresh to match what actually shipped in v2.15.0. No app code changes.
+
+### Changed
+
+- **README** brought current with the v2.15.0 feature set: Query logs now lists **5 sub-views** (added By Redash), the Monitoring section covers the server memory breakdown / top memory-CPU query tables / blocked-task strip / per-replica lag / p50-p95-p99 chips / Memory·CPU·ZooKeeper metrics tabs, Live queries notes CPU time + thread count + sortable columns, and User Experience reflects the shipped **light + dark + Auto-by-time** theme. Added a **Monitoring** row to the "Why CHouse UI" table and listed **CH 24.11** under tested compatibility.
+- **Landing page** (`docs/portfolio`):
+  - New **"What shipped recently"** release-highlight strip above the fold — three hairline-grid cards (light theme / monitoring deep-dive / By Redash) with a staggered scroll reveal, marked by a pulsing `v2.15.0` accent tag.
+  - **Features** gained a **Monitoring & Observability** category (8 items); section reworded to "Six domains". UX "Dark Theme" item → "Light + Dark + Auto"; Responsive item now mentions container-query layouts.
+  - **Highlights** "Live operations" → **"Deep observability"**, reframed around ClickHouse-native monitoring with the no-exporter angle.
+  - **Hero** subtitle now mentions ClickHouse-native monitoring; boot-log version bumped to match the release.
+  - Synced the stale landing CHANGELOG copy (was v2.3.0) from the root so the version badge + changelog section render the latest release.
+
+
 ## [v2.15.0] - 2026-05-20
 
 Phase 3 lands on top of the Monitoring deep-dive from v2.14.0: a full Light mode (with auto-by-time-of-day switching), a memory-pressure story that finally answers "kepakai apa", and a By Redash rollup so DE/Data Platform can map cluster pain back to the saved dashboard query that caused it.

--- a/docs/portfolio/public/CHANGELOG.md
+++ b/docs/portfolio/public/CHANGELOG.md
@@ -5,6 +5,1348 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## [v2.15.0] - 2026-05-20
+
+Phase 3 lands on top of the Monitoring deep-dive from v2.14.0: a full Light mode (with auto-by-time-of-day switching), a memory-pressure story that finally answers "kepakai apa", and a By Redash rollup so DE/Data Platform can map cluster pain back to the saved dashboard query that caused it.
+
+### Added
+
+- **Light theme + Auto-by-time mode** — `theme-provider` gained `"auto"` alongside the existing `system`/`dark`/`light` modes. Auto reads the user's local clock and flips to light between 06:00–18:00, dark otherwise (re-evaluated every minute). Resolved theme exposed via `resolvedTheme` for consumers that need a concrete value (Sonner, Monaco, ag-grid, uPlot). Light side uses a warm-stone palette (`#f7f6f3` page bg) and an amber-shifted brand (`#d4a300`) so the contrast doesn't read clinical.
+- **Grafana-style drill-down date picker** — `RangePickerDrilldown` component on top of react-day-picker v9. Header button climbs the view: day → month → year. Range mode normalises same-day picks to 00:00:00 → 23:59:59.999 so picking "May 18 twice" gives a usable full-day window. Replaces the standalone "Single day" toggle which is now redundant.
+- **Server memory breakdown** — new `ServerMemoryBreakdown` card lives in Metrics → Memory. Top row shows Server RAM / Used by ClickHouse / Free for OS read from `system.asynchronous_metrics.{OSMemoryTotal, MemoryResident}`. Stacked bar below decomposes RSS into attributable slices (active queries / mark cache / uncompressed cache / merges / primary keys / index granularity / Other = runtime + bg). Card degrades to "Attributed memory" or "Used by ClickHouse" alone when the server hides `OSMemoryTotal` (managed CH, hardened RBAC) instead of blanking out.
+- **Server memory strip on Live Queries** — single-row "resident / total" bar with % gauge. Brand-yellow under 75%, amber at ≥75%, red at ≥90%. Gives the per-query "Total memory" tile below it some context — 26 GB of queries reads very differently against a 32 GB box vs a 256 GB one.
+- **Monitoring → Query logs → By Redash sub-tab** — groups every Redash-originated query by the `query_id` embedded in its leading SQL comment (`/* Username: …, query_id: NNNN, Queue: …, Job ID: … */`). Columns mirror Patterns but the lead column is `#NNN · username` so you can map cluster pain back to the saved dashboard query in one hop. Runs, Avg / Min / Max duration, Total dur, Min / Max memory (each sortable), Read rows, Read bytes.
+- **Top memory queries / Top CPU queries panels** — bottom of Metrics → Memory and CPU tabs. Heaviest 10 from the last hour of `system.query_log`, with ✕ chip on failed rows, copy-to-clipboard query_id, and the secondary metric (CPU when sorted by memory and vice versa) rendered next to the primary one with thread count. Verified against Paysera prod: surfaces 120 GB / 13m-of-CPU queries that previously needed ad-hoc SQL.
+- **p50 / p95 / p99 latency chips** on the Query histogram card. New `useQueryPercentiles` hook runs a single `quantile(…)` aggregation alongside the existing histogram fetch. p99 gets an amber-tinted chip so the tail value pops without a legend. Formatter switches between ms / bytes / compact-number per metric.
+- **CPU column + sortable headers on Live Queries** — backend `/api/live-queries` now selects `ProfileEvents['OSCPUVirtualTimeMicroseconds']` and `length(thread_ids)` from `system.processes`. Front-end shows CPU time + thread count (helps decode "44s wall / 5m 52s CPU" as healthy parallelism instead of a clock anomaly). Duration / Memory / Rows / CPU headers are click-to-sort, single-direction (desc) because every operator chasing a hot query wants biggest at top.
+- **Blocked task indicator strip on Cluster activity** — 4 tiles visible on every sub-tab (Long queries >60s, Long merges >5min, Open mutations, Max replica lag). Tile lights amber once threshold is crossed so operators looking at Mutations don't miss that the merge queue is backed up. One `useBlockedTaskSummary` SQL call rolls them up so polling stays cheap.
+- **Per-replica status panel** on the Replication queue view — top 6 replicas by `absolute_delay` from `system.replicas`, with queue size and a red lag value when the replica is sick (lag >60s, readonly, or session expired).
+- **Metrics → Memory / CPU / ZooKeeper sub-tabs** replace the crowded single "System" tab. Each tab follows the same editorial card pattern: header chip + stat tile row + hairline divider + sub-section with time-series. Memory tab carries the breakdown card + allocator history. CPU tab carries load avg / global threads / schedule pool / file descriptors + CPU mode-split + concurrency. ZooKeeper tab carries system load + transactions/sec + traffic + Keeper time-series.
+
+### Changed
+
+- **Monitoring header redesigned** — inline horizontal underline tab pills replace the 6-card grid that was cramping at laptop width. Title, tabs, last-updated stamp, and refresh icons share one row on desktop and wrap cleanly on narrow viewports. The time-range select moved out of the global header into the Metrics page itself (where it semantically belongs) so the header geometry no longer shifts when switching between tabs.
+- **Webkit scrollbar slimmed** from 10 px to 6 px and the inner transparent border dropped. On macOS with "Always show scrollbars" enabled, the previous 10 px gutter read as a thick gray bar down the right side of every chart pane; the new hairline is far less obtrusive.
+- **Light paper text scale bumped one step darker** (paper-faint moved from stone-400 to stone-500, etc.) so eyebrow labels, hints, and inactive states keep ≥4.5:1 contrast on warm-white instead of dropping below AA the way the initial pass did.
+- **Status pills and red action buttons** got light-mode pairings via `dark:` prefixes. Pattern was `border-emerald-900/60 bg-emerald-950/40 text-emerald-300` for the dark-only treatment; light side now uses `border-emerald-300 bg-emerald-50 text-emerald-700` with the dark recipe preserved under `dark:`. Same for red (Delete logs button, Failed counter, Failed chip), the LIVE nav pill, and the trash-icon hover pattern used across Admin / AI Models / Connection / User pages.
+- **uPlot axis labels are now theme-aware** — chart draws onto a canvas with no CSS hook and was hardcoded to `rgba(255,255,255,…)` for stroke / grid / ticks. On the light side that became white-on-warm-stone, so every metric chart's timestamps and value labels were invisible. New `axisPalette` reads `resolvedTheme` and switches to `rgba(28,25,23,…)` for light. `resolvedTheme` is in the `useEffect` deps so the chart re-renders on theme toggle.
+- **Metrics → System split into Memory / CPU / ZooKeeper** (see Added). Old card that overlaid OS RSS with MemoryTracking on the same axis (producing the "Tracked: 657 GB vs RSS: 63 GB" misread) is gone — replaced by the breakdown card.
+
+### Fixed
+
+- **`NO_COMMON_TYPE: String vs DateTime`** on Cluster activity → Mutations and Replication queue against CH 24.11. Root cause: `formatDateTime(create_time, …) AS create_time` aliased back to the same name as the source column, and the planner picked the String alias in the WHERE / ORDER BY where the original DateTime was expected. Renamed aliases to `*_str` (create_time_str / last_attempt_time_str / latest_fail_time_str). Same trap caught in the new Top memory / Top CPU and By Redash queries — fixed at the same time. system.part_log already qualifies its reference as `pl.event_time` so it wasn't affected.
+- **Memory Analysis empty against CH 24.11** — `arraySum([COLUMNS('CurrentMetric_.*CacheBytes') APPLY avg])` resolved to zero columns on this build, making the array `Nothing`-typed and crashing the aggregate with "array aggregation function cannot be performed on type Nothing". Wrapped with `arrayConcat([toFloat64(0)], [...])` so the array is always typed even when no columns match. Separately, `CurrentMetric_PrimaryIndexCacheBytes` and `CurrentMetric_PrimaryIndexCacheFiles` don't exist on 24.11 yet; new `checkColumnExists()` helper gates the references and falls back to the existing "0" placeholder when the column isn't there.
+- **Query result table rendered in dark mode on light pages** — DataTable was hardcoded to `bg-zinc-900/98 border-white/10 text-white/90` and a half-dozen other glassmorphic vestiges. Replaced the whole shell with ink/paper tokens. AgTable.tsx (unused since SqlTab migrated to DataTable) deleted at the same time.
+- **Sonner toast variants always rendered dark** — success / error / warning had `bg-emerald-950/30 text-emerald-100` with no light pairing, so connection toasts stayed dark green on a light page. Added `dark:`-prefixed pairings; light side uses 50/700 shades.
+- **Layout shift on every monitoring tab switch** — the time-range select only rendered on the Metrics tab and pushed the header sideways when it appeared. Moved into the Metrics page where it semantically belongs; header geometry now stable.
+- **ServerMemoryBreakdown blanked out on servers that hide `OSMemoryTotal`** — gate was strict (`total_bytes === 0` → empty state) so a managed CH or hardened RBAC user saw "Memory metrics aren't available" even though `system.processes` was returning 6 active queries and 225 GB of attributed memory. Rendering now degrades: server total + RSS + breakdown bar when everything's there; just RSS + breakdown when `OSMemoryTotal` is hidden; just the attributed-slice sum with a "Server total not exposed" hint when even RSS is gone.
+- **Light-mode audit** — DataTable, Sonner, LiveQueries rows + expanded detail + kill dialog, Metrics empty state, DataControls toolbar, DownloadDialog, PermissionGuard, DefaultRedirect, CreateDatabase cluster card, RbacRolesTable expanded permissions, DataExplorer search icons, ImportWizard shell + StepUpload + StepProgress, VisualExplain node icons, UPlotMetricItemComponent hover tooltip, SyntaxView SQL token colors. All converted from dark-only Tailwind utilities to editorial tokens with `dark:` pairings.
+
+
+## [v2.14.0] - 2026-05-19
+
+This release builds on phase-1's editorial baseline (v2.13.0) with two parallel tracks: polish that finishes the "bespoke product" feel, and a Monitoring deep-dive built on ideas from [QueryDog](https://github.com/benjaminwootton/QueryDog) (Elastic License 2.0) by Benjamin Wootton. No QueryDog source is bundled — every component was rewritten on top of React 19 + shadcn/ui + recharts + the editorial design system — but the layout and aggregation patterns deserve durable credit, recorded in [NOTICE](./NOTICE).
+
+### Added
+
+- **Command palette (⌘/Ctrl+K)** — `src/components/common/CommandPalette.tsx` (396 lines) with cmdk + shadcn Command. Sections: recent (5 queries), pages (RBAC-gated routes), databases (8), tables (12 sampled), saved queries (from open workspace tabs with `isSaved`), actions (new query / refresh / toggle dock mode / log out), help (shortcuts). Trigger via window-level `keydown` listener in `App.tsx`. Cross-component events: `dock:toggle-mode` (FloatingDock listens) + `shortcuts:open` (SqlTab listens).
+- **Skeleton loading rollout** — primitive at `src/components/ui/skeleton.tsx` swapped to `bg-ink-200 rounded-xs`. New helper file `src/components/common/Skeletons.tsx` (204 lines) exporting `SkeletonRows`, `SkeletonStatGrid`, `SkeletonCardGrid`, `SkeletonTree`, `SkeletonChart`, `SkeletonList`, `SkeletonText`. Rolled out across Home (cluster stats + recent queries + saved queries), UserManagement, ConnectionManagement, ClickHouseUsers, AI Models 3 sub-tabs, LiveQueries, Logs, DataExplorer, Schema + DataSample sections.
+- **Monitoring → Query logs deep-dive** with four sub-views sharing one filter strip, one chart, one time-range chip group, and one pagination component:
+  - **Queries** — compact 10-column table (Time / Status icon / Query / User / Duration / Read rows / Read bytes / Memory / Query ID + checkbox column), SQL ordering plumbed through `useQueryLogs(sortBy, sortDir)` so "memory desc" actually returns the top-memory queries instead of the top of the latest batch. Memory pressure flag: Flame red ≥25%, AlertTriangle amber ≥10% of cluster RAM (read from `system.asynchronous_metrics.OSMemoryTotal`).
+  - **Patterns** — `normalizeQuery()` rollup with cumulative cost columns (Runs / Avg dur / Total dur / Max mem / Read rows / Read bytes), default sort Total dur DESC. Surfaces hot query shapes for ETL/Redash workloads where the same template runs thousands of times.
+  - **By table** — `arrayJoin(tables)` per-table rollup grouped by hot table. SQL pushes the system-schema filter into `arrayFilter` before `arrayJoin` so busy clusters (109k queries / 6h) return in ~1s instead of timing out.
+  - **Histogram** — distribution of duration / memory / read rows / read bytes across the active window. Vertical bar chart with brand-yellow bars, fixed boundary array via `multiIf()` so the bucket cardinality stays tiny.
+- **Query timeline chart** — `src/components/monitoring/QueryTimelineChart.tsx` — stacked bar (default) / stacked area (gradient fills) / line (multi-series, non-stacked) variants, per query_kind (Select / Insert / Delete / Other). Chart-type switcher inside the card header, brand-yellow active chip.
+- **Custom date-range picker** — combined with 15m/1h/6h/24h presets into a single popover trigger. Two-column popover: left "QUICK" list (presets with subtitle hints), right "CUSTOM RANGE" with shadcn `Calendar mode="range"` + Clear / Apply Range. Trigger label adapts: `Last 6h` for presets, `May 18 → May 19` for day-only custom ranges (drops 00:00 suffix), `May 18 14:30 → May 19 16:45` when sub-day times matter.
+- **Query preview tooltip with SQL keyword highlighting** — Radix Tooltip rendered as a popover-style card (max-w-640px, max-h-360px scrollable `<pre>`). Brand-tinted keyword highlighter (SELECT / FROM / WHERE / JOIN / GROUP BY / ORDER BY / etc.), block + line comments dim to paper-faint italic. Header strip shows char count.
+- **Side-by-side query compare dialog** — row-selection checkboxes in Queries sub-view, brand-tinted `N selected · Compare` chip lights up when ≥2 rows picked. Dialog lays the two queries out side by side with their SQL (keyword-highlighted), Query ID, Duration / Memory / Read rows / Read bytes, and any exception. Per-metric Diff strip below shows absolute delta + percentage with emerald/red tint (lower = better).
+- **Profile events drill-down** in the expanded log row — lazy-fetches `system.query_log.ProfileEvents` for the clicked query, renders a 2-column grid sorted by value desc with a brand-tinted ratio bar. Auto-format follows ClickHouse naming: `*Microseconds` → µs/ms/s, `*Bytes`/`*Size` → KB/MB/GB. Top 20 by default; "Show all (N)" toggle reveals the full set.
+- **Views triggered drill-down** in the expanded log row — lazy-fetches `system.query_views_log` keyed on `initial_query_id`. Each row maps to one materialized / normal view that fired as part of the query, sorted by `view_duration_ms` DESC. Section auto-hides when no views fired or the table isn't configured at server level (`<query_views_log>` block opt-in), so successful single-table SELECTs and clusters without the log enabled stay quiet.
+- **Monitoring → Parts** tab — `system.part_log` stacked area chart of event types (NewPart / MergeParts / DownloadPart / MutatePart / RemovePart / Other) + paginated event table with editorial chrome and filter strip. Gated on `METRICS_VIEW`.
+- **Monitoring → Schema doctor** tab — `system.parts_columns` linter with two sub-tabs: Nullable (columns wrapped in `Nullable(T)` ranked by on-disk bytes — the per-row null bitmap is dead weight when the column never holds NULL) and Oversized integers (Int64/UInt64/Int128/UInt128/Int256/UInt256 ranked the same way — most workloads end up Int64 by habit; downcasting often cuts 2-8× off the row weight). Each sub-tab carries an editorial rationale strip, search across all visible fields, totals chip, and a brand-yellow ratio bar showing each column's share of total on-disk bytes.
+- **Monitoring → Cluster activity** tab — two sub-tabs over `system.mutations` (ALTER UPDATE/DELETE in-flight or finished within 7 days, status chip flips red on `latest_fail_reason`) and `system.replication_queue` (sorted by `num_tries` desc so chronically retrying tasks bubble to the top; tries column goes red at 3+). Auto-refresh every 15 s when the Monitoring header toggle is on. Emerald "queue is clean" / "no mutations to report" empty states.
+- **Client-side pagination** across Logs, Parts, and Schema doctor — shared `PaginationBar` component at `src/components/monitoring/PaginationBar.tsx` with first/prev/next/last chevron chips and an `X–Y of Z` range counter.
+- **Cluster RAM helper hook** — `useClusterMemoryTotal()` reads `system.asynchronous_metrics.OSMemoryTotal` once (5-min stale time), powers the memory-pressure flag and Compare dialog's memory cell tint.
+- **NOTICE attribution** — durable acknowledgment of QueryDog (Elastic License 2.0) as the source of the Monitoring deep-dive ideas, alongside the existing CH-UI acknowledgment.
+
+### Changed
+
+- **Monitoring → Logs page restructured end-to-end** to match the dense chart-plus-table model. Top: filter strip (search + log-type + user + role + page-size + clear) on the left, time-range popover + bucket label + total counter on the right. Below: chart card (per query_kind), then a sub-tab strip (Queries / Patterns / By table / Histogram), then the table card with its own pagination bar. Dropped the 4-stat card grid (chart replaces the "Total / Successful / Failed / Avg duration" summary), the framer-motion stagger/status-change animations, and the vertical LogEntry card-list. Click row → expand-in-place reveal with type chip, full query, exception, 4-cell meta grid, optional Views triggered drill-down, and Profile events block.
+- **`useQueryLogs` hook signature** — added `hoursBack`, `sortBy`, `sortDir`, and `customRange` parameters. SQL gained a positive `type IN ('QueryFinish', 'ExceptionWhileProcessing', 'ExceptionBeforeStart')` filter (more selective than the old `type != 'QueryStart'`), `substring(query, 1, 2000) AS query` + `substring(exception, 1, 2000) AS exception` to cap row payload on ETL workloads, and a dynamic `ORDER BY ${col} ${dir}` whitelist mapping for safe SQL-side sorting.
+- **Memory pressure thresholds tuned** — warn at ≥10 % of cluster RAM, danger at ≥25 %. ClickHouse's `max_server_memory_usage` defaults to 0.9 × OS RAM and per-query allocations are additive, so the effective headroom shrinks fast: 4 queries at 25 % each is already OOM territory once background merges and page cache claim their share. 10 % warn catches heavy queries preventively, before they coincide with other heavy queries and trigger `MEMORY_LIMIT_EXCEEDED` kills.
+- **Time column adapts to context** — `formatRowTime` shows date-only context for rows that aren't from today (`May 18 16:58:00`) while today's rows stay short (`16:58:00`). Column width bumped to 140 px to fit.
+- **Connection management — Add / Edit dialog** converted to editorial chrome: chip header (Server icon + mono eyebrow + flat title), mono uppercase labels, hairline ink-500 inputs with brand focus ring, lock-chip SSL/TLS card, emerald/red test-result alerts, brand-yellow Create CTA next to an editorial outline Test connection button.
+- **Microcopy pass** — voiced headlines, specific empty states, "Click to X" copy collapsed to verbs. Admin header "Manage users, roles & access" → "Who can do what, where." All "No X found/configured" + "Get started by..." rewritten to lead with concrete next action ("No connections yet" + "Wire up a ClickHouse server — host, port, credentials"; "No ClickHouse users yet" + "Provision a user with database-scoped grants — DDL or DML, your call"). AiChatBubble welcome "Ask anything about your ClickHouse data." → "What do you want to know?" + trust signal "the assistant has read access to your schema."
+- **Query timeline + table SQL slimmed** — chart aggregation no longer runs `upper(trimLeft(query)) LIKE 'SELECT%'` per row (categorisation is enum-only on `query_kind`); `type IN (…)` filter replaces `!= 'QueryStart'` in both queries.
+- **By-table SQL optimised for busy clusters** — system-schema filter pushed into `arrayFilter` before `arrayJoin`, so a 6 h window with 109 k queries on the BI cluster returns in ~1 s instead of timing out. Outer `length(user_tables) > 0` gates the explode so queries that only touched metadata never join at all.
+- **`useQueryLogs` SQL fetch sorted server-side** so picking "sort by memory desc" returns the genuine top-N across the entire time window, not just the top of the latest 1000 rows by time.
+
+### Fixed
+
+- **Calendar prev/next chevrons missing in react-day-picker v9** — shared `Calendar` was registering v8's `IconLeft`/`IconRight` components which v9 ignores in favour of a single `Chevron` component with an `orientation` prop. The buttons existed and worked, but rendered no glyph. Swapped to the v9 `components.Chevron` contract, editorial-upped the nav buttons (rounded-xs ink chips), and anchored them to `.rdp-months` so they sit next to the calendar grid instead of drifting to the popover corners. Affects every Calendar consumer (Logs custom range, RbacAuditPruneDialog, RbacAuditExportDialog, Preferences).
+- **`<tr>` rendered outside `<table>`** — `SkeletonRows` always returns table rows but was used inside a `<div>` in the Logs and Parts loading branches, triggering a React hydration warning. Wrapped each call site in `<table><tbody>` of its own.
+- **Query preview tooltip line-clamp broken** — earlier `<span class="block max-w-full ... line-clamp-1">` forced `display: flow-root` because `block` overrode `line-clamp-1`'s `display: -webkit-box`. Dropping `block` restored the truncation.
+- **Missing `system.query_views_log` surfaced as a scary red banner** — on clusters where `<query_views_log>` isn't enabled in server config, the SELECT throws `UNKNOWN_TABLE`. Hook now catches the specific missing-table error, treats it as "no views fired", and the auto-hide collapses the section silently. Real errors (network, permissions) still propagate. React Query retries disabled on this hook so the same error doesn't get hammered three times.
+
+
+## [v2.13.0] - 2026-05-18
+
+### Changed
+
+- **Editorial redesign of the main app SPA**: migrated every authenticated page from the inherited "AI-template" look (purple→blue gradients, glassmorphism, animated rings, drop-shadow glow, emoji role icons, vivid status pills, drag-to-move floating panels, bright `richColors` toasts) to the editorial style already shipped on the landing page. The new system uses a dark monochrome canvas (`bg-ink-50`), ClickHouse-yellow as the sole brand accent, Geist Sans + Geist Mono typography, hairline `border-ink-500` borders, and mono uppercase eyebrows for chrome.
+  - **Foundation**: `src/index.css` ports the editorial design tokens (ink-0…ink-700 scale, paper/paper-muted/dim/faint text scale, brand/brand-soft/brand-dim ClickHouse-yellow). Dark shadcn vars are remapped to ink/paper/brand. `src/App.tsx` drops the root radial purple-violet gradient and the two `bg-purple-500/10` / `bg-blue-500/10` blur orbs that bled a violet halo under every authenticated page.
+  - **Pages**: Login, Home/Overview, Explorer shell, Monitoring wrapper, LiveQueries, Logs, Metrics (StatCard + chart wrappers + 7 sub-tabs; Overview tab progress bars use brand-yellow default with amber 60–80% / red >80% tier), Admin wrapper, Preferences (full rewrite with 4 SettingCards, profile hero with initials chip + emerald online dot + brand role pills, `StatusFooter` helper).
+  - **Workspace**: WorkspaceTabs, HomeTab empty state, SqlEditor toolbar (header strip, save-status pill, Save/Kill/Shortcuts dialogs), SqlTab Monaco wrapper + result/explain/statistics tabs, EmptyQueryResult, StatisticsDisplay.
+  - **Sidebar / dock**: FloatingDock, DataExplorer sidebar tree + TreeNode, ConnectionSelector (4 states), UserMenu, Saved Queries connection filter dropdown.
+  - **Admin sub-components**: UserManagement, RbacRolesTable (unified `ROLE_STYLE` with 2-letter codes SA/AD/DV/AN/VW/GS replacing the per-role color map), ConnectionManagement + ConnectionUserAccess, ClickHouseUsers full 4-step wizard (stepper with brand progress fill, unified DV/AN/VW role cards, editorial database tree, emerald/ink password requirement pills, amber DDL preview warning), AiModels (index + Providers/BaseModels/Configs tabs), CreateUser, EditUser, UserDataAccess, RoleFormDialog, RbacAuditLogs (11-variant `ACTION_COLORS` → single uniform `ACTION_BADGE`), RbacAuditPruneDialog, RbacAuditExportDialog.
+- **Shared infrastructure cascading edits**:
+  - `ConfirmationDialog` (`src/components/common/`) — variant chip (red destructive / amber warning / brand info / emerald success) carries the semantic, title stays neutral. Cascades to every delete/logout confirmation across the app (Preferences logout, Admin → Users/Roles/CH Users/AI Models/Connections/Data access rules).
+  - Sonner `Toaster` (`src/components/ui/sonner.tsx` + `src/main.tsx`) — dropped `richColors`, registered editorial classNames per variant (success emerald-950/30 + emerald-300 icon, error red-950/30 + red-300, warning amber-950/30 + amber-300, info ink-100). Also fixed a quiet bug where `{...props}` in the wrapper component was overriding `toastOptions` from callers (main.tsx passed `closeButton: true` and accidentally dropped our classNames).
+- **`AiChatBubble` converted from draggable modal to side-sheet**: removed the 1340×840 floating modal with zoom system, corner/bottom/left resize handles, and free position state. Replaced with a right-anchored side-sheet (compact 420 / standard 560 / wide 760 width cycle, full viewport height, slide-in from right edge with cubic-out easing). Persistence kept compatible with `getChatPrefsFromWorkspace` / `mergeChatPrefsIntoWorkspace` — position pinned to {0,0}, sheet width stored in `size.width`. Net −97 lines after dropping `useDragControls`, `PanInfo`, and three resize handlers. Mobile FAB behavior unchanged. Industry-standard pattern matching Cursor / Copilot Chat / JetBrains AI.
+- **`docker-compose.yml`**: JWT_SECRET / RBAC_ENCRYPTION_KEY / RBAC_ENCRYPTION_SALT switched to `${VAR:-fallback}` substitution. Operators can drop real-length secrets via shell or `.env` without forking the compose file; dev placeholders still allow local boot.
+
+### Fixed
+
+- **`/overview` crash after polling tick**: `q.duration.toFixed is not a function` thrown by `Home.tsx:738` when the recent-queries API serialized `duration` as a JSON string (ClickHouse UInt64 / Float64 fields arrive as strings to preserve precision past 2^53). Now defensively coerced through `Number()` + `Number.isFinite` guard.
+- **Live Queries header stats showed absurd values (`16.47 EB`, `700.15Q`, `1.879e+82 EB`)**: root cause was `useLiveQueriesStats` doing `acc + q.memory_usage` in a reduce. With a string operand, JS `+` switches from numeric addition to string concatenation — 4 queries of ~2.5 GB became literal "0247423385618345678903142559232367289..." which coerced to ~1e40 bytes. Fixed by introducing a `toFinite()` helper at the boundary and running every summed field through `Number()` before `+` or `Math.max`. Defense-in-depth in the `LiveQueries.tsx` formatters: extended bytes units B → YB so the index always lands in-bounds, all formatters use 2 decimals via a centralized `fixed2()` helper that falls back to compact `.toExponential(2)` for values past 1e15, formatters now accept `unknown` and coerce internally.
+- **Query Logs avg duration showed `9.65e+58ms`**: same UInt64-as-string root cause in `useQueryLogs`. Only `event_timestamp` was being run through `Number()`; `query_duration_ms`, `read_rows`, `read_bytes`, `memory_usage` were assigned raw from the API. The `durations.reduce((sum, d) => sum + d, 0)` consumer in `Logs.tsx` was doing string concatenation, then dividing by 50. Fixed at the boundary in `useQueryLogs` — the two later remaps in the same hook read from the now-coerced `logs` array and inherit the fix automatically.
+- **AiChatBubble input invisible against new `bg-ink-100` panel**: bumped to `bg-ink-200` for a differentiated surface.
+- **AiChatBubble thread-empty welcome state vertically over-centered** post-flatten: reflowed to top-aligned, matching the ChatGPT empty-state pattern.
+- **App.tsx dock mode-change race condition**: `FloatingDock` dispatched the event before `App.tsx` had attached its listener (React child effects run before parent effects). Dispatch now goes through `setTimeout(_, 0)` so the listener wins the race.
+
+
+## [v2.12.10] - 2026-04-01
+
+### Fixed
+
+- **Migration startup crash (#195)**: The RBAC migration system crashed on startup when SQLite columns added in a previous run already existed. Drizzle ORM wraps the native `bun:sqlite` error into a `DrizzleError` where the original `"duplicate column name: …"` message is placed in `error.cause.message`, not `error.message`. The catch blocks across migrations 1.2.1, 1.11.0, 1.15.0, 1.17.0, and 1.17.1 checked only `error.message`, so the guard never matched and the error was re-thrown — preventing the app from starting on any upgrade that had already partially applied those migrations. Similarly, the UNIQUE constraint guard in migration 1.2.2 had the same gap. Introduced `isDuplicateColumnError` and `isUniqueConstraintError` helpers that inspect both `error.message` and `error.cause?.message`, ensuring all six affected catch blocks correctly skip already-existing columns and constraints.
+
+## [v2.12.9] - 2026-03-02
+
+### Added
+
+- **Server logging (Pino)**: New `packages/server/src/utils/logger.ts` — base logger and `requestLogger(requestId)` for request-scoped correlation. Single-line JSON in production; `pino-pretty` in development. Level controlled by `LOG_LEVEL` (debug | info | warn | error); default `info` in production, `debug` in development.
+- **Client log helper**: New `src/lib/log.ts` — `log.error`, `log.warn`, `log.info`, `log.debug` with optional context; info/debug only in dev; no sensitive data. Used across app, API, components, pages, hooks, and stores.
+- **Log level config**: `LOG_LEVEL` in `.env.example` and `log_level` in `.config.example.yaml`. Documented in README.md env table.
+- **Dependencies**: `pino` and `pino-pretty` (dev) in `packages/server/package.json`.
+
+### Changed
+
+- **Server**: All server-side `console.log` / `console.error` / `console.warn` replaced with `logger` or `requestLogger(c.get('requestId'))` in: `packages/server/src/index.ts` (startup, env validation, request logging, cleanup, shutdown), error middleware, RBAC (cli, routes, services, db/index, migrations), routes (ai-chat, explorer, query, saved-queries, live-queries), services (clickhouse, clientManager, chatHistory, aiOptimizer), configLoader, cors, dataAccess. Request logging runs in all environments (one JSON line per request: method, path, status, durationMs, requestId).
+- **Frontend**: Dozens of files now use `log` from `@/lib/log` instead of `console.*` (e.g. App, api/client, api/rbac, Sidebar, SqlTab, Explorer, hooks, stores, admin/RBAC/workspace components).
+- **Error handler**: Error middleware logs via `requestLogger` with structured fields; 500s use `reqLog.error`, non-404 client errors and 404 use `reqLog.warn`.
+- **Tests**: `packages/server/src/middleware/error.test.ts` mocks `../utils/logger` (`requestLogger` returns `{ error, warn }`); assertions use `mockError`/`mockWarn` instead of `console` spies; `afterEach` uses `vi.clearAllMocks()`.
+- **Docs**: ARCHITECTURE.md — `src/lib` count and log.ts description; "Logging (Server)" row (Pino) in stack table.
+
+## [v2.12.8] - 2026-03-01
+
+### Added
+
+- **Shared agent tools** (`agentTools.ts`): Common RBAC-aware ClickHouse tools (list DBs/tables, get schema/DDL, run SELECT, explain, validate_sql, export, slow queries, etc.) and `AgentToolContext`. Used by AI Chat, Optimizer, and Debugger.
+- **Agent-driven Optimizer & Debugger**: Both use `ToolLoopAgent`; they get `AgentToolContext` and call tools for DDL/EXPLAIN/analyze, then return structured JSON. Routes pass context and no longer pre-fetch table details.
+- **SQL “no FORMAT” rule**: Prompts tell the model not to append FORMAT; `stripFormatClause()` strips it from agent output.
+- **Keyboard Shortcuts dialog**: Run, Format, Comment, Find, Explain, Optimize, Save/Save as… with ⌘/Ctrl shortcuts; opened from editor toolbar.
+- **Results-panel action strip**: Run/Stop, Explain, AI Optimize at top of results (replaces toolbar buttons).
+- **SqlEditor ref** (`SqlEditorHandle`): `format`, `commentLine`, `find`, `save`, `saveAs`, `stop`, `getQuery` exposed to parent. Keybindings: F5 run, Cmd+Shift+F/E/I for format, explain, optimize.
+- **chouse-light theme** and **db.table** highlighting in Monaco.
+- **“Debug with AI”** button in query error panel when user has permission.
+
+### Changed
+
+- **AI Chat**: Uses shared `createCoreTools` + `createChartTool`; `ChatContext` = `AgentToolContext`; step limit 30; no FORMAT in prompt.
+- **AI Optimizer**: ToolLoopAgent + tools; APIs take `agentContext` instead of `tableDetails`. Structured JSON via Zod + `extractJson()`.
+- **SqlTab**: Strip above results; simpler resize handle. **SqlEditor**: Toolbar replaced by single shortcuts button.
+- **Tests**: `aiOptimizer.test.ts` updated for context-based API.
+
+## [v2.12.7] - 2026-03-01
+
+### Added
+
+- **Enriched Audit Logs**: Audit log entries now capture parsed client information extracted from HTTP headers — browser name & version, operating system & version, device type (Desktop / Mobile / Tablet / Bot), preferred language (from `Accept-Language`), and country (from CDN headers such as `CF-IPCountry`). A new lightweight, zero-dependency `parseUserAgent` utility performs regex-based User-Agent parsing server-side.
+- **Extended Audit Coverage**: Added audit logging for operations that were previously untracked:
+  - **AI Management**: Provider create/update/delete, Model create/update/delete, Config create/update/delete.
+  - **Connection Management**: Create, update, delete, connect, grant access, revoke access.
+  - **Data Access Rules**: Create, update, delete, bulk set.
+  - **Saved Queries**: Create, update, delete.
+  - **Explorer Operations**: Create database, drop database, create table, drop table.
+- **Audit Action Constants**: New `AUDIT_ACTIONS` entries for all newly tracked operations in `packages/server/src/rbac/schema/base.ts`.
+- **Client Info UI**: The audit logs table replaces the plain "IP Address" column with a rich "Client Info" cell showing device icon, browser, OS, country, language, and IP — with a tooltip displaying the full User-Agent string.
+- **DB Migration 1.17.0**: Adds `browser`, `browser_version`, `os`, `os_version`, `device_type`, `language`, and `country` columns to `rbac_audit_logs` for both SQLite and PostgreSQL.
+- **Broader Country Detection** (enhancement): Fixed country always being `null` when the server runs without Cloudflare or Vercel. Country resolution now follows a prioritised fallback chain across all major CDN and proxy providers:
+  1. Cloudflare (`CF-IPCountry`)
+  2. Vercel (`X-Vercel-IP-Country`)
+  3. AWS CloudFront (`CloudFront-Viewer-Country`)
+  4. Fastly (`X-Country-Code`)
+  5. Akamai (`X-Akamai-Edgescape`, parsed `country_code=XX`)
+  6. Nginx GeoIP (`X-GeoIP-Country` / `X-Real-Country`)
+  7. Accept-Language region tag fallback (`id-ID` → `ID`) for on-premise / CDN-less deployments
+- **Deeper Client Context** (enhancement): Five additional fields are now extracted per audit log entry:
+  - `device_model` — mobile/tablet brand and model parsed from User-Agent (e.g. `Samsung SM-S918B`, `Pixel 8`, `iPhone`)
+  - `architecture` — CPU/platform architecture parsed from User-Agent (e.g. `x86_64`, `ARM64`, `x86 (WOW64)`)
+  - `city` — city name from CDN geo headers (Cloudflare `CF-IPCity`, Vercel `X-Vercel-IP-City`, CloudFront `CloudFront-Viewer-City`, Akamai Edgescape)
+  - `country_region` — subdivision/state code from CDN headers (Vercel `X-Vercel-IP-Country-Region`, CloudFront `CloudFront-Viewer-Country-Region`, Akamai)
+  - `timezone` — IANA timezone from CDN headers (Vercel `X-Vercel-IP-Timezone`, CloudFront `CloudFront-Viewer-Time-Zone`, Akamai)
+- **DB Migration 1.17.1**: Adds `timezone`, `city`, `country_region`, `device_model`, and `architecture` columns to `rbac_audit_logs` for both SQLite and PostgreSQL.
+- **Enriched Client Info UI** (enhancement): The "Client Info" table cell and hover tooltip are redesigned to surface all new fields:
+  - Compact row now shows device model (mobile/tablet only) with architecture chip badge, and city + country code together.
+  - Tooltip is restructured into three labelled sections — **Client** (device type, model, arch, browser, OS), **Location** (city, country/region, timezone, language), **Network** (IP) — plus a raw User-Agent footer.
+
+### Changed
+
+- **`createAuditLogWithContext` Helper**: Introduced a new `createAuditLogWithContext(c, ...)` function that auto-extracts User-Agent, Accept-Language, and CDN country headers from the Hono request context. All RBAC route handlers (auth, users, roles, connections, data access, ClickHouse users, AI providers, AI models, AI configs, audit) now use this helper instead of manually passing `userAgent`.
+- **`getClientHeaders` expanded**: Now reads geo headers from all major CDN providers (Cloudflare, Vercel, AWS CloudFront, Fastly, Akamai, Nginx GeoIP) including city, country region, and timezone fields, in addition to the previously supported country-only headers.
+- **Audit Logs CSV Export**: Export now includes all client info fields — `Device Model`, `Architecture`, `City`, `Country Region`, and `Timezone` added alongside the existing browser, OS, device type, language, and country columns (24 total columns, up from 19).
+
+## [v2.12.6] - 2026-03-01
+
+### Added
+
+- **ClickHouse SQL Dialect**: Replaced generic SQL formatter with `sql-formatter`'s native ClickHouse dialect. New shared `formatClickHouseSQL` utility used across InfoTab, AI dialogs, Monaco editor, and server-side AI prompts.
+- **ClickHouse Monarch Tokenizer**: New `clickhouseLanguage.ts` with comprehensive syntax highlighting for ClickHouse-specific keywords, data types, engines, settings, and constructs (`PREWHERE`, `FINAL`, `MATERIALIZED`, `CODEC`, window functions, etc.).
+- **Rich Function Intellisense**: Functions now show aggregate/regular badges, syntax blocks, and Markdown descriptions sourced from `system.functions` metadata (`is_aggregate`, `description`, `syntax`).
+- **Hover & Signature Help**: Hovering over functions, columns, tables, databases, and data types shows contextual documentation. Typing inside function parentheses triggers signature help with parameter highlighting.
+- **Extended Completion Contexts**: Autocomplete for `GROUP BY`, `ORDER BY`, `HAVING`, `PREWHERE`, `SETTINGS`, `ENGINE =`, `INSERT INTO`, `USING`, `VALUES`, and data type positions — each suggesting contextually appropriate items (settings, engines, types, etc.).
+- **SQL Snippets**: Common patterns (`SELECT … FROM`, `CREATE TABLE`, `INSERT INTO`, `ALTER TABLE ADD COLUMN`) as snippet completions with tab-stop placeholders.
+- **CTE & Alias Resolution**: Autocomplete resolves CTE aliases (`WITH … AS`) and table aliases to their underlying tables for column suggestions (e.g., `alias.` triggers column list).
+- **Custom Suggest Widget Icons**: Replaced default codicon icons with custom SVG icons for database, table, column, function, aggregate, setting, engine, data type, keyword, and snippet.
+- **Expand All Columns Suggestion**: In `SELECT` context, autocomplete now offers a `* (expand all columns)` completion at the top of the list. Selecting it inserts all column names from every table in scope, with alias-prefixed names for multi-table joins (e.g. `u.id,\n  u.name,\n  o.total`). The suggestion label shows the total column count and the participating table aliases.
+
+### Changed
+
+- **Intellisense Data Model**: `IntellisenseFunctionInfo` now carries `name`, `is_aggregate`, `description`, `syntax` (previously plain strings). Server queries `system.functions` with full metadata.
+- **Completion Provider**: Refactored into factory functions (`createCompletionProvider`, `createHoverProvider`, `createSignatureHelpProvider`). Fine-grained priority sorting (`00_`–`09_`) for context-aware ranking. Added `(` and `,` as trigger characters.
+- **Multi-line Context Detection**: `parseQueryContext` now scans all text before the cursor instead of only the current line, correctly handling multi-line queries.
+- **Implicit Alias Detection**: `getTablesInScope` detects implicit aliases (`FROM users u`) with a keyword blocklist to avoid false positives.
+- **Full-Query Table Scope**: `getTablesInScope` now scans the entire query instead of only the text before the cursor. This ensures column completions correctly resolve tables declared in the `FROM`/`JOIN` clauses even when the cursor is still editing the `SELECT` list.
+- **Editor Theme**: Added Monarch token-specific color rules to `chouse-dark` (bold keywords, teal types, italic comments, etc.). Enabled snippet previews and parameter hints.
+- **sql-formatter**: Upgraded from `^15.6.10` to `^15.7.2`.
+- **AI Chat Resize Handles**: Made invisible (functional-only) — removed visible border decorations and hover effects.
+- **Tests**: Extended `sqlCompletionUtils.test.ts` with coverage for `getTextBeforeCursor`, `parseCTEDefinitions`, `resolveTableAlias`, all new context kinds, multi-line detection, implicit aliases, and CTE resolution.
+
+## [v2.12.5] - 2026-02-28
+
+### Added
+
+- **ResponsiveDraggableDialog**: New shared dialog wrapper for explorer modals (Upload file, AI debugger, AI optimizer, Create table, Create database). Viewport-friendly on tablet and mobile; draggable and resizable on desktop with position and size persisted per device in user preferences.
+- **Explorer dialog preferences**: Extended `devicePreferences` with `explorerDialogPreferences` (per-device, per-dialog position/size), `getExplorerDialogPrefsFromWorkspace`, `mergeExplorerDialogPrefsIntoWorkspace`, and default position/size per device for explorer dialogs.
+- **AI Chat resize handles**: Resize handles (top, right, corners) for the AI chat window with new CSS classes in `index.css`; desktop-only, with drag disabled while resizing.
+
+### Changed
+
+- **Explorer modals**: Debug Query, Optimize Query, Create Database, Create Table, and Import Wizard now use `ResponsiveDraggableDialog` for consistent behavior and persisted layout across devices.
+- **AI Chat drag**: Full header is draggable (replaced dedicated grip handle) with touch support and no-drag when interacting with header buttons/inputs.
+- **ARCHITECTURE.md**: Common components count and directory tree updated to include ResponsiveDraggableDialog.
+
+## [v2.12.4] - 2026-02-27
+
+### ⚠️ Security
+
+We **recommend upgrading to v2.12.4** due to a security fix in RBAC query execution. Earlier versions could, under certain permission combinations, allow broader or more destructive SQL operations than intended when role permissions were not strictly matched to each statement type.
+
+### Security
+
+- **RBAC Data Access Enforcement**: Tightened ClickHouse RBAC data access middleware so each SQL statement type (SELECT, INSERT, UPDATE, DELETE, CREATE, ALTER, DROP, TRUNCATE, SHOW/DESCRIBE, USE/SET/EXPLAIN/EXISTS/CHECK/KILL) now requires a specific permission (e.g. `table:select`, `table:insert`, `table:delete`, `table:create`, `table:alter`, `table:drop`, `database:drop`, `query:execute:misc`). This prevents permissive combinations (such as having `table:create` only) from implicitly authorizing unrelated destructive operations like `DROP DATABASE` or `DROP TABLE`.
+- **Multi-Statement Protection**: Improved per-statement validation and error reporting for multi-statement batches so failures clearly indicate the index and exact missing permission, reducing the risk of accidentally executing a dangerous statement buried in a longer script.
+
+### Changed
+
+- **Operation-Specific Permissions**: Updated data access middleware to resolve an operation-specific required permission for every supported statement and deny execution if that exact permission is missing, while still using high-level access types (read/write/admin) only for data access rule evaluation.
+- **Tests**: Expanded and updated `dataAccess` middleware tests to cover DROP DATABASE/TABLE, TRUNCATE, and mixed batches across different permission combinations, ensuring the tightened security behavior is enforced.
+
+## [v2.12.3] - 2026-02-27
+
+### Added
+
+- **Per-device workspace preferences**: Dock and AI chat position/size are now stored and loaded per device type (mobile, tablet, laptop, pc). New `useDeviceType` hook and `devicePreferences` helpers (`getDockPrefsFromWorkspace`, `getChatPrefsFromWorkspace`, merge helpers) with defaults per device; FloatingDock and AiChatBubble use them so layout is appropriate when switching viewport sizes or devices.
+- **AI chart export**: Charts from AI Chat support download as PNG (via html-to-image), CSV, or JSON from a new dropdown menu on each chart. Pie/donut charts cap at 12 slices (rest aggregated as "Other"); bar-family charts cap at 25 categories for readability.
+- **AI Chat tools**: New agent tools `validate_sql` (syntax-only validation), `export_query_result` (run SELECT and return CSV or JSON, up to 1000 rows), and `get_slow_queries` (recent slow queries from query_log). Skills updated to reference them (sql-generation, data-visualization, query-optimization, system-troubleshooting, data-exploration).
+- **AI Chat UX**: Thread rename (inline edit in sidebar), copy message to clipboard, export thread as Markdown; virtualized message list for long threads; Retry button only when server sends `retryable !== false`.
+- **Stream rate limit**: POST `/api/ai-chat/stream` is rate-limited to 30 requests per minute per user.
+- **Tests**: Unit tests for `devicePreferences` and `preprocessMarkdown`; MSW handlers for PATCH thread, GET models, POST stream; ai-chat API and route tests extended.
+
+### Changed
+
+- **AI Chat backend**: Stream request validation (message max length 32k, messages array max 50, schema for role/content); SSE error events include `retryable`. `run_select_query` adds LIMIT 100 when missing; `search_columns` pattern sanitized (LIKE escape, max length 200) to prevent injection.
+- **AI Chat frontend**: Assistant markdown is sanitized with DOMPurify and normalized with `preprocessMarkdown` (leading whitespace, line endings, table-safe handling).
+- **ARCHITECTURE.md**: Documented `/api/ai-chat`, AI Chat and Chat History services, hooks/lib counts, and new "Data Flow: AI Chat" sequence diagram.
+
+## [v2.12.2] - 2026-02-26
+
+### Added
+
+- **SQL Editor Auto-Complete**: Optimized completion using the intellisense API (single cache, cleared on logout), trigger characters, context-aware ordering, and column-level suggestions from FROM/JOIN tables (including aliases) in SELECT/WHERE/ON.
+
+- **Draggable AI Chat Window**: The `AiChatBubble` has been upgraded with `framer-motion` capabilities. The desktop chat window can now be freely dragged around the screen using new header drag handles, allowing position anywhere to view underlying query data while chatting.
+- **Context Persistence**: The AI chat bubble window now remembers the last opened chat `activeThreadId` if closed and reopened within **5 minutes** (as long as the connection string stays the same). This allows for easy multithreading and quick navigation without losing chat context during work.
+- **Metadata Sync**: Both the new constrained Floating Dock `placement` and the `AiChatBubble`'s freely dragged position are persisted to the backend user `preferences` table, so your layout configuration persists across sessions and devices.
+
+### Changed
+
+- **Constrained Floating Dock**: The Floating Dock drag behavior was previously based on free `(x, y)` coordinate positioning, which often caused visually disjointed hiding behaviors. The dock has been heavily refactored to snap to the closest **Top, Bottom, Left, or Right edges**. The `autoHide` sliding animation now accurately slides off the screen in the chosen direction. The dock also loads in `sidebar` mode by default.
+
+### Fixed
+
+- **ClickHouse Connection Port Parsing**: Fixed validation error when entering port numbers in the connection form. Typed input values (e.g., "18123") were treated as strings, causing "Invalid input: expected number, received string" errors (#172).
+- **Dialog Close Buttons**: Fixed the 'x' close button inside the `DebugQueryDialog` and `OptimizeQueryDialog` which were previously unclickable due to styling overlaps. They have now been mapped to a custom close button in the header, enabling immediate query cancellation and modal dismissal.
+- **Mobile/Tablet Drag Support**: Fixed drag functionality for FloatingDock and AI Chat components on tablet and smartphone devices. Enabled drag on tablets for `AiChatBubble`, added `touch-action: none` CSS to prevent default browser touch behaviors, enhanced drag handles with minimum 44x44px touch targets for accessibility, and improved touch event handling with proper `preventDefault()` calls. Both components now support smooth dragging on touch devices without interfering with scrolling or zooming.
+
+## [v2.12.1] - 2026-02-25
+### Added
+
+- **Provider-Config Cascade Deactivation**: When an AI provider is deactivated, all AI configs belonging to models under that provider are automatically deactivated to maintain data consistency. This ensures inactive providers cannot have active configs.
+- **Provider Type Constants**: Introduced centralized provider type definitions in `packages/server/src/rbac/constants/aiProviders.ts` and `src/constants/aiProviders.ts` as a single source of truth for all supported provider types (openai, anthropic, google, huggingface, openai-compatible). Adding new provider types now requires minimal code changes.
+- **Database Schema Update**: Added `provider_type` column to `rbac_ai_providers` table to separate provider type (e.g., "openai", "anthropic") from display name (e.g., "OpenAI Production"). Database migration version 1.16.2 automatically adds the `provider_type` column, copies existing `name` values to `provider_type` for backward compatibility, validates all provider types, and makes the column NOT NULL. The `name` field now stores custom display names while `provider_type` stores the actual provider type used for SDK initialization.
+
+### Changed
+
+- **Database Schema**: Updated `rbac_ai_providers` table schema in both PostgreSQL and SQLite to include `provider_type VARCHAR(255) NOT NULL` column. Updated Drizzle ORM schema definitions in `packages/server/src/rbac/schema/postgres.ts` and `packages/server/src/rbac/schema/sqlite.ts`.
+- **Provider Management**: Updated all provider-related services and API routes to use `providerType` field instead of inferring type from `name`. The UI now displays both provider name and provider type separately.
+- **Config Activation Validation**: Enhanced validation to prevent activating or creating AI configs when their associated provider is inactive. Users receive clear error messages indicating which provider needs to be activated first.
+- **Error Handling Improvements**: Updated AI Configs API routes and UI components to display user-readable error messages from the server, replacing generic "Failed to update/create" messages with specific guidance (e.g., "Cannot activate config because its provider 'OpenAI Production' is inactive. Please activate the provider first.").
+
+### Fixed
+
+- **Data Consistency**: Fixed a bug where configs could be activated even when their provider was inactive, which could lead to runtime failures when attempting to use AI features.
+
+## [v2.12.0] - 2026-02-25
+
+### ⚠️ BREAKING CHANGE / MIGRATION REQUIRED
+- **AI Configuration via Environment Variables Removed**: The system no longer reads `AI_API_KEY`, `AI_PROVIDER`, etc. from `.env` or `.config.yaml`.
+  - **Migration**: Log in as an Admin, navigate to **Preferences > AI Models** to manually configure your AI Providers, SDK Models, and Active Deployments via the new interactive UI.
+
+### Added
+
+- **AI Dashboard UI**: Integrated a unified 3-tier management system for AI configurations natively into the application.
+  - **Providers**: Manage API keys and Base URLs for OpenAI, Anthropic, Google, HuggingFace, etc., encrypted at rest.
+  - **SDK Models**: Define the available base models (`gpt-4o`, `claude-3-5-sonnet`) supported by your providers.
+  - **Config Deployments**: Create user-facing active configurations complete with dynamic default selection.
+- **Agent Skills Architecture**: Introduced a new `packages/server/src/skills/` directory to externalize AI instructions into modular `SKILL.md` files.
+  - Dynamically loads complex operating instructions (skills) like data visualization, SQL generation, and query optimization.
+  - Reduces main system prompt size, dramatically improving AI instruction adherence and minimizing token limits.
+  - Added specific skills: `data-visualization`, `data-exploration`, `sql-generation`, `query-optimization`, `system-troubleshooting` (for AI Chat), and `optimizer`, `debugger`, `evaluator` (for AI Optimizer).
+
+### Changed
+
+- **AI Dialogs Refactored**: The "Debug with AI" and "Optimize Query" dialogs now feature an explicitly interactive grid forcing manual user selection of the desired AI Config before execution, instead of auto-running.
+- **AI Chat Window**: Replaced native `<select>` dropdowns for Model Selection with a dynamically styled `DropdownMenu`. Instantly listens to `ai-config-updated` broadcasts for zero-reload updates.
+- **AI Chat Enhancements**: Refactored `aiChat.ts` to utilize a `load_skill` tool and explicit Intent-to-Skill routing framework.
+  - Enforced STRICT TOOL-FIRST rules to prevent text-based hallucinations when charts are requested.
+  - The AI now dynamically loads visualization rules only when a `render_chart` visualization is needed.
+
+## [v2.11.3] - 2026-02-25
+
+### Added
+
+- **YAML Configuration**: Added support for configuring the application via a `.config.yaml` file (`packages/server/src/utils/configLoader`). Replaced the extensive environment variables tab in the Portfolio UI with a streamlined YAML Configuration tab.
+
+### Fixed
+
+- **Docker Configuration**: Updated and formatted the project Dockerfile.
+
+## [v2.11.2] - 2026-02-24
+
+### Added
+
+- **Interactive AI Charts & Persistence**: The AI Chat Assistant now generates and renders interactive Recharts inline from ClickHouse query results.
+  - **16 Supported Types**: Includes Bar, Stacked Bar, Grouped Bar, Horizontal Bar, Line, Multi-line, Area, Stacked Area, Pie, Donut, Scatter, Radar, Treemap, Funnel, Histogram, and Heatmap.
+  - **Smart Data Inference**: Automatically infers X and Y axes from column metadata.
+  - **Persistent History**: All generated charts (including multiple charts in a single response) are securely stored in the internal Drizzle database (`rbac_ai_chat_messages`), restoring seamlessly on page reload.
+  - **Real-Time Streaming**: Enhanced Server-Sent Events (SSE) with `chart-data` deltas to buffer arrays of large JSON chart specifications dynamically.
+
+### Changed
+
+- **AI Tooling Rules**: Upgraded the AI system prompt with strict rules on when to use `render_chart`, including mandatory schema checks to prevent hallucinating non-existent columns.
+
+### Fixed
+
+- **Chart Overwrite Bug**: Patched an issue causing newer charts to overwrite previous charts in multi-chart responses.
+- **BigInt Serialization**: Fixed server crashes when returning ClickHouse aggregation results (`BigInt` counts) by adding a custom JSON replacer.
+- **SSE Buffer Truncation**: Fixed the frontend SSE parser splitting payloads by a single `\n` instead of `\n\n`, which broke large JSON streams.
+- **Vite HMR Crashes**: Resolved Hot Module Replacement crashes in `AiChartRenderer.tsx` by cleanly separating logic into `AiChartUtils.ts`.
+- **Hydration Error**: Fixed invalid HTML nesting (`<button>` inside `<button>`) in `SidebarThreadButton`.
+
+## [v2.11.1] - 2026-02-23
+
+### Changed
+
+- **AI Chat Agent & Core Enhancements**: Migrated to AI SDK v6 `ToolLoopAgent` for automatic tool orchestration (limit raised to 30 steps), capped message history to 50, and improved scratchpad stripping for reliable CoT marker removal.
+- **AI Chat UI & Polish**: Redesigned the thread sidebar with recency grouping, polished the "Thinking" panel with glassmorphism/shimmer effects, and added message arrival animations.
+- **Expanded Suggested Prompts**: Increased welcome-screen prompts to a randomized pool of 16 with a new shuffle button.
+- **Responsive & Resizable Chat Window**: Implemented a fully responsive interface using proportional `transform: scale()` for layout stability across all devices. Includes free-form resizing, adaptive UI logic (auto-hiding sidebar at narrow widths), and a fullscreen mobile overlay with FAB trigger.
+- **Z-Index Optimization**: Refreshed layering for the floating dock and chat components to ensure proper rendering of popups, tooltips, and floating triggers.
+- **Connection Isolation**: Enforced ClickHouse connection isolation across the entire stack, ensuring threads and history are correctly filtered by active connection in both frontend and backend.
+- **Query & API Refinement**: Fixed `get_table_size` aggregation logic and standardized `connectionId` handling in all chat-related API endpoints.
+
+### Fixed
+
+- **Layout & Reset Fixes**: Resolved resizing glitches by pivoting from legacy CSS `zoom` to `transform: scale()`, and fixed the AI Chat sidebar failing to reset during connection changes.
+
+## [v2.11.0] - 2026-02-23
+
+### Added
+
+- **AI Chat Assistant**: Introduced a fully integrated AI-powered chat assistant for ClickHouse exploration and analysis.
+  - **Floating Chat Bubble**: New floating `AiChatBubble` component accessible from every page via a persistent button. Opens a resizable chat window with a premium glassmorphic design.
+  - **Multi-turn Conversations**: Supports threaded conversations with full history — create, switch, and delete threads from a collapsible sidebar.
+  - **Live Tool Execution Panel**: Expandable "Thinking" panel shows each tool the AI calls in real-time, including parsed arguments and a brief result summary (e.g. "12 rows returned"). SQL args render in a scrollable `<pre>` block.
+  - **Streaming Responses**: AI text streams token-by-token using Server-Sent Events (SSE) with a live cursor indicator.
+  - **Markdown Rendering**: Full GFM support — tables, fenced `sql` code blocks with syntax highlighting, inline code, headers, and lists. Includes `preprocessMarkdown` to normalise literal `\n` sequences and collapse code fences inside table cells.
+  - **AI Tools**: The assistant has access to 14 ClickHouse tools — `list_databases`, `list_tables`, `get_table_schema`, `get_table_ddl`, `get_table_sample`, `get_table_size`, `run_select_query`, `explain_query`, `analyze_query`, `optimize_query`, `search_columns`, `get_slow_queries`, `get_database_stats`, and `generate_query`.
+  - **RBAC Protection**: AI Chat is gated behind `AI_CHAT` permission; only users with the permission can open and use the assistant.
+  - **Thread Persistence**: Conversations and tool-call results are persisted to the RBAC metadata database, surviving page reloads and sessions.
+  - **Escape Key Support & Accessibility**: Press `Esc` to close the chat window; `aria-label` added for screen readers.
+  - **Retry & Fallback UX**: Error messages include a styled "Retry" button; an empty-response fallback message is shown when the AI returns no content.
+
+## [v2.10.3] - 2026-02-21
+
+
+### Added
+
+- **New Monitoring Metrics**: Added 7 new metrics to the Metrics Dashboard aligned with ClickHouse system tables.
+  - **Performance Tab**: CPU Usage (Cores), Data Throughput (Bytes), Write I/O (disk/filesystem bytes/sec).
+  - **Merges Tab**: Merged Bytes Throughput, Delayed Inserts (backpressure indicator with wait time).
+  - **System Tab**: Load Average (15min) history chart, ZooKeeper Transactions/sec, ZooKeeper Traffic (bytes sent/received).
+- **Home Page Refresh Button**: Added a global refresh button to the Home page header for refreshing all dashboard data (system stats, databases, queries, favorites) with a 3-second cooldown and spin animation.
+- **Full-Screen Mode**: Added global full-screen toggle to the Floating Dock using the native Browser Fullscreen API. Sidebar mode auto-switches to floating during full-screen for maximum content space. Toggle between `Maximize2`/`Minimize2` icons with ESC key support.
+- **Dock Settings Popover**: Consolidated dock control buttons (auto-hide, orientation, dock mode, reset position) into a single `⚙` gear popover with labeled rows. Fullscreen and manual hide buttons remain inline. Redesigned auto-hide indicator to show current page icon/label with a pulsing connection dot.
+
+### Changed
+
+- **Home Page Layout**: Updated Home page to use full-width layout matching Admin, Monitoring, and Preference pages (removed `max-w-7xl` constraint).
+- **Home Page Background**: Removed custom dark gradient background so the Home page inherits the same glass-style background as other pages.
+- **Chart Y-Axis Formatting**: Improved value formatting for metrics with small decimal values (Cores, Load, Txn/s, Delayed) using adaptive precision instead of compact notation that rounded to zero.
+- **Dock UX Improvements**: Increased auto-hide delay to 3.5s for better reliability, replaced Eye/EyeOff with Pin/PinOff icons for the auto-hide toggle, and removed keyboard shortcut labels (⌘1–⌘5) from dock tooltips.
+
+### Fixed
+
+- **ClickHouse Users Refresh Button**: Fixed "Check Connection" button on the ClickHouse Users tab doing nothing when no active session exists. The button now performs a server-side session check and provides feedback via toast notification.
+- **Cache Bytes Calculation**: Fixed `cache_bytes` metric to correctly sum all in-memory cache types (mark cache, uncompressed cache, compiled expression cache, etc.) using `arraySum(COLUMNS('CurrentMetric_.*CacheBytes'))` instead of only `PrimaryIndexCacheBytes`.
+- **System History Queries**: Fixed `getSystemMetricsHistory` to correctly query `system.metric_log` for `CurrentMetric_Query/Merge/PartMutation` and `system.asynchronous_metric_log` for `TotalPartsOfMergeTreeTables` (was incorrectly querying async log for all metrics).
+- **Network History Metrics**: Updated `getNetworkMetricsHistory` to use `system.asynchronous_metric_log` with `LIKE` patterns for network send/receive bytes (matching ClickHouse monitoring dashboards), with fallback to `system.metric_log`.
+
+### Security
+
+- **Live Queries RBAC Privilege Escalation**: Fixed security issue where non-admin RBAC users with `live_queries:view` and `live_queries:kill` permissions could see and terminate queries belonging to admin and super_admin users. Non-admin users now only see their own queries. Added new `live_queries:kill_all` permission for admin-level kill privileges; the existing `live_queries:kill` permission now only allows killing own queries.
+
+## [v2.10.2] - 2026-02-20
+
+### Added
+
+- **AI Query Optimizer Support**: Added support for OpenAI-compatible AI providers using the `@ai-sdk/openai-compatible` package (Issue #143).
+  - Enables integration with self-hosted models via Ollama, LocalAI, Together AI, etc.
+  - Added `AI_OPENAI_COMPATIBLE_HEADERS` for custom authentication headers support.
+- **Import Wizard Append Feature**: Enhanced Import Wizard to support appending data to existing ClickHouse tables (Issue #147).
+  - Users can select existing tables via dropdown mapping in "Append to Existing Table" mode.
+  - Fetch target table schema and provide interactive Column Mapping.
+  - Skip "Create Table" process when appending and explicitly match columns upon insertion.
+
+### Changed
+
+- **Import Wizard**: Enhanced the schema preview step with advanced table configuration options (Issue #146).
+  - Admins can now configure Table Engine, Partition By, TTL Expression, and Table Comments directly before importing.
+  - Added support for column-level descriptions and Sort Key (`ORDER BY`) toggles depending on the Engine.
+- **Create Table UI**: Redesigned the Database Explorer's column definition interface (Issue #144).
+  - Replaced single-row flex layouts with responsive, multi-row cards.
+  - Added native toggles for `Nullable` types and input fields for `Default Value` and `Description`.
+  - Integrated `ORDER BY` and primary key selection inside column cards with visual highlighting.
+
+### Fixed
+
+- **Server Stat Display**: Fixed `totalRows` statistic formatting issue on the Home page (Issue #148).
+- **AI Query Debugger**: Added UI error handling to gracefully display API failure messages with a retry option in the Debug Query Dialog (Issue #145).
+
+## [v2.10.1] - 2026-02-17
+
+### Added
+
+- **AI Query Debugger**:
+  - Introduced AI-powered Query Debugger to automatically analyze and suggest fixes for failed SQL queries (Issue #138).
+  - Added frontend support with a new `DebugQueryDialog`.
+- **SQL Parser**:
+  - Replaced legacy regex-based parsing with a full Abstract Syntax Tree (AST) parser using `node-sql-parser`.
+  - Added support for Common Table Expressions (CTE) in SQL analysis.
+  - Improved table and column extraction for complex queries.
+
+### Changed
+
+- **AI Query Optimizer**:
+  - Improved robustness with specialized system prompts to prevent infinite optimization loops.
+  - Enhanced permission checks for AI features (Optimizer and Debugger) to follow RBAC.
+- **UI/UX Refinement**:
+  - Optimized the Explain popup and tab by conditionally hiding the Analysis tab when the AI Optimizer is enabled.
+  - Resolved "Double Icon" bug in `ExplainPopout`, `RoleFormDialog`, and `ExplainTab` by leveraging automatic icon rendering in the standardized `Alert` component.
+  - Refined visuals for SQL editor and query optimization dialogs.
+- **Documentation Standards**: Standardized screenshot guidelines and updated documentation with new visual assets for all major features (Issue #130).
+- **Portfolio Enhancements**:
+  - Enhanced gallery with marquee scroll for a smoother experience.
+  - Updated Quick Start guides and Docker Compose configurations.
+  - Fixed various SEO and meta-tag issues.
+  - Refactored API client for better resilience.
+  - Added global `auth:unauthorized` event for immediate redirection on session loss.
+- **Server Performance**: Introduced `ClientManager` to pool ClickHouse connections, reducing overhead and improving stability.
+- **Session Duration**: Increased session expiration duration from 15 minutes to 4 hours (Issue #128).
+- **Portfolio UI**: Updated portfolio text to prioritize "UI" over "Interface" and added dynamic copyright years.
+- **Connection Troubleshooting**:
+  - Implemented "smart" connection probing to automatically check alternative hosts (`127.0.0.1`, `host.docker.internal`) when `localhost` fails with `ECONNREFUSED`.
+  - Improved error messages to suggest actionable fixes for connection refusal issues.
+  - Bypass `ClientManager` caching during connection tests to ensure fresh connection attempts.
+
+### Fixed
+
+- **Authentication Stability**: Fixed critical race conditions in token refresh logic that caused random logouts.
+  - Implemented global concurrency lock for token refreshes.
+  - Updated all server routes to correctly return `401 Unauthorized` instead of `403 Forbidden` for expired sessions, enabling automatic recovery.
+- **Audit Log Snapshots**: Enhanced query history to use user snapshots from audit logs, ensuring correct user display even for deleted or modified accounts.
+- **Explain Popout**: Fixed "Analysis" tab visibility to correctly respect AI Optimizer configuration (Issue #129).
+- **Session Enforcement**: Fixed a bug where database sessions were hardcoded to 7 days, ignoring configuration (Issue #128).
+- **CI/CD**: Fixed release triggers for Dockerfile changes and enabled concurrent job cancellation to prevent build redundancy.
+
+
+## [v2.10.0] - 2026-02-15
+
+### Added
+
+- **AI Query Optimizer**: Integrated intelligent query optimization directly into the SQL Editor (Issue #115).
+  - **Multi-Provider Support**: Supports OpenAI, Anthropic, Google Gemini, and HuggingFace models.
+  - **Interactive Dialog**: Dedicated interface to optimize queries with custom prompts.
+  - **Diff View**: Visual comparison between original and optimized SQL.
+  - **Detailed Analysis**: Provides markdown-formatted explanations, performance summaries, and actionable tips.
+  - **RBAC Protection**: Restricted to users with `AI_OPTIMIZE` permission.
+- **Audit Log Export**: Added ability to export audit logs to CSV with comprehensive filtering options.
+  - Supports filtering by Date Range, Action, Username, Email, and Status.
+  - Export respects current active filters.
+
+
+### Changed
+
+- **Explain Tab Enhancements**: Refactored Explain tab to distinct view types (Plan, AST, Syntax, Pipeline).
+- **RBAC Roles UI**: Improved role management interface with better permission grouping and visual feedback.
+- **SQL Editor**: Added direct access to AI Optimizer and improved save functionality.
+- **Audit Log Filters**: Enhanced Audit Logs page with granular filtering by Username, Email, and Status.
+  - Added dynamic metadata fetching for filter dropdowns.
+  - Improved status visualization (Success vs Failed).
+
+
+### Fixed
+
+- **Home Page Navigation**: Fixed issue where clicking Favorites, Recent items, or Saved Queries from a different connection would fail.
+  - Filtered Favorites, Recent items, and Saved Queries in the Home page to only show those belonging to the currently active connection (Issue #125).
+  - Prevents "table not found" errors by ensure context matches the selected item.
+- **Data Access Display**: Fixed "Data Access" card in Preferences to correctly show "Full Global Access" for all admin users.
+  - Previously only updated for super admins, now correctly reflects promoted admin status immediately.
+- **Audit Log Logic**: Fixed backend filtering logic for audit logs.
+  - Ensure filters for username, email, and status are correctly applied in listing, export, and pruning operations.
+
+
+## [v2.9.2] - 2026-02-14
+
+### Added
+
+- **Preferences Page**: Completely redesigned user preferences interface with enhanced visual design.
+  - **Profile Hero Section**: Large profile card displaying user avatar, display name, email, join date, and assigned roles with gradient styling.
+  - **Identity & Access Card**: Shows username, RBAC ID, and session status with visual indicators.
+  - **Connection Details Card**: Displays ClickHouse endpoint and version with copy-to-clipboard functionality.
+  - **Data Access Card**: Collapsible hierarchical view of data access rules organized by connection and database with expand/collapse functionality.
+  - **Functional Access Card**: Categorized display of all user permissions grouped by category (e.g., queries, databases, tables).
+  - **Premium Glass Morphism Design**: Modern glassmorphic cards with backdrop blur, gradient accents, and smooth animations.
+  - **Responsive Grid Layout**: 3-column grid layout that adapts to different screen sizes.
+
+### Changed
+
+- **Settings → Preferences Rename**: Renamed "Settings" page to "Preferences" throughout the application for better clarity.
+  - Updated route from `/settings` to `/preferences` with backward compatibility redirect.
+  - Changed navigation icon from `Settings` to `UserCog` in FloatingDock.
+  - Updated navigation label from "Settings" to "Preferences".
+  - Removed `SETTINGS_VIEW` permission requirement (now accessible to all authenticated users).
+- **Admin Page Redesign**: Completely redesigned admin page with modern card-based tab navigation.
+  - **Tab Cards**: Replaced traditional tab list with large, interactive tab cards showing icon, label, and description.
+  - **Visual Feedback**: Added hover effects, active state indicators, and smooth animations for tab switching.
+  - **Color-Coded Tabs**: Each tab has a unique color scheme (purple for Users, blue for Roles, cyan for Connections, indigo for ClickHouse Users, green for Audit).
+  - **Improved Layout**: Better spacing, glassmorphic design, and visual hierarchy.
+- **Home Page Layout Improvements**: Enhanced Quick Access and Saved Queries sections.
+  - **Fixed Heights**: Set consistent height (450px) for Quick Access and Saved Queries cards.
+  - **Scrollable Content**: Added overflow scrolling to handle large lists without breaking layout.
+  - **Full List Display**: Removed arbitrary limits (previously showed only 6 items), now displays all items with scrolling.
+  - **Better Flex Layout**: Improved flex container structure for proper content distribution.
+- **Monitoring Page Consolidation**: Unified Live Queries, Logs, and Metrics into a single Monitoring page.
+  - Added backward compatibility redirects from `/logs` and `/metrics` to `/monitoring`.
+  - Streamlined navigation with single entry point for all monitoring features.
+- **Typography Refinements**: Improved text styling across Preferences page.
+  - Changed labels to bold semibold font for better readability.
+  - Enhanced contrast with proper color hierarchy (white for values, gray for labels).
+  - Improved badge styling with proper padding and border radius.
+
+### Fixed
+
+- **Query Analyzer Type Safety**: Improved type handling in query analyzer service.
+  - Fixed potential type errors in query pattern matching.
+  - Added proper null checks and type guards.
+- **RBAC Auth Route**: Enhanced authentication route error handling.
+  - Improved session validation logic.
+  - Better error messages for authentication failures.
+- **Connection Management UI**: Fixed layout issues in connection management component.
+  - Improved responsive behavior.
+  - Fixed button alignment and spacing.
+- **ClickHouse Users Management**: Refined user management interface.
+  - Better error handling for user operations.
+  - Improved loading states and feedback.
+- **Preferences Page Access**: Fixed `DataAccessCard` to correctly display admin access status for non-super-admin administrators (Issue #124).
+
+### Removed
+
+- **Settings Page**: Removed old Settings page (`src/pages/Settings.tsx`) in favor of new Preferences page.
+  - Old Settings page had limited functionality and outdated design.
+  - New Preferences page provides comprehensive user profile and access information.
+
+## [v2.9.1] - 2026-02-13
+
+### Added
+
+- **Data Import Wizard**: Replaced the simple file upload with a comprehensive wizard (Issue #102).
+  - **Schema Inference**: Automatically detects column names, types, and nullability from CSV, TSV, and JSON files.
+  - **Interactive Editor**: Review and modify the inferred schema before import.
+  - **Data Preview**: Visualize the dataset structure and sample values.
+  - **Streaming Upload**: Efficiently handles large file uploads using streaming inserts.
+  - **Progress Tracking**: Real-time status updates for table creation and data insertion.
+- **Visual Query Explain Plan**: Added visual representation of query execution plans (Issue #101).
+  - **Explain Tab**: New tab in SQL Editor to visualize the query plan.
+  - **Interactive Graph**: Uses ReactFlow and Dagre for DAG visualization of query steps with execution order numbering.
+  - **Tear-out Window**: Support for popping out the explain plan into a standalone window via button or drag-and-drop.
+  - **JSON Output**: Supports `EXPLAIN JSON` for detailed plan analysis.
+- **Collapsible Explorer Sidebar**: Added ability to collapse/expand the database explorer sidebar to maximize workspace.
+- **Floating Dock Navigation**: Replaced traditional sidebar with a modern floating dock.
+  - **Draggable Dock**: Move the navigation dock anywhere on screen with drag-and-drop.
+  - **Orientation Toggle**: Switch between horizontal and vertical dock layouts.
+  - **Auto-Hide**: Dock automatically hides after inactivity with smooth reveal on hover.
+  - **Sidebar Mode**: Option to pin the dock as a fixed sidebar on the left edge.
+  - **Preferences Sync**: Dock configuration (mode, orientation, position, auto-hide) persists to database for cross-device sync.
+
+### Changed
+
+- **Overview Page Redesign**: Completely redesigned home page with bento-style layout.
+  - **Server Stats Cards**: At-a-glance view of databases, tables, total rows, storage, connections, and active queries.
+  - **Connection Info Header**: Displays active connection name, ClickHouse version, and server uptime.
+  - **Quick Actions**: One-click access to New Query, Import, Monitor, and Query History.
+  - **Quick Access Section**: Tabbed view for favorites and recently visited tables/databases.
+  - **Saved Queries Panel**: Easy access to saved queries with public/private badges.
+  - **Recent Activity**: Grid view of recent query executions with status indicators.
+  - **ClickHouse Resources**: Quick links to official documentation, SQL reference, and best practices.
+
+## [v2.8.7] - 2026-02-08
+
+### Added
+
+- **System Metrics Tab**: Added a new "System" tab to the Metrics Dashboard (Issue #110).
+  - Monitoring for Memory Usage (Resident vs Tracking).
+  - Visualization of File Descriptor usage.
+  - Detailed breakdown of ClickHouse Thread Pools (Global, Local, Background).
+- **Network Metrics Tab**: Added a new "Network" tab to the Metrics Dashboard (Issue #110).
+  - Real-time tracking of TCP, HTTP, and Interserver connections.
+- **Enhanced Performance Tab**: Refactored Performance tab to focus on latency extremes.
+  - Added "Max Latency" card to highlight worst-case performance.
+  - Removed duplicate p95/p99 metrics (now available in the header).
+
+### Changed
+
+- **Metrics Unification**: Removed duplicate metrics (QPS, Latency p95/p99) from individual tabs to ensure a cleaner, zero-duplication interface.
+- **Backend Optimization**: Optimized `getProductionMetrics` service to fetch new system and network metrics in parallel.
+
+### Fixed
+
+- **Live Queries User Display**: Fixed inconsistent user display in Live Queries (Issue #108).
+  - Now displays the specific RBAC user (e.g., `alice`) instead of the generic database user (e.g., `default`).
+  - Added tooltip to show both RBAC user and ClickHouse user details.
+  - Ensures consistency with Query Log display.
+- **SQL Results Interaction**: Fixed layout and scrolling issues in SQL Results (Issue #109).
+  - **Sticky Header**: Re-enabled sticky header with refined "Dark Glass" styling for better readability.
+  - **Column Freezing**: Disabled sticky first column to prevent layout breakage on horizontal scroll.
+  - **Pagination**: Added client-side pagination with configurable page size (10-100 rows) for improved performance.
+  - **Visuals**: Aligned background brightness with Data Sample section for a consistent aesthetic.
+
+## [v2.8.6] - 2026-02-07
+
+### Added
+
+- **Sidebar User Menu Redesign**: Replaced the "Account" section with a unified, premium User Menu (Issue #105).
+  - **Expandable Profile**: Expanded sidebar shows full profile details (Name/Email) to efficiently use space.
+  - **Minimalist Icon**: Collapsed sidebar shows a clean, icon-only avatar with tooltip details.
+  - **Dynamic Interactions**: Added hover effects for better visual feedback (Red gradient for logout).
+  - **Direct Actions**: Simplified interaction model with intuitive logout controls.
+- **Logout Confirmation**: Added a confirmation dialog to prevent accidental logouts.
+  - Implemented in both the **Sidebar User Menu** and the **Settings Page**.
+  - Standardized the confirmation message ("Are you sure you want to log out?") across the app.
+- **Audit Log Pruning**: Added retention policy support for audit logs (Issue #97).
+  - Users can now prune logs older than 7, 30, or 90 days.
+  - Support for custom date pruning.
+  - Consolidated deletion logic into a single `RbacAuditPruneDialog`.
+  - "Delete Logs" now supports deleting based on current active filters.
+- **Audit Log Enhancements**: Improved audit log accuracy and usability (Issue #99).
+  - **User Snapshots**: Audit logs now snapshot user details (`username`, `email`, `displayName`) at the time of the event, ensuring historical data remains accurate even if users are deleted or modified.
+  - **Enhanced UI**: Added explicit columns for Display Name, Username, and Email in the Audit Logs table, replacing the single "User" column.
+  - **Improved Export**: CSV export now includes snapshot fields (`Username (Snapshot)`, `Email (Snapshot)`, `Display Name (Snapshot)`) for better reporting.
+  - **Horizontal Scrolling**: Enabled horizontal scrolling for the audit logs table to prevent content truncation.
+
+### Fixed
+
+- **Sidebar Layout**: Optimized vertical space usage in the sidebar by grouping account actions.
+- **User Management Actions**: Fixed issue where the "More options" menu was visible for users with no permissions to act on the target user (Issue #98).
+  - Conditionally render the dropdown menu only when valid actions (Edit, Delete, Reset Password) are available.
+  - Ensures cleaner UI for admins who cannot modify super admins or other protected users.
+- **Logout Request Loop**: Fixed issue where clicking logout would trigger multiple requests to the logout endpoint, causing 429 errors.
+  - Implemented singleton `BroadcastChannel` in `sessionCleanup` to prevent self-notification loops.
+  - Added authentication check safeguard in `AppInit` to prevent redundant logout calls.
+- **SET Command Syntax Error**: Fixed issue where `SET` commands were treated as queries, causing `FORMAT JSON` to be appended and resulting in syntax errors (Issue #100).
+  - Added `SET` to the list of command patterns in `ClickHouseService` to ensure it's executed as a command without formatting.
+- **API Client Resilience**: Fixed application crash when receiving non-JSON error responses (e.g., 429 Too Many Requests) (Issue #103).
+  - Client now attempts to parse response as JSON and falls back to plain text if parsing fails.
+  - Ensures graceful error handling for rate limits and other infrastructure-level errors.
+- **Rate Limit Mitigation**: Mitigated frequent 429 "Too Many Requests" errors in production (Issue #104).
+  - Relaxed server-side rate limits (Queries: 300/min, API: 1000/min).
+  - Implemented client-side retry logic with exponential backoff for 429 responses.
+  - Optimized `useSystemStats` polling interval to reduce server load.
+- **Environment Configuration**: Fixed `bun run dev` not consistently loading `.env` variables.
+  - Updated `dev` script to explicitly use `--env-file=.env` flag, ensuring correct environment loading.
+
+## [v2.8.5] - 2026-02-03
+
+### Added
+
+- **RBAC-based Query Execution**: Strictly execute queries based on user permissions (Issue #94).
+  - Backend now handles permission checks for specific SQL commands.
+  - Ensures robust security enforcement at the API level.
+
+### Changed
+
+- **Metrics Dashboard Unification**: Unified Metrics dashboard visuals with the Overview page (Issue #93).
+  - Updated cards to match Overview style (Total Rows, Tables).
+  - Consistent iconography for better UX.
+
+### Fixed
+
+- **Execution Control**: Fixed issue where the Execute button remained accessible during a running query without kill permissions (Issue #92).
+  - Prevents unauthorized users from attempting to stop or re-run queries indiscriminately.
+
+## [v2.8.4] - 2026-02-01
+
+### Added
+
+- **Audit Log Cleanup**: Added ability to delete audit logs based on active filters (Issue #89).
+  - New "Delete Logs" button in Audit Logs tab with confirmation summarize.
+  - Secure backend endpoint `DELETE /api/rbac/audit` with support for filtering.
+  - Configurable retention protection (`CHOUSE_AUDIT_LOG_RETENTION_DAYS`, default 365).
+  - New permission `audit:delete` for controlling cleanup operations.
+- **Audit Deletion Migration**: Migration `v1.9.0` ensures the new `audit:delete` permission is assigned to the `super_admin` role automatically.
+- **Version Display**: Added CHouse UI version number to sidebar footer (Issue #87).
+  - Version is always visible in the sidebar
+  - Shows abbreviated version when sidebar is collapsed with full version in tooltip
+  - Version is dynamically read from package.json at build time
+- **Kill Query Button**: Added ability to terminate running queries directly from the SQL Editor (Issue #88).
+  - New "Stop" button appears in the toolbar when a query is executing
+  - Confirmation dialog prevents accidental query termination
+  - Requires `LIVE_QUERIES_KILL` permission
+  - Dynamically tracks query execution status via `queryId`
+
+### Changed
+
+- **Premium Popover Design**: Updated Date Range and Delete Logs popovers with `backdrop-blur-3xl` glassmorphism and refined dark aesthetics.
+- **Date Range UX**: Simplified interaction and added quick-select presets for range selection.
+- **Query Logs View**: Default view mode changed to Grid Only (Issue #80).
+  - Removed table view option to simplify the interface
+  - Removed view toggle buttons
+  - Set grid view as the permanent display mode
+- **Explorer Page Title**: Removed redundant 'Explore' title from Explorer page header (Issue #85).
+  - The sidebar already identifies the page as 'Explorer'
+  - Title now only appears as a breadcrumb when navigating to a database/table
+  - Creates a cleaner interface with more space for actual content
+- **SQL Editor Toolbar**: Complete redesign of the editor toolbar for better aesthetics and UX.
+  - New modular control group with black styling and backdrop blur
+  - Dynamic button hover states (Blue for Run, Red for Stop)
+  - Icon-only "Run" and "Stop" buttons with tooltips for a cleaner, modern look
+  - Integrated save status indicators and tooltips for all actions
+
+### Fixed
+
+- **Calendar Alignment & Visibility**: Fixed "Su MoTuWeThFrSa" alignment issues by syncing with `react-day-picker` v9 classes.
+  - Implemented robust CSS Grid layout for perfect weekday and date centering.
+  - Enabled `fixedWeeks` to ensure all dates are visible without height jumps.
+- **Dynamic Page Titles**: Fixed browser tab title not updating when navigating between pages (Issue #84).
+  - Added `PageTitleUpdater` component to manage titles globally
+  - Titles now update dynamically (e.g., "CHouse UI | Overview", "CHouse UI | Monitoring")
+  - Explorer page retains context-aware titles (database/table names)
+- **Search Bar Layout**: Fixed layout shift issue where search bar would expand unpredictably (Issue #81).
+  - Enforced stable width for search bar input container
+- **Refresh Button UX**: Added visual feedback to the Refresh button on Overview page (Issue #82).
+  - Button now shows disabled state and spinning icon while refreshing
+  - Added visual confirmation that refresh action is in progress
+- **Metrics Updates**: Fixed issue where Errors card and other metrics would not update when switching connections (Issue #83).
+  - Updated React Query hooks (`useMetrics`, `useSystemStats`, etc.) to include connection ID in query keys
+  - Ensures data is automatically refetched when active connection changes
+- **Horizontal Scrolling**: Fixed issue where query result grids wouldn't scroll horizontally with many columns.
+  - Added width constraints and overflow management to the results panel
+  - Ensured AG Grid correctly fills the available container space
+
+
+## [v2.8.3] - 2026-01-31
+
+### Added
+
+- **Connection management RBAC**: New permissions `connections:view`, `connections:edit`, and `connections:delete` to control access to the Connections tab and CRUD actions.
+  - **Backend**: Permissions in schema and seed; migration 1.8.0 assigns them to `super_admin`; connection routes require appropriate permission per action.
+  - **Frontend**: `CONNECTIONS_VIEW`, `CONNECTIONS_EDIT`, `CONNECTIONS_DELETE` in RBAC store; Admin tab visibility uses `connections:view`.
+
+### Changed
+
+- **Connection Management UI**: Edit and Delete actions are permission-gated.
+  - Add Connection, Edit, and Activate/Deactivate require `connections:edit`.
+  - Delete requires `connections:delete`.
+  - Test and Manage Access remain available to users with `connections:view`.
+- **Role cards**: Connection-related permissions are grouped under "Connections" instead of "Other" in the Roles table (`PERMISSION_CATEGORIES`).
+
+## [v2.8.2] - 2026-01-31
+
+### Removed
+
+#### Set Default Connection Feature (Issue #64)
+- **Remove Set Default Connection**: Removed the non-functional 'Set Default Connection' feature that was admin-only and didn't persist correctly after login.
+  - Removed `setDefault` method from `RBACConnectionsApi` in `src/api/rbac.ts`
+  - Removed `handleSetDefault` and "Set as Default" button from `ConnectionManagement/index.tsx`
+  - Removed `setDefaultConnection` function from `packages/server/src/rbac/services/connections.ts`
+  - Removed `PUT /connections/:id/default` endpoint from `packages/server/src/rbac/routes/connections.ts`
+  - Removed related tests from `connections.test.ts`
+
+### Changed
+
+#### Metrics Page Improvements
+- **Replace CPU Load with Read Rate**: Replaced the CPU Load metric in the Performance tab with "Read Rate" (bytes read per second), providing more meaningful performance insights.
+  - Read Rate calculated from `system.query_log` ProfileEvents over the last 60 seconds
+  - Added `read_rate` field to `ResourceMetrics` interface (backend and frontend)
+  - Updated `getResourceMetrics` service to query read throughput data
+- **Cache Performance Icon**: Changed Cache Performance section icon from `Cpu` to `Zap` for visual consistency.
+
+#### Overview Page Improvements  
+- **Replace CPU Load with Error Rate**: Replaced the unreliable CPU Load metric on the Overview page with "Errors (24h)" for better utility.
+  - Shows count of failed queries in the last 24 hours from `useMetrics` hook
+  - Conditional styling: green when no errors, red/amber when errors present
+  - Displays "All clear" or "Check logs" subtext based on error count
+- **Removed Unused Components**: Removed unused `ProgressBar` component from Home.tsx.
+
+## [v2.8.1] - 2026-01-30
+
+### Fixed
+
+- **PostgreSQL migration 1.7.0**: Fixed failure when using PostgreSQL; the postgres driver expects string/Buffer for bind params, not `Date`. Use `createdAt.toISOString()` for the `created_at` column in the role-permissions INSERT (fixes "Received an instance of Date" error).
+
+## [v2.8.0] - 2026-01-30
+
+### Added
+
+- **Live Query Management** (Issue #71): Admins can view and stop running ClickHouse queries from the UI.
+  - **View**: New Live Queries page lists executing queries from `system.processes` (filtered to exclude internal queries).
+  - **Control**: Kill running queries via UI with confirmation; requires `live_queries:kill` permission.
+  - **Security**: Restricted via RBAC; new permissions `live_queries:view` and `live_queries:kill` (assigned to admin roles).
+  - **Backend**: New `/api/live-queries` route (GET list, POST kill); audit logging for kill actions.
+  - **Frontend**: `liveQueriesApi`, `useLiveQueries`, `useKillQuery`, `useLiveQueriesStats`; Monitoring/Live Queries pages and nav entry.
+  - **Tests**: Server route tests (`live-queries.test.ts`), frontend API and hook tests, MSW handlers for live-queries.
+
+- **Overview Largest Tables**: Top tables by size now use `system.tables` (non-system databases only) so the overview "Largest Tables" section is populated even when `system.parts` is empty (e.g. non-MergeTree tables or restricted environments).
+  - **Tests**: `getTopTablesBySize` and GET `/metrics/top-tables` tests; `getTopTables` and `useTopTables` frontend tests; MSW handler for `/metrics/top-tables`.
+
+### Fixed
+
+- **Upload to `default` database**: Allowed `default` as a valid database name in SQL identifier validation so file uploads to the ClickHouse `default` database no longer fail with "Invalid identifier: default".
+  - **Frontend**: Removed `default` from reserved keywords in `src/helpers/sqlUtils.ts`; added tests for `validateIdentifier('default')` and `escapeQualifiedIdentifier(['default', 'table'])`.
+  - **Server**: Same change in `packages/server/src/utils/sqlIdentifier.ts` and tests.
+
+### Testing
+
+- Added and updated tests for Live Queries (server routes, API, hooks, `useLiveQueriesStats`).
+- Added tests for top-tables API, `useTopTables` export, and metrics GET `/metrics/top-tables`.
+- Added tests for `default` identifier and `escapeQualifiedIdentifier` with `default` database (frontend and server).
+
+## [v2.7.6] - 2026-01-22
+
+### Added
+
+- **Saved Queries Deletion** (Issue #65): Added ability to delete saved queries directly from the Data Explorer UI.
+  - Delete button (trash icon) on saved query items
+  - Confirmation dialog to prevent accidental deletion
+  - Permissions check (`SAVED_QUERIES_DELETE`)
+
+### Fixed
+
+- **Duplicate Connection Filters** (Issue #66): Fixed issue where the active connection name was duplicated in "Pinned", "Recent", and "Queries" filter dropdowns in Data Explorer.
+- **Role Icon Consistency** (Issue #67): Fixed icon mismatch between Roles Table and Role Form Dialog.
+  - Aligned icons for Super Admin and Admin roles across the application
+  - Updated Custom Role icon to `🔐` (Lock with Key) for consistency in Create/Edit User forms
+  - Added "User Count" display to Role Form Dialog to match the table view
+
+## [v2.7.5] - 2026-01-18
+
+### Added
+
+#### Comprehensive Server Test Infrastructure
+- **187 Unit Tests**: Comprehensive test coverage across server codebase (96.4% pass rate)
+  - Services: 49 tests (RBAC, ClickHouse, JWT, passwords, etc.)
+  - Middleware: 48 tests (CORS, error handling, SQL parsing, data access)
+  - RBAC Core: 24 tests (DB initialization, auth middleware, schema)
+  - Routes: 21 tests (config, explorer, metrics, query)
+  - RBAC Routes: 45 tests (auth, users, roles, audit, etc.)
+
+- **Isolated Test Runner**: Custom shell script (`scripts/test-isolated-server.sh`) for complete test isolation
+  - Runs each test file independently to prevent mock leakage
+  - Shows running success rate (e.g., "5/5 (100%)")
+  - Color-coded output with pass/fail indicators
+  - 100% test pass rate with isolated execution
+
+- **CI Integration**: Automated testing in GitHub Actions workflow
+  - Runs on every push/PR to main/develop branches
+  - Validates TypeScript compilation
+  - Executes full test suite with isolation
+  - Ensures code quality before merging
+
+- **Test Scripts**: Added npm scripts for different test scenarios
+  - `test` - Run all tests (quick feedback)
+  - `test:coverage` - Run with coverage reports
+  - `test:isolated` - Run with complete isolation (for CI)
+  - `typecheck` - TypeScript validation
+
+### Fixed
+
+- **Rate Limiter Configuration** (Issue #30): Fixed aggressive rate limiting causing 429 errors
+  - Increased login attempts: 5 → 10 per 15 minutes
+  - Increased query endpoints: 10 → 100 per minute
+  - Increased general API: 100 → 300 per minute
+  - Users no longer experience rate limit errors during normal usage
+
+- **Type Safety Improvements** (Issue #31): Enhanced TypeScript type safety across server
+  - All tests include proper type checking
+  - Improved error handling with typed errors
+  - Better IDE support with stricter types
+  - Reduced runtime errors through compile-time validation
+
+### Changed
+
+#### Project Organization
+- **Centralized Scripts**: Moved test scripts to `/scripts` directory for monorepo organization
+  - Renamed to `test-isolated-server.sh` for clarity
+  - Script auto-navigates to packages/server
+  - Prepared structure for future frontend tests
+
+#### Testing Infrastructure
+- **Mock Isolation**: Tests run file-by-file to prevent mock leakage between test suites
+- **Coverage Reporting**: Added Codecov integration for tracking test coverage over time
+- **CI Workflow**: Updated to use isolated test runner for reliability
+
+### Testing
+
+- Created comprehensive test suite covering:
+  - JWT token generation and verification
+  - Password hashing and validation
+  - RBAC middleware and permissions
+  - Route authentication and authorization
+  - Database initialization and migrations
+  - SQL parsing and injection prevention
+  - Error handling and formatting
+  - CORS policy enforcement
+
+### Documentation
+
+- Added test execution instructions to development workflow
+- Documented known test limitations (saved-queries mock issue)
+- Updated CI/CD documentation with test integration details
+
+## [v2.7.4] - 2026-01-18
+
+### Added
+
+- **Automatic Database Creation**: Added automatic database creation for PostgreSQL and SQLite metadata databases:
+  - **SQLite**: Automatically creates the database directory and file if they don't exist
+  - **PostgreSQL**: Automatically creates the database if it doesn't exist (requires `CREATEDB` privilege)
+  - Eliminates the need for manual database setup during initial configuration
+  - Graceful error handling with informative logging
+
+- **Comprehensive Permission-Based UI Hiding**: All UI elements are now hidden based on user permissions:
+  - **Metrics Page**: Advanced tabs (Performance, Storage, Merges, Errors) are hidden for users with only `METRICS_VIEW` permission
+  - **Home/Overview Page**: Quick Actions section hides actions based on permissions (Explorer, Metrics, Logs, Admin)
+  - **Explorer Page**: Database/table operation dropdowns show only actions user has permission for:
+    - "New Database" requires `DB_CREATE`
+    - "New Table" requires `TABLE_CREATE`
+    - "Upload File" requires `TABLE_INSERT`
+  - **Logs Page**: User/role filter dropdowns now check `QUERY_HISTORY_VIEW_ALL` permission (not just super admin)
+  - **Saved Queries**: All saved query features are permission-gated:
+    - DataExplorer "Queries" tab requires `SAVED_QUERIES_VIEW`
+    - HomeTab saved queries section requires `SAVED_QUERIES_VIEW`
+    - SqlEditor save button requires `SAVED_QUERIES_CREATE` or `SAVED_QUERIES_UPDATE`
+  - Users can only see and access features they have permission for, improving security and UX
+
+### Documentation
+
+- Added PostgreSQL permission requirements to README with SQL examples for granting `CREATEDB` privilege
+- Added troubleshooting entry for PostgreSQL permission issues
+
+## [v2.7.3] - 2026-01-18
+
+### Added
+
+- **RBAC Permission Checks for All Pages**: Added proper RBAC permission checks for all application pages:
+  - **Overview/Home Page**: Now requires admin role (consistent with sidebar visibility)
+  - **Logs Page**: Requires `QUERY_HISTORY_VIEW` or `QUERY_HISTORY_VIEW_ALL` permission
+  - **Explorer Page**: Requires `DB_VIEW` or `TABLE_VIEW` permission
+  - **Settings Page**: Requires `SETTINGS_VIEW` permission
+  - All pages now properly enforce RBAC permissions, redirecting unauthorized users appropriately
+
+- **Role Form Dialog Enhancements**: Added Collapse/Expand All button in role creation/editing dialog:
+  - Single toggle button that switches between "Expand All" and "Collapse All" based on current state
+  - Makes it easier to navigate permission categories when managing roles
+  - Button shows appropriate icon (ChevronsDown/ChevronsUp) based on state
+
+### Fixed
+
+- **Duplicate Icon in Alert**: Fixed duplicate AlertCircle icon in "At least one permission is required" alert message. The Alert component already includes an icon based on variant, so the manual icon was removed.
+
+## [v2.7.2] - 2026-01-18
+
+### Fixed
+
+- **Super Admin System Role Modification**: Fixed bug where super admins were blocked from modifying system roles despite having the proper permissions. The service layer now respects the route-level permission check, allowing super admins to modify system roles (including the super_admin role itself). (Fixes #50)
+- **GitHub Pages SPA Routing for Googlebot**: Fixed redirect errors for Googlebot smartphone crawler by adding automatic `404.html` file generation during build. GitHub Pages now properly serves the SPA for all routes, ensuring proper indexing without redirect errors. (Fixes Google Search Console redirect errors)
+
+## [v2.7.1] - 2026-01-18
+
+### Fixed
+
+- **Role Permissions in Edit Mode**: Fixed bug where previously selected permissions were missing when editing a role. The issue was caused by a mismatch between permission names (returned by backend) and permission IDs (expected by frontend). Now correctly maps permission names to IDs when initializing the edit form. (Fixes #46)
+- **Explorer Dropdown Menu Actions**: Fixed two related bugs in the Explorer page dropdown menu:
+  - Clicking "New Query" no longer triggers "View Details" action. Added proper event propagation handling to prevent unintended side effects.
+  - Clicking disabled menu items (due to missing permissions) no longer opens the info tab. Disabled items now properly prevent event propagation. (Fixes #47)
+
+## [v2.7.0] - 2026-01-17
+
+### Added
+
+#### Role Management UI
+- **Interactive Role Creation/Editing**: New beautiful UI dialog for creating and editing RBAC roles
+  - Create custom roles with custom permissions
+  - Edit custom roles (name, display name, description, permissions, default flag)
+  - Edit predefined/system roles (display name, description, permissions - backend enforces system role protection)
+  - Permission selection by category with search functionality
+  - Select All/Deselect All permissions
+  - Collapsible permission categories with visual feedback
+  - Smooth animations using Framer Motion
+  - Default role assignment with automatic flag management
+
+### Fixed
+
+- **Default Role Flag**: Fixed bug where assigning a custom role as default didn't remove the default flag from the previous default role. Now ensures only one role can be default at any given time with atomic operations.
+
+### Changed
+
+#### Legacy Authentication Removal
+- **RBAC-Only Authentication**: Removed all legacy ClickHouse session-based authentication code
+  - Deleted `packages/server/src/routes/auth.ts` (legacy auth routes)
+  - Deleted `src/api/auth.ts` (legacy auth API client)
+  - Deleted `packages/server/src/middleware/auth.ts` (legacy auth middleware)
+  - All authentication now strictly uses RBAC, improving security and simplifying the codebase
+
+#### UI/UX Enhancements
+- **Consistent Button Styling**: All buttons in Admin page now use consistent styling (`variant="outline"` with unified className)
+- **Dialog Layout Improvements**: Fixed padding and scrolling issues in all dialogs
+  - Proper flexbox layout for scrollable content
+  - Consistent padding structure (`px-6` for horizontal, `py-4`/`py-6` for vertical)
+  - Fixed height dialogs (`h-[90vh]`) with proper overflow handling
+- **Enhanced Visual Design**: Improved animations and visual hierarchy across role management components
+
+### Removed
+
+- **Legacy Authentication Code**: Complete removal of unused ClickHouse session-based authentication
+  - Legacy auth routes, API client, and middleware removed
+  - All routes now require RBAC authentication only
+
+### Security
+
+- **Strengthened Authentication**: Removal of legacy auth paths reduces attack surface
+- **RBAC Enforcement**: All routes now strictly require RBAC authentication
+
+### Code Quality
+
+- **Console Logging**: All debug console.log statements in ClickHouseUsers component are now wrapped in `process.env.NODE_ENV === 'development'` checks
+- **Code Review**: All changes reviewed against `.rules/CODE_CHANGES.md` and `.rules/CODE_REVIEWER.md`
+
+## [v2.6.1] - 2026-01-16
+
+### Security
+
+#### Critical Security Fixes
+- **SQL Injection Vulnerabilities (Issue #27)**: Fixed multiple SQL injection vulnerabilities across the codebase
+  - Added SQL identifier validation and escaping utilities (`validateIdentifier`, `escapeIdentifier`, `escapeQualifiedIdentifier`)
+  - Implemented column type validation against whitelist
+  - Fixed SQL injection in file upload, database/table routes, ALTER TABLE operations, and query hooks
+  - All user-provided identifiers (database, table, column names) are now validated and properly escaped before use in SQL queries
+
+- **XSS Vulnerabilities (Issue #28)**: Fixed cross-site scripting vulnerabilities
+  - Integrated DOMPurify for HTML sanitization across all components using `dangerouslySetInnerHTML`
+  - Fixed XSS in `AgTable`, `SqlTab`, `ManualCreationForm`, and `ConfirmationDialog` components
+  - Added security warnings about localStorage token storage risks
+  - All HTML content is now sanitized before rendering to prevent script injection
+
+- **Weak Encryption and Environment Validation (Issue #29)**: Strengthened encryption and added production validation
+  - Replaced weak `scryptSync` with proper PBKDF2 key derivation (100,000 iterations)
+  - Removed hardcoded salt - now requires `RBAC_ENCRYPTION_SALT` environment variable in production
+  - Removed default JWT secret - now requires `JWT_SECRET` (minimum 32 characters) in production
+  - Added startup validation that fails fast if required environment variables are missing
+  - Fixed silent decryption failures to throw errors instead of logging and returning null
+
+### Changed
+
+#### Breaking Changes
+- **Production Environment Variables**: The following environment variables are now **required** in production:
+  - `JWT_SECRET` (minimum 32 characters, recommended 64+)
+  - `RBAC_ENCRYPTION_KEY` (minimum 32 characters, recommended 64 hex characters)
+  - `RBAC_ENCRYPTION_SALT` (exactly 64 hex characters)
+  - Server will **fail to start** in production if these are not set, preventing deployment with weak defaults
+
+#### Migration Notes
+- Existing encrypted passwords may need to be re-encrypted if the encryption key changes
+- All SQL identifiers are now validated and escaped, which may reject previously accepted invalid names
+- HTML content is now sanitized, which may affect custom formatting in some edge cases
+
+## [v2.6.0] - 2026-01-16
+
+### Added
+
+#### Saved Queries Migration to RBAC Database
+- **RBAC-Based Storage**: Migrated saved queries from ClickHouse to RBAC metadata database (`rbac_saved_queries` table). Queries are now properly scoped by user with optional connection association.
+- **Shareable Queries**: Saved queries can now be shared across connections. When `connectionId` is null, queries are accessible from any connection.
+- **Connection Filter**: Added connection filter dropdown to Explorer page for filtering Saved Queries, Pinned items, and Recent items by connection.
+- **Connection Names API**: New `/saved-queries/connections` endpoint to fetch unique connection names for filter dropdown.
+
+#### Auto-Save Functionality
+- **Real-Time Sync**: Saved queries now auto-save 2 seconds after user stops typing, similar to Google Docs.
+- **Visual Status Indicators**: New status badges showing `Saving...`, `Saved`, `Unsaved`, and `Synced` states in the SQL editor.
+- **Immediate Save**: Press `⌘S` to save immediately without waiting for auto-save delay.
+
+#### Save As Functionality
+- **Save As New Query**: Duplicate saved queries with "Save As..." option (`⇧⌘S` shortcut).
+- **Duplicate Name Detection**: Warning shown when query name already exists.
+- **Rename & Save**: Update query name through dedicated menu option.
+
+#### Explorer Page Redesign
+- **Tab-Based Navigation**: Replaced collapsible sections with clean tab navigation (Databases, Pinned, Recent, Queries).
+- **Unified Search**: Context-aware search for each tab (databases/tables and saved queries).
+- **Connection-Aware Filtering**: Filter Pinned, Recent, and Saved Queries by connection (current, all, or specific).
+- **Polished Empty States**: Contextual empty states with helpful descriptions for each tab.
+- **Animated Transitions**: Smooth tab transitions with Framer Motion.
+
+### Changed
+
+#### Database Schema
+- **Saved Queries Table**: New `rbac_saved_queries` table with `userId`, `connectionId`, `connectionName`, `name`, `query`, `description`, `isPublic`, `createdAt`, `updatedAt` columns.
+- **User Favorites/Recent Items**: Extended `rbac_user_favorites` and `rbac_user_recent_items` tables with `connectionId` and `connectionName` columns for connection-aware tracking.
+- **Migrations**: Added v1.4.0, v1.5.0, v1.6.0 migrations for schema changes with proper `ON DELETE SET NULL` handling.
+
+#### API Changes
+- **Saved Queries Routes**: Refactored to use RBAC database instead of ClickHouse. Removed `/status`, `/activate`, `/deactivate` endpoints.
+- **User Preferences Routes**: Extended favorites and recent items APIs to accept `connectionId` and `connectionName`.
+- **Auth Store**: Added `activeConnectionId` and `activeConnectionName` to global state for connection-aware operations.
+
+#### UI/UX Improvements
+- **Consistent Colors**: Aligned Explorer page colors with global theme using `white/5` and `white/10` opacity values.
+- **Reactive Favorites**: Pinned star now updates immediately without requiring page refresh.
+- **Non-Clickable Title**: SQL editor title is now display-only; renaming available through dropdown menu.
+- **Removed Pencil Icon**: Removed edit icon from SQL editor for cleaner interface.
+
+### Fixed
+
+- **Pinned Star Not Updating**: Fixed `TreeNode` component to subscribe directly to favorites array for reactive re-rendering.
+- **Rename and Save Not Working**: Fixed `updateSavedQuery` to properly pass name parameter and invalidate query cache.
+- **Saved Queries Not Refreshing**: Added proper React Query cache invalidation after save/update operations.
+- **Count Display Issues**: Fixed messy count badges in Explorer tabs by using proper `tabular-nums` styling.
+- **Color Inconsistency**: Removed custom gradients and aligned hover/background colors across Explorer page.
+- **Connection Filter Scope**: Filter now correctly applies only to Pinned, Recent, and Queries tabs (not Databases, which is connection-specific).
+
+### Removed
+
+- **ActivateSavedQueries Component**: Removed admin component for enabling/disabling ClickHouse-based saved queries (feature now always available via RBAC).
+- **ClickHouse Saved Queries**: Removed all ClickHouse-specific saved queries logic from `ClickHouseService`.
+- **Legacy Status Checks**: Removed `useSavedQueriesStatus`, `useActivateSavedQueries`, `useDeactivateSavedQueries` hooks.
+
+### Security
+
+- **Ownership Validation**: Saved queries can only be updated/deleted by their owner (validated server-side).
+- **User Scoping**: Queries are properly scoped by `userId` with optional public sharing.
+
+## [v2.5.3] - 2026-01-15
+
+### Fixed
+
+- **Metrics Page Auto-Refresh**: Fixed metrics page not automatically refreshing when ClickHouse connection is switched. Metrics now automatically update when switching connections via the connection selector.
+- **SQLite RBAC Migration**: Fixed SQLite syntax error during RBAC initialization caused by reserved keyword 'table' in `rbac_user_favorites` and `rbac_user_recent_items` tables. Column names are now properly quoted in SQLite migrations.
+- **Explorer Auto-Refresh**: Fixed Explorer tab not automatically refreshing when connection changes. Explorer now listens to connection change events and automatically fetches databases and tables from the newly selected connection.
+- **Database Creation with ON CLUSTER**: Fixed database creation to properly support `ON CLUSTER` statements for distributed ClickHouse setups. Removed incorrect condition that prevented cluster creation from working.
+
+### Security
+
+- **Hono Framework**: Upgraded Hono from 4.11.3 to 4.11.4 to address security vulnerability.
+
+### Added
+
+- **Database Cluster Support**: Added cluster selection UI to database creation dialog, matching table creation functionality. Users can now create databases on distributed ClickHouse clusters through the UI.
+
+### Changed
+
+- **Database Creation API**: Updated `CreateDatabase` component to use `createDatabase` API function instead of direct query execution, ensuring proper cluster parameter handling.
+
+## [v2.5.2] - 2026-01-15
+
+### Added
+
+- **Release Announcements**: Automatic discussion announcement creation when new releases are published
+  - Extracts release notes from CHANGELOG.md
+  - Formats as announcement with installation instructions and resources
+  - Posts to Announcements discussion category automatically
+
+### Fixed
+
+- **Release Workflow**: Improved release workflow to include automatic announcement generation
+
+## [v2.5.1] - 2026-01-14
+
+### Fixed
+
+- **RBAC Migration**: Fixed syntax error in PostgreSQL `rbac_user_favorites` migration.
+- **Logs Page Refresh**: Fixed logs page verification to correctly refresh when switching connections.
+- **Connection Display**: Added connection name display in Logs page with improved matching logic and non-super-admin fallback.
+- **Audit Logs Export**: Fixed export functionality to correctly handle blob responses and download files.
+
+## [v2.5.0] - 2026-01-13
+
+### Added
+
+- **User Preferences System**: Migrated user preferences from `localStorage` to database-backed storage for cross-device persistence
+  - Explorer preferences (favorites, recent tables, panel sizes, view modes)
+  - Monaco editor settings (font size, word wrap, minimap, etc.)
+  - Logs page preferences (filters, view mode, auto-refresh, pagination)
+  - User Management preferences (page size, search, filters)
+  - New REST API endpoints (`/api/rbac/user-preferences`)
+
+### Fixed
+
+- **Session Isolation**: Fixed users seeing other users' favorites, recent tables, and unauthorized data
+- **Query Status Detection**: Fixed failed queries (`QueryStart` with exceptions, `ExceptionBeforeStart`) incorrectly showing as "running"
+- **Logs Page Stats**: Fixed inconsistent statistics by using shared processing logic for filtering, deduplication, and stats calculation
+- **Metrics Page Alignment**: Unified failed query counting logic between Logs and Metrics pages
+- **RBAC User Mapping**: Improved query log to RBAC user mapping with optimized audit log fetching and wider timestamp matching
+- **Cache Metrics Query**: Fixed `getCacheMetrics` to use `event` column instead of `metric` when querying `system.events`
+- **Top Tables Query**: Fixed "ILLEGAL_AGGREGATION" error by removing nested aggregate functions and moving size formatting to application code
+- **Connection Access Control**: Fixed basic admins seeing connections they're not assigned to
+- **Tab Persistence**: Fixed table tabs persisting after role change or logout
+
+### Changed
+
+- **Logs Page**: Added "Failed (Before Start)" filter option, enhanced status detection for all failed query types
+- **Metrics Page**: Unified failed query definition to include all exception types (`ExceptionWhileProcessing`, `ExceptionBeforeStart`, `QueryFinish`/`QueryStart` with exceptions)
+- **Explorer Sidebar**: Set minimum width to 33% to prevent messy structure when resizing
+- **Database Schema**: Added `rbac_user_preferences` table with migration support
+- **Performance**: Optimized audit log fetching and implemented debouncing for preference updates
+
+## [v2.4.1] - 2026-01-11
+
+### Changed
+- **Changelog Sync**: Updated changelog synchronization workflow
+
+## [v2.4.0] - 2026-01-11
+
+### Added
+
+#### Code Quality & Standards
+- **Agent Rules**: Created comprehensive coding rules for AI agents and contributors
+  - `.rules/CODE_CHANGES.md` - Rules for making code changes (TypeScript, React, error handling, security, performance)
+  - `.rules/CODE_REVIEWER.md` - Rules for reviewing code (checklist, common issues, approval criteria)
+- **AI Agent Guidelines**: Added section in README instructing AI agents to follow established coding rules
+
+#### Licensing & Legal
+- **Apache 2.0 License**: Added full Apache License 2.0 text in LICENSE file
+- **NOTICE File**: Created NOTICE file acknowledging original CH-UI project by Caio Ricciuti
+- **License Documentation**: Updated README with License section and Third-Party Code attribution
+- **Portfolio License**: Added license information to docs/portfolio (LICENSE file, footer attribution, package.json)
+
+#### Logs Page Enhancements
+- **Clear Filters Button**: Added clear button to reset all applied filters (search, logType, user, role)
+- **Filter Limit Fix**: Fixed limit filter inconsistency - increased fetch multiplier to 20x when filters are active (was 2x) to ensure correct number of unique queries after filtering and deduplication
+
+### Fixed
+
+#### Production-Grade Code Improvements
+
+##### Server-Side (RBAC/Server)
+- **Audit Route** (`packages/server/src/rbac/routes/audit.ts`):
+  - Fixed immutable query object handling (use `effectiveUserId` instead of mutating query)
+  - Added input validation for userId format
+  - Added error handling with try-catch around `getAuditLogs`
+  - Added missing date filtering support in `getAuditLogs` service (gte/lte operators)
+  
+- **Metrics Route** (`packages/server/src/routes/metrics.ts`):
+  - Fixed type safety: replaced `any` types with proper `Context<{ Variables: Variables }>` and `Next`
+  - Fixed service cleanup: ensure ClickHouse service is closed in `finally` block to prevent memory leaks
+  - Improved error handling with proper cleanup on errors
+  - Added `rbacConnectionId` to Variables type definition
+  
+- **Users Route** (`packages/server/src/rbac/routes/users.ts`):
+  - Added input validation for user ID format
+  - Added error handling with try-catch around `getUserById`
+  
+- **Query Route** (`packages/server/src/routes/query.ts`):
+  - Improved error message formatting in audit log failure handling
+  
+- **RBAC Service** (`packages/server/src/rbac/services/rbac.ts`):
+  - Fixed missing date filtering: added `gte` and `lte` operators for `startDate`/`endDate` in `getAuditLogs`
+  - Improved query structure using `whereClause` for consistency
+
+##### Client-Side
+- **Logs Page** (`src/pages/Logs.tsx`):
+  - Fixed memory leak: `setTimeout` in `useEffect` now properly cleaned up
+  - Improved error handling with better error message formatting
+  - Made debug logging conditional on `NODE_ENV === 'development'`
+  
+- **InfoTab Component** (`src/features/workspace/components/infoTab/InfoTab.tsx`):
+  - Fixed memory leak: `setTimeout` for copy feedback cleaned up with `useRef` and `useEffect`
+  - Fixed missing imports: added `useRef` and `useEffect` to React imports
+  - Improved error handling with better error message extraction and type checking
+  - Added proper timeout cleanup on component unmount
+  
+- **CreateTable Component** (`src/features/explorer/components/CreateTable.tsx`):
+  - Improved error handling with better error message extraction
+  
+- **useQuery Hook** (`src/hooks/useQuery.ts`):
+  - Made debug console.logs conditional on `NODE_ENV === 'development'`
+  - Improved error handling with better error messages and fallback behavior
+
+### Changed
+
+#### Code Quality
+- **Console Logging**: Made debug console.logs conditional on development environment across codebase
+- **Error Messages**: Improved error message formatting and context throughout
+- **Type Safety**: Enhanced TypeScript type safety across server and client code
+- **Resource Cleanup**: Improved cleanup of timers, connections, and other resources
+
+#### Documentation
+- **README Updates**: 
+  - Added "For AI Agents and Contributors" section with coding rules requirements
+  - Added "License" section with Apache 2.0 information
+  - Added "Third-Party Code" section acknowledging CH-UI project
+- **Portfolio Documentation**: Updated footer and metadata with license information
+
+## [v2.3.1] - 2026-01-11
+
+### Fixed
+
+#### Build & Dependencies
+- **Docker Build**: Removed sensitive ENV variables (JWT_SECRET, RBAC_ENCRYPTION_KEY, RBAC_ADMIN_PASSWORD) from Dockerfile to follow security best practices.
+- **ESLint Configuration**: Added missing `@eslint/js` package required for ESLint 9 flat config format.
+- **Tailwind CSS**: Added missing `tailwindcss` dependency required by `@tailwindcss/vite` v4.
+- **Bun Lockfile**: Regenerated `bun.lock` with correct package name to fix build errors.
+
 ## [v2.3.0] - 2026-01-11
 
 ### Added

--- a/docs/portfolio/src/App.tsx
+++ b/docs/portfolio/src/App.tsx
@@ -1,5 +1,6 @@
 import Navbar from './components/Navbar';
 import Hero from './components/Hero';
+import WhatsNew from './components/WhatsNew';
 import Features from './components/Features';
 import ScreenshotGallery from './components/ScreenshotGallery';
 import TryLab from './components/TryLab';
@@ -16,6 +17,7 @@ function App() {
     <div className="min-h-screen bg-[#0a0a0a]">
       <Navbar />
       <Hero />
+      <WhatsNew />
       <Features />
       <ScreenshotGallery />
       <TryLab />

--- a/docs/portfolio/src/components/Features.tsx
+++ b/docs/portfolio/src/components/Features.tsx
@@ -3,6 +3,7 @@ import { motion, AnimatePresence } from "framer-motion";
 import {
   Shield, Database, BarChart3, Palette, Lock, Users, FileText, Zap, Search,
   Download, Settings, Eye, Plus, Minus, Activity, Star, Sparkles, Bot, MessageSquare,
+  Gauge, MemoryStick, Layers, Stethoscope, Network, SunMoon,
   type LucideIcon,
 } from "lucide-react";
 import { Section, Container, SectionHeader } from "./Section";
@@ -51,6 +52,20 @@ const GROUPS: FeatureGroup[] = [
     ],
   },
   {
+    category: "Monitoring & Observability",
+    icon: Gauge,
+    items: [
+      { icon: FileText, title: "Query Logs", desc: "Five rollups: every execution, by pattern, by table, by Redash query_id, and a duration/memory histogram" },
+      { icon: MemoryStick, title: "Memory Breakdown", desc: "Server RSS attributed to queries, caches, merges, primary keys — vs total RAM" },
+      { icon: BarChart3, title: "Top Resource Queries", desc: "Heaviest queries by memory and CPU, straight from system.query_log" },
+      { icon: Activity, title: "Live Queries", desc: "Running queries with CPU time + thread count, sortable, with kill support" },
+      { icon: Network, title: "Cluster Activity", desc: "Mutations, replication queue, per-replica lag, blocked-task indicators" },
+      { icon: Layers, title: "Parts & Merges", desc: "system.part_log timeline of merges, mutations, downloads, removals" },
+      { icon: Stethoscope, title: "Schema Doctor", desc: "Nullable + oversized-integer lints ranked by on-disk bytes" },
+      { icon: Zap, title: "Latency Percentiles", desc: "p50 / p95 / p99 on the query histogram, no exporter required" },
+    ],
+  },
+  {
     category: "Query & Analytics",
     icon: BarChart3,
     items: [
@@ -65,10 +80,10 @@ const GROUPS: FeatureGroup[] = [
     category: "User Experience",
     icon: Palette,
     items: [
+      { icon: SunMoon, title: "Light + Dark + Auto", desc: "Warm-stone light theme, editorial dark, and an Auto mode that switches by local time of day" },
       { icon: Star, title: "Favorites & Recent", desc: "Pin databases and tables for instant access" },
-      { icon: Settings, title: "Responsive", desc: "Desktop and tablet, with draggable modals" },
-      { icon: Zap, title: "Keyboard Shortcuts", desc: "Power-user shortcuts across the workspace" },
-      { icon: Palette, title: "Dark Theme", desc: "Editorial dark UI tuned for long sessions" },
+      { icon: Settings, title: "Responsive", desc: "Container-query layouts adapt per component, not just per viewport" },
+      { icon: Zap, title: "Keyboard Shortcuts", desc: "Power-user shortcuts + ⌘K command palette" },
     ],
   },
 ];
@@ -83,7 +98,7 @@ export default function Features() {
           eyebrow="What's inside"
           eyebrowIndex={2}
           title="Everything you need to give ClickHouse to a team."
-          description="Five domains, one consistent UI. Click a category to expand its items."
+          description="Six domains, one consistent UI. Click a category to expand its items."
         />
 
         <div className="mt-16 grid grid-cols-12 gap-x-6 gap-y-4">

--- a/docs/portfolio/src/components/Hero.tsx
+++ b/docs/portfolio/src/components/Hero.tsx
@@ -16,7 +16,7 @@ const BOOT_LOG = [
   { kind: "muted", text: "" },
   { kind: "muted", text: "[RBAC] Initializing RBAC system…" },
   { kind: "muted", text: "[RBAC] Database type: sqlite" },
-  { kind: "muted", text: "[RBAC] App version: 2.15.0" },
+  { kind: "muted", text: "[RBAC] App version: 2.15.1" },
   { kind: "muted", text: "[RBAC] Running migration: 1.17.1" },
   { kind: "accent", text: "[RBAC] system ready" },
   { kind: "muted", text: "" },

--- a/docs/portfolio/src/components/Hero.tsx
+++ b/docs/portfolio/src/components/Hero.tsx
@@ -16,7 +16,7 @@ const BOOT_LOG = [
   { kind: "muted", text: "" },
   { kind: "muted", text: "[RBAC] Initializing RBAC system…" },
   { kind: "muted", text: "[RBAC] Database type: sqlite" },
-  { kind: "muted", text: "[RBAC] App version: 2.12.9" },
+  { kind: "muted", text: "[RBAC] App version: 2.15.0" },
   { kind: "muted", text: "[RBAC] Running migration: 1.17.1" },
   { kind: "accent", text: "[RBAC] system ready" },
   { kind: "muted", text: "" },
@@ -107,8 +107,9 @@ export default function Hero() {
             >
               Open-source web interface for ClickHouse with{" "}
               <span className="text-paper">first-class RBAC</span>, encrypted credentials,
-              audit logging, and a SQL workspace that does not pretend the database is
-              a toy.
+              audit logging, a SQL workspace, and{" "}
+              <span className="text-paper">ClickHouse-native monitoring</span> — that does
+              not pretend the database is a toy.
             </motion.p>
 
             {/* Actions */}

--- a/docs/portfolio/src/components/Highlights.tsx
+++ b/docs/portfolio/src/components/Highlights.tsx
@@ -30,9 +30,9 @@ const HIGHLIGHTS: Highlight[] = [
   },
   {
     icon: Activity,
-    title: "Live operations",
-    description: "Real-time query monitoring, system metrics dashboard, comprehensive audit logs.",
-    meta: "Always on",
+    title: "Deep observability",
+    description: "ClickHouse-native monitoring — query logs, memory breakdown, top-resource queries, replica lag, schema lints. No exporter to install.",
+    meta: "No exporter",
   },
 ];
 

--- a/docs/portfolio/src/components/WhatsNew.tsx
+++ b/docs/portfolio/src/components/WhatsNew.tsx
@@ -1,0 +1,109 @@
+import { motion } from "framer-motion";
+import { SunMoon, Gauge, FileSearch, ArrowUpRight, type LucideIcon } from "lucide-react";
+import { Section, Container } from "./Section";
+
+/**
+ * Release-highlight strip for the most recent version. Deliberately NOT part
+ * of the numbered section sequence — it reads as a callout banner, marked by
+ * the version tag instead of an "0N" index. Update RELEASE + ITEMS each time
+ * a release ships a few headline features worth surfacing above the fold.
+ */
+
+const RELEASE = "v2.15.0";
+
+interface NewItem {
+  icon: LucideIcon;
+  title: string;
+  desc: string;
+}
+
+const ITEMS: NewItem[] = [
+  {
+    icon: SunMoon,
+    title: "Light + dark, auto by time",
+    desc: "Full light theme on a warm-stone palette, plus an Auto mode that follows your local clock. Every chart, table, and pill is theme-aware.",
+  },
+  {
+    icon: Gauge,
+    title: "Monitoring deep-dive",
+    desc: "Server memory breakdown, top memory/CPU queries, blocked-task indicators, per-replica lag, and p50/p95/p99 latency — no exporter required.",
+  },
+  {
+    icon: FileSearch,
+    title: "By Redash rollup",
+    desc: "Group every query by the Redash query_id in its SQL comment, so cluster load maps straight back to the saved dashboard that caused it.",
+  },
+];
+
+const EASE = [0.16, 1, 0.3, 1] as const;
+
+export default function WhatsNew() {
+  return (
+    <Section id="whats-new" aria-label="What's new" dense>
+      <Container>
+        {/* Header row — version tag instead of a numbered eyebrow */}
+        <motion.div
+          initial={{ opacity: 0, y: 10 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={{ once: true, margin: "-80px" }}
+          transition={{ duration: 0.5, ease: EASE }}
+          className="flex flex-col gap-5 md:flex-row md:items-end md:justify-between"
+        >
+          <div className="flex flex-col gap-4">
+            <span className="label-mono inline-flex items-center gap-3">
+              <span className="inline-flex items-center gap-1.5 rounded-xs border border-accent/40 px-2 py-0.5 text-accent">
+                <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-accent" aria-hidden />
+                {RELEASE}
+              </span>
+              <span className="h-px w-6 bg-ink-700" aria-hidden />
+              <span>Latest release</span>
+            </span>
+            <h2 className="text-display-lg font-semibold text-paper text-balance">
+              What shipped recently.
+            </h2>
+          </div>
+
+          <a
+            href="#changelog"
+            className="group inline-flex items-center gap-2 self-start rounded-xs border border-ink-500 px-3 py-1.5 font-mono text-[11px] uppercase tracking-[0.14em] text-paper-muted transition-colors hover:border-ink-700 hover:text-paper md:self-auto"
+          >
+            Full changelog
+            <ArrowUpRight className="h-3.5 w-3.5 transition-transform group-hover:translate-x-0.5 group-hover:-translate-y-0.5" />
+          </a>
+        </motion.div>
+
+        {/* Cards — stagger in on scroll */}
+        <div className="mt-12 grid grid-cols-1 gap-px overflow-hidden rounded-md border border-ink-500 bg-ink-500 md:grid-cols-3">
+          {ITEMS.map((item, idx) => {
+            const Icon = item.icon;
+            return (
+              <motion.div
+                key={item.title}
+                initial={{ opacity: 0, y: 16 }}
+                whileInView={{ opacity: 1, y: 0 }}
+                viewport={{ once: true, margin: "-60px" }}
+                transition={{ duration: 0.55, delay: 0.08 + idx * 0.1, ease: EASE }}
+                className="group flex flex-col gap-4 bg-ink-100 p-6 transition-colors hover:bg-ink-200 md:p-8"
+              >
+                <div className="flex items-center justify-between">
+                  <span className="grid h-10 w-10 place-items-center rounded-xs border border-ink-500 bg-ink-200 text-paper transition-colors group-hover:border-accent group-hover:text-accent">
+                    <Icon className="h-4 w-4" aria-hidden />
+                  </span>
+                  <span className="font-mono text-[10px] uppercase tracking-[0.18em] text-accent">
+                    New
+                  </span>
+                </div>
+                <div className="flex flex-col gap-2">
+                  <h3 className="text-[17px] font-semibold leading-tight text-paper">
+                    {item.title}
+                  </h3>
+                  <p className="text-sm leading-relaxed text-paper-muted">{item.desc}</p>
+                </div>
+              </motion.div>
+            );
+          })}
+        </div>
+      </Container>
+    </Section>
+  );
+}

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "chouseui",
   "private": true,
   "author": "daun-gatal",
-  "version": "2.15.0",
+  "version": "2.15.1",
   "license": "Apache-2.0",
   "type": "module",
   "workspaces": [

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chouseui/server",
-  "version": "2.15.0",
+  "version": "2.15.1",
   "type": "module",
   "scripts": {
     "dev": "bun run --watch src/index.ts",


### PR DESCRIPTION
README was written pre-phase-3 — it listed 4 query-log sub-views (now 5, added By Redash), capped Metrics at the old 7-tab layout, called light theme "on the roadmap", and the Monitoring section pre-dated the memory breakdown / top-resource-queries / blocked-task / replica-lag / latency- percentile work. Brought all of it current, added a Monitoring row to the "Why" table, and noted CH 24.11 in tested compatibility.

Landing page (docs/portfolio):
- Features: added a "Monitoring & Observability" category (8 items) and refreshed the section to "Six domains". Reworked the User Experience "Dark Theme" item into "Light + Dark + Auto", updated Responsive to mention container-query layouts.
- Highlights: "Live operations" → "Deep observability", reframed around CH-native monitoring with the no-exporter angle.
- Hero: subtitle now mentions ClickHouse-native monitoring; boot-log version bumped 2.12.9 → 2.15.0.
- Synced the stale landing CHANGELOG copy (was v2.3.0) from the root CHANGELOG so the version badge + changelog section show v2.15.0.