### PR TITLE
fix: fleet inventory counts all databases including system ones (v2.17.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [v2.17.3] - 2026-06-08
+
+### Changed
+
+- **Fleet inventory counts all databases** — `schema_totals` query no longer excludes `system`, `INFORMATION_SCHEMA`, and `information_schema` databases; counts now align with what ClickHouse reports on the home page and metrics views
+
 ## [v2.17.2] - 2026-06-08
 
 UI consistency fixes across Fleet Doctor, Preferences, and Admin Roles.

--- a/docs/portfolio/package.json
+++ b/docs/portfolio/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chouseui-portfolio",
   "private": true,
-  "version": "2.12.9",
+  "version": "2.17.3",
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "chouseui",
   "private": true,
   "author": "daun-gatal",
-  "version": "2.17.0",
+  "version": "2.17.3",
   "license": "Apache-2.0",
   "type": "module",
   "workspaces": [

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chouseui/server",
-  "version": "2.17.0",
+  "version": "2.17.3",
   "type": "module",
   "scripts": {
     "dev": "bun run --watch src/index.ts",

--- a/packages/server/src/services/fleetMetrics.ts
+++ b/packages/server/src/services/fleetMetrics.ts
@@ -88,12 +88,13 @@ export const FLEET_METRICS = {
   `,
 
   /**
-   * One-row schema census for the node: how many user databases, tables,
-   * views, and rows it holds. Views = engine containing "View" (View +
-   * MaterializedView); everything else counts as a table. Single full
-   * aggregate over system.tables (metadata only — total_rows is a cached
-   * column, no data scan). The fleet page sums these across nodes for an
-   * at-a-glance "what's in my fleet" strip.
+   * One-row schema census for the node: how many databases, tables,
+   * views, and rows it holds (all databases, including system ones).
+   * Views = engine containing "View" (View + MaterializedView); everything
+   * else counts as a table. Single full aggregate over system.tables
+   * (metadata only — total_rows is a cached column, no data scan).
+   * The fleet page sums these across nodes for an at-a-glance
+   * "what's in my fleet" strip.
    */
   schema_totals: `
     SELECT
@@ -103,7 +104,6 @@ export const FLEET_METRICS = {
       coalesce(sum(total_rows), 0) AS rows,
       coalesce(sum(total_bytes), 0) AS bytes
     FROM system.tables
-    WHERE database NOT IN ('system', 'INFORMATION_SCHEMA', 'information_schema')
   `,
 
   /**


### PR DESCRIPTION
## Description

Fleet inventory cards (Databases, Tables, Views, Total Rows, Storage) were only counting user-created objects because the `schema_totals` query explicitly excluded `system`, `INFORMATION_SCHEMA`, and `information_schema` databases. This caused the numbers to differ from what ClickHouse shows on the home page and metrics views.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issue

Closes #

## Changes Made

- **`packages/server/src/services/fleetMetrics.ts`** — Removed `WHERE database NOT IN ('system', 'INFORMATION_SCHEMA', 'information_schema')` from the `schema_totals` SQL query so all databases are counted
- **`CHANGELOG.md`** — Added `v2.17.3` entry
- **`package.json`** / **`packages/server/package.json`** — Bumped version from `2.17.0` → `2.17.3`

## Testing

- [x] I have tested this locally
- [ ] I have added/updated tests
- [x] All existing tests pass

### Test Steps

1. Register one or more ClickHouse connections
2. Start the server — the fleet poller runs automatically on boot
3. Navigate to the Fleet page
4. Verify the **Databases**, **Tables**, **Views**, **Total Rows**, and **Storage** cards match the total counts reported by ClickHouse (including system databases)

## Screenshots

N/A — backend-only query change; no UI changes

## Checklist

- [x] My code follows the project's code style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly (if applicable)
- [x] My changes generate no new warnings or errors
- [x] I have checked for breaking changes and documented them (if applicable)
- [x] I have tested the changes in the relevant environment (development/production)

## Additional Notes

The `schema_totals` query reads from `system.tables` (a metadata-only table — no data scan). Removing the filter is safe and performant. The `system` database itself typically contains 100+ internal ClickHouse tables, so fleet counts will appear higher than before — this is the correct, expected behavior.