### PR TITLE
docs: add PR creation and versioning rules to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,6 +106,19 @@ bunx vitest run                # Frontend tests
 - Comments explain *why*, not *what* — no commented-out code
 - JSDoc only for complex functions
 
+## Pull Request Creation
+
+When creating a PR via `gh pr create`, always read `.github/pull_request_template.md` and use its structure as the `--body` content, filling in each section based on the actual changes. Never write a free-form body that skips the template sections.
+
+## Versioning & Releases
+
+When adding a new version entry to `CHANGELOG.md` (e.g. `## [2.18.0] - 2026-06-08`), always bump the `version` field to match in all three:
+- `package.json` (root)
+- `packages/server/package.json`
+- `docs/portfolio/package.json`
+
+All three must stay in sync with the CHANGELOG version at all times.
+
 ## When to Apply Each Rule
 
 | Situation | Rule file to follow |


### PR DESCRIPTION
## Description

Adds two new sections to `CLAUDE.md` to codify conventions that should be followed by AI agents working on this repo.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Other (please describe):

## Related Issue

Closes #

## Changes Made

- **Pull Request Creation** — agents must read `.github/pull_request_template.md` and use its structure as the `--body` when running `gh pr create`. Prevents free-form PR bodies that skip required template sections.
- **Versioning & Releases** — whenever a new CHANGELOG version entry is added, the `version` field must be bumped to match in all three `package.json` files (`root`, `packages/server/`, `docs/portfolio/`). Keeps versions in sync across the monorepo.

## Testing

- [ ] I have tested this locally
- [ ] I have added/updated tests
- [ ] All existing tests pass

### Test Steps

Documentation-only change — no runtime testing required.

## Screenshots

N/A

## Checklist

- [x] My code follows the project's code style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly (if applicable)
- [x] My changes generate no new warnings or errors
- [ ] I have checked for breaking changes and documented them (if applicable)
- [x] I have tested the changes in the relevant environment (development/production)

## Additional Notes

Documentation-only change to `CLAUDE.md`. No code was modified.