### PR TITLE
fix: fleet inventory, Doctor UI consistency, Appearance redesign, permissions grouping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [v2.17.2] - 2026-06-08
+
+UI consistency fixes across Fleet Doctor, Preferences, and Admin Roles.
+
+### Fixed
+
+- **Fleet inventory cards** — `formatBytes(0)` and `formatNumber(0)` returned an empty string instead of `"0 Bytes"` / `"0.00"` due to a swapped guard order; zero values now display correctly
+- **Fleet Doctor model selector** — replaced native `<select>` on the Doctor page and the Scheduled Scans dialog with a styled Radix `DropdownMenu` matching the AI chat model picker exactly (radio indicators, provider subtitle, mono font, hover effects); added `modal={false}` to prevent Radix focus-trap conflict when the dropdown is inside a dialog
+- **Fleet Doctor time filter** — replaced native `<select>` with a segmented button group (`1h · 6h · 24h · 3d`) consistent with the Fleet page's history range picker
+- **Admin → Roles permission badges** — permission badges now show the full string (e.g. `logs:view`) instead of only the action suffix; 7 missing permission prefixes (`logs`, `parts`, `schema_advisor`, `cluster`, `errors`, `fleet`, `doctor`) added to the category map, eliminating the "Other" catch-all group
+
+### Changed
+
+- **Fleet poller enabled by default** — the background snapshot poller now starts automatically without requiring `FLEET_POLLER_ENABLED=true`; set `FLEET_POLLER_ENABLED=false` to opt out (e.g. in test environments)
+- **Preferences Appearance card** — redesigned from a narrow single-column vertical list to a full-width `grid-cols-4` horizontal card layout with larger icons and centered alignment
+
 ## [v2.17.1] - 2026-06-07
 
 Documentation and developer experience overhaul. No app code changes.

--- a/packages/server/src/services/fleetPoller.ts
+++ b/packages/server/src/services/fleetPoller.ts
@@ -246,14 +246,17 @@ class FleetPoller {
   }
 
   /**
-   * Start the worker. No-op if the FLEET_POLLER_ENABLED env is not set, so
-   * importers can call this unconditionally from index.ts.
+   * Start the worker. Runs by default; set FLEET_POLLER_ENABLED=false to
+   * explicitly disable (e.g. in test environments or single-node setups that
+   * don't want background polling).
    */
   start(): void {
-    if (!envBool("FLEET_POLLER_ENABLED")) {
+    const raw = (process.env.FLEET_POLLER_ENABLED ?? "").toLowerCase();
+    const disabled = raw === "0" || raw === "false" || raw === "no" || raw === "off";
+    if (disabled) {
       logger.info(
         { module: "FleetPoller" },
-        "Fleet poller is disabled (set FLEET_POLLER_ENABLED=true to enable)",
+        "Fleet poller is disabled (FLEET_POLLER_ENABLED=false)",
       );
       return;
     }

--- a/src/features/fleet/components/DoctorScheduleDialog.tsx
+++ b/src/features/fleet/components/DoctorScheduleDialog.tsx
@@ -6,7 +6,7 @@
 
 import { useEffect, useState } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { CalendarClock, Loader2, Check } from "lucide-react";
+import { CalendarClock, Loader2, Check, ChevronDown } from "lucide-react";
 import { toast } from "sonner";
 
 import {
@@ -17,6 +17,12 @@ import {
   DialogDescription,
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { cn } from "@/lib/utils";
 import { useFleetConnections } from "@/hooks/useFleetMetrics";
 import {
@@ -312,20 +318,66 @@ export default function DoctorScheduleDialog({
                   </div>
                 </div>
                 {models.length > 1 && (
-                  <label className="flex flex-col gap-1">
+                  <div className="flex flex-col gap-1">
                     <span className={labelCls}>Model</span>
-                    <select
-                      value={resolvedModelId ?? ""}
-                      onChange={(e) => setModelId(e.target.value)}
-                      className={selectCls}
-                    >
-                      {models.map((m) => (
-                        <option key={m.id} value={m.id}>
-                          {m.label} · {m.model}
-                        </option>
-                      ))}
-                    </select>
-                  </label>
+                    <DropdownMenu modal={false}>
+                      <DropdownMenuTrigger asChild>
+                        <button
+                          type="button"
+                          className="inline-flex items-center gap-2 rounded-xs border border-ink-500 bg-ink-100 px-2 py-1 font-mono text-[11px] text-paper transition-colors hover:border-ink-700 hover:bg-ink-300 max-w-[180px]"
+                        >
+                          <span className="truncate">
+                            {models.find((m) => m.id === resolvedModelId)?.label ?? "Select model"}
+                          </span>
+                          <ChevronDown className="h-3 w-3 shrink-0 text-paper-dim" aria-hidden />
+                        </button>
+                      </DropdownMenuTrigger>
+                      <DropdownMenuContent align="end" className="w-[240px] rounded-md border-ink-500 bg-ink-100 p-0">
+                        <div className="border-b border-ink-500 px-3 py-2 font-mono text-[10px] uppercase tracking-[0.18em] text-paper-faint">
+                          AI Models
+                        </div>
+                        <div className="flex max-h-[280px] flex-col gap-0.5 overflow-y-auto p-1">
+                          {models.map((m) => {
+                            const isCurrent = resolvedModelId === m.id;
+                            return (
+                              <DropdownMenuItem
+                                key={m.id}
+                                onClick={() => setModelId(m.id)}
+                                className={cn(
+                                  "flex cursor-pointer items-start gap-2.5 rounded-xs px-3 py-2 transition-colors hover:bg-ink-200",
+                                  isCurrent && "bg-ink-200",
+                                )}
+                              >
+                                <div className="mt-0.5 flex-shrink-0">
+                                  <div
+                                    className={cn(
+                                      "grid h-3.5 w-3.5 place-items-center rounded-full border",
+                                      isCurrent ? "border-brand" : "border-ink-700",
+                                    )}
+                                  >
+                                    {isCurrent && <div className="h-1.5 w-1.5 rounded-full bg-brand" />}
+                                  </div>
+                                </div>
+                                <div className="flex min-w-0 flex-col gap-0.5">
+                                  <span
+                                    className={cn(
+                                      "truncate text-[13px] font-medium",
+                                      isCurrent ? "text-paper" : "text-paper-muted",
+                                    )}
+                                  >
+                                    {m.label}
+                                  </span>
+                                  <span className="truncate font-mono text-[10px] uppercase tracking-[0.14em] text-paper-faint">
+                                    {m.provider || m.model}
+                                  </span>
+                                </div>
+                              </DropdownMenuItem>
+                            );
+                          })}
+                        </div>
+                      </DropdownMenuContent>
+                    </DropdownMenu>
+                  </div>
                 )}
               </div>
 

--- a/src/features/rbac/components/RbacRolesTable.tsx
+++ b/src/features/rbac/components/RbacRolesTable.tsx
@@ -95,6 +95,13 @@ const PERMISSION_CATEGORIES: Record<string, string> = {
   'query': 'Query',
   'saved_queries': 'Saved Queries',
   'metrics': 'Metrics',
+  'logs': 'Monitoring',
+  'parts': 'Monitoring',
+  'schema_advisor': 'Monitoring',
+  'cluster': 'Monitoring',
+  'errors': 'Monitoring',
+  'fleet': 'Fleet Management',
+  'doctor': 'Fleet Doctor',
   'settings': 'Settings',
   'audit': 'Audit',
   'live_queries': 'Live Queries',
@@ -381,7 +388,7 @@ export const RbacRolesTable: React.FC<RbacRolesTableProps> = ({
                                       key={perm}
                                       className="inline-flex items-center rounded-xs border border-ink-500 bg-ink-200 px-2 py-0.5 font-mono text-[11px] text-paper-muted transition-colors hover:border-ink-700 hover:text-paper"
                                     >
-                                      {perm.split(':').slice(1).join(':')}
+                                      {perm}
                                     </span>
                                   ))}
                                 </div>

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -34,8 +34,11 @@ describe('lib/utils', () => {
       expect(formatBytes(1536)).toBe('1.5 KB');
     });
 
-    it('should handle falsy values', () => {
-      expect(formatBytes(0)).toBe('');
+    it('should handle zero bytes', () => {
+      expect(formatBytes(0)).toBe('0 Bytes');
+    });
+
+    it('should handle falsy non-zero values', () => {
       expect(formatBytes(null as any)).toBe('');
     });
   });
@@ -61,8 +64,11 @@ describe('lib/utils', () => {
       expect(formatNumber(1000)).toBe('1,000.00');
     });
 
-    it('should handle falsy values', () => {
-      expect(formatNumber(0)).toBe('');
+    it('should handle zero', () => {
+      expect(formatNumber(0)).toBe('0.00');
+    });
+
+    it('should handle falsy non-zero values', () => {
       expect(formatNumber(null as any)).toBe('');
     });
   });

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -6,8 +6,8 @@ export function cn(...inputs: ClassValue[]) {
 }
 
 export function formatBytes(bytes: number) {
-  if (!bytes) return "";
   if (bytes === 0) return "0 Bytes";
+  if (!bytes) return "";
   const k = 1024;
   const sizes = ["Bytes", "KB", "MB", "GB", "TB"];
   const i = Math.floor(Math.log(bytes) / Math.log(k));
@@ -24,6 +24,7 @@ export function formatDate(date: Date, format: string) {
 }
 
 export function formatNumber(number: number) {
+  if (number === 0) return "0.00";
   if (!number) return "";
   return number.toLocaleString("en-US", {
     minimumFractionDigits: 2,

--- a/src/pages/Doctor.tsx
+++ b/src/pages/Doctor.tsx
@@ -16,6 +16,12 @@ import { toast } from "sonner";
 
 import { Button } from "@/components/ui/button";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { cn } from "@/lib/utils";
 import { useFleetConnections } from "@/hooks/useFleetMetrics";
 import {
@@ -73,7 +79,14 @@ function InvestigatingPanel({ model }: { model?: string }) {
   );
 }
 
-/** Investigation window (lookback) selector. */
+const WINDOW_OPTIONS = [
+  { label: "1h", hours: 1 },
+  { label: "6h", hours: 6 },
+  { label: "24h", hours: 24 },
+  { label: "3d", hours: 72 },
+];
+
+/** Investigation window (lookback) selector — segmented button group. */
 function WindowSelect({
   hours,
   onChange,
@@ -84,18 +97,37 @@ function WindowSelect({
   disabled?: boolean;
 }) {
   return (
-    <select
-      value={hours}
-      onChange={(e) => onChange(Number(e.target.value))}
-      disabled={disabled}
-      title="Investigation window (how far back to look)"
-      className="h-9 rounded-xs border border-ink-500 bg-ink-200 px-2 text-[11px] text-paper focus:border-brand focus:outline-none disabled:opacity-50"
+    <div
+      className="inline-flex overflow-hidden rounded-xs border border-ink-500"
+      role="radiogroup"
+      aria-label="Investigation window"
+      title="How far back to look"
     >
-      <option value={1}>Last 1h</option>
-      <option value={6}>Last 6h</option>
-      <option value={24}>Last 24h</option>
-      <option value={72}>Last 3d</option>
-    </select>
+      {WINDOW_OPTIONS.map((opt, idx) => {
+        const selected = hours === opt.hours;
+        return (
+          <button
+            key={opt.hours}
+            type="button"
+            role="radio"
+            aria-checked={selected}
+            disabled={disabled}
+            onClick={() => onChange(opt.hours)}
+            className={cn(
+              "h-9 px-3 font-mono text-[10px] uppercase tracking-[0.14em] transition-colors",
+              "focus:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-inset",
+              "disabled:opacity-50",
+              idx > 0 && "border-l border-ink-500",
+              selected
+                ? "bg-brand text-ink-50"
+                : "bg-ink-100 text-paper-muted hover:bg-ink-200 hover:text-paper",
+            )}
+          >
+            {opt.label}
+          </button>
+        );
+      })}
+    </div>
   );
 }
 
@@ -393,20 +425,60 @@ export default function Doctor() {
                 <CalendarClock className="h-4 w-4" aria-hidden />
               </button>
               {showPicker && (
-                <select
-                  value={resolvedModelId ?? ""}
-                  onChange={(e) => setSelectedModelId(e.target.value)}
-                  disabled={scan.isPending}
-                  className="h-9 max-w-[200px] rounded-xs border border-ink-500 bg-ink-200 px-2 text-[11px] text-paper focus:border-brand focus:outline-none disabled:opacity-50"
-                  title="Model for the next scan"
-                >
-                  {models.map((m) => (
-                    <option key={m.id} value={m.id}>
-                      {m.label} · {m.model}
-                      {m.isDefault ? " (default)" : ""}
-                    </option>
-                  ))}
-                </select>
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <button
+                      type="button"
+                      disabled={scan.isPending}
+                      className="inline-flex items-center gap-2 rounded-xs border border-ink-500 bg-ink-100 px-2 py-1 font-mono text-[11px] text-paper transition-colors hover:border-ink-700 hover:bg-ink-300 max-w-[180px] disabled:opacity-50"
+                    >
+                      <span className="truncate">
+                        {models.find((m) => m.id === resolvedModelId)?.label ?? "Select model"}
+                      </span>
+                      <ChevronDown className="h-3 w-3 shrink-0 text-paper-dim" aria-hidden />
+                    </button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent align="end" className="w-[240px] rounded-md border-ink-500 bg-ink-100 p-0">
+                    <div className="border-b border-ink-500 px-3 py-2 font-mono text-[10px] uppercase tracking-[0.18em] text-paper-faint">
+                      AI Models
+                    </div>
+                    <div className="flex max-h-[280px] flex-col gap-0.5 overflow-y-auto p-1">
+                      {models.map((m) => {
+                        const isCurrent = resolvedModelId === m.id;
+                        return (
+                          <DropdownMenuItem
+                            key={m.id}
+                            onClick={() => setSelectedModelId(m.id)}
+                            className={cn(
+                              "flex cursor-pointer items-start gap-2.5 rounded-xs px-3 py-2 transition-colors hover:bg-ink-200",
+                              isCurrent && "bg-ink-200",
+                            )}
+                          >
+                            <div className="mt-0.5 flex-shrink-0">
+                              <div className={cn(
+                                "grid h-3.5 w-3.5 place-items-center rounded-full border",
+                                isCurrent ? "border-brand" : "border-ink-700",
+                              )}>
+                                {isCurrent && <div className="h-1.5 w-1.5 rounded-full bg-brand" />}
+                              </div>
+                            </div>
+                            <div className="flex min-w-0 flex-col gap-0.5">
+                              <span className={cn(
+                                "truncate text-[13px] font-medium",
+                                isCurrent ? "text-paper" : "text-paper-muted",
+                              )}>
+                                {m.label}
+                              </span>
+                              <span className="truncate font-mono text-[10px] uppercase tracking-[0.14em] text-paper-faint">
+                                {m.provider || m.model}
+                              </span>
+                            </div>
+                          </DropdownMenuItem>
+                        );
+                      })}
+                    </div>
+                  </DropdownMenuContent>
+                </DropdownMenu>
               )}
               <Button
                 onClick={startScan}

--- a/src/pages/Preferences.tsx
+++ b/src/pages/Preferences.tsx
@@ -146,52 +146,52 @@ const AppearanceCard: React.FC = () => {
       description="How the interface looks for you"
       icon={Palette}
       delay={0.25}
-      className="md:col-span-1"
+      className="md:col-span-3"
     >
-      <div className="flex flex-col gap-2">
-        {THEME_OPTIONS.map((opt) => {
-          const active = theme === opt.id;
-          const Icon = opt.icon;
-          return (
-            <button
-              key={opt.id}
-              type="button"
-              onClick={() => setTheme(opt.id)}
-              aria-pressed={active}
-              className={cn(
-                "group flex w-full items-center justify-between gap-3 rounded-xs border bg-ink-200 px-3 py-2.5 text-left transition-colors",
-                active
-                  ? "border-brand"
-                  : "border-ink-500 hover:border-ink-700 hover:bg-ink-300"
-              )}
-            >
-              <div className="flex items-center gap-3">
+      <div className="flex flex-col gap-3">
+        <div className="grid grid-cols-2 gap-3 md:grid-cols-4">
+          {THEME_OPTIONS.map((opt) => {
+            const active = theme === opt.id;
+            const Icon = opt.icon;
+            return (
+              <button
+                key={opt.id}
+                type="button"
+                onClick={() => setTheme(opt.id)}
+                aria-pressed={active}
+                className={cn(
+                  "group flex flex-col items-center gap-3 rounded-xs border bg-ink-200 px-4 py-5 text-center transition-colors",
+                  active
+                    ? "border-brand"
+                    : "border-ink-500 hover:border-ink-700 hover:bg-ink-300"
+                )}
+              >
                 <span
                   className={cn(
-                    "grid h-7 w-7 place-items-center rounded-xs border transition-colors",
+                    "grid h-10 w-10 place-items-center rounded-xs border transition-colors",
                     active
                       ? "border-brand bg-ink-100 text-brand"
                       : "border-ink-500 bg-ink-100 text-paper-muted"
                   )}
                 >
-                  <Icon className="h-3.5 w-3.5" aria-hidden />
+                  <Icon className="h-5 w-5" aria-hidden />
                 </span>
-                <div className="flex flex-col gap-0.5">
+                <div className="flex flex-col gap-1">
                   <span className="text-[13px] font-medium text-paper">{opt.label}</span>
-                  <span className={MONO_FAINT}>{opt.hint}</span>
+                  <span className={cn(MONO_FAINT, "text-[10px]")}>{opt.hint}</span>
                 </div>
-              </div>
-              {active && (
-                <span
-                  className="rounded-xs border border-brand/40 bg-brand/[0.08] px-1.5 py-0.5 font-mono text-[9px] uppercase tracking-[0.16em] text-brand"
-                  aria-hidden
-                >
-                  Active
-                </span>
-              )}
-            </button>
-          );
-        })}
+                {active && (
+                  <span
+                    className="rounded-xs border border-brand/40 bg-brand/[0.08] px-1.5 py-0.5 font-mono text-[9px] uppercase tracking-[0.16em] text-brand"
+                    aria-hidden
+                  >
+                    Active
+                  </span>
+                )}
+              </button>
+            );
+          })}
+        </div>
         <StatusFooter
           label="Now rendering"
           meta={resolvedTheme === "dark" ? "Dark" : "Light"}


### PR DESCRIPTION
## Summary

- **Fleet poller on by default** — no longer requires `FLEET_POLLER_ENABLED=true`; opt out with `=false` instead
- **Fleet inventory cards** — fix `formatBytes`/`formatNumber` returning blank for zero values (`0` now renders as `"0 Bytes"` / `"0.00"`)
- **Fleet Doctor model dropdown** — replaced native `<select>` on both the Doctor page and `DoctorScheduleDialog` with a Radix `DropdownMenu` matching the AI chat model selector exactly (radio indicators, provider subtitle, hover effects, `bg-ink-100`, `font-mono text-[11px]`)
- **Fleet Doctor time filter** — replaced native `<select>` with a segmented button group (`1h · 6h · 24h · 3d`) consistent with the Fleet page's `HistoryRangePicker`
- **Preferences Appearance card** — expanded from `col-span-1` to `col-span-3` (full width), switched vertical list to `grid-cols-4` horizontal card layout with larger icons (`h-10 w-10`)
- **Admin → Roles permission badges** — now display full permission strings (e.g. `logs:view`) instead of stripped suffixes; added missing prefixes (`logs`, `parts`, `schema_advisor`, `cluster`, `errors`, `fleet`, `doctor`) to eliminate the "Other" catch-all group

## Test plan

- [ ] Navigate to `/fleet` — inventory cards (Databases, Tables, Views, Total Rows, Storage) populate within ~30s without setting any env var
- [ ] Navigate to `/doctor` — model dropdown matches AI chat style; time filter shows `1h · 6h · 24h · 3d` pill buttons
- [ ] Open the Scheduled Scans dialog in Fleet Doctor — model dropdown (when >1 model configured) matches AI chat style and opens correctly inside the dialog
- [ ] Navigate to Preferences — Appearance section spans full width with 4 theme cards side by side
- [ ] Navigate to Admin → Roles — expand any role; no "Other" group, all permissions show full `prefix:action` strings in correct categories
- [ ] Verify `formatBytes(0)` returns `"0 Bytes"` (run `bunx vitest run`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)