### PR TITLE
fix: align schema counts across Fleet, Home, and Metrics pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [v2.17.4] - 2026-06-08
+
+### Fixed
+
+- **Fleet, Home, and Metrics page schema counts are now consistent** — all three now use the same canonical logic: `(SELECT count() FROM system.databases)` for databases (catches empty databases), `countIf`/`count()` against `system.tables` for tables and views (including system databases), and `sum(total_rows)`/`sum(total_bytes)` from `system.tables` for row and byte totals. Previously each page used a different query with different inclusion rules (some excluded system databases, some used `system.parts WHERE active`), causing mismatched numbers across the UI.
+
 ## [v2.17.3] - 2026-06-08
 
 ### Changed

--- a/docs/portfolio/package.json
+++ b/docs/portfolio/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chouseui-portfolio",
   "private": true,
-  "version": "2.17.3",
+  "version": "2.17.4",
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "chouseui",
   "private": true,
   "author": "daun-gatal",
-  "version": "2.17.3",
+  "version": "2.17.4",
   "license": "Apache-2.0",
   "type": "module",
   "workspaces": [

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chouseui/server",
-  "version": "2.17.3",
+  "version": "2.17.4",
   "type": "module",
   "scripts": {
     "dev": "bun run --watch src/index.ts",

--- a/packages/server/src/services/clickhouse.ts
+++ b/packages/server/src/services/clickhouse.ts
@@ -411,8 +411,8 @@ export class ClickHouseService {
         this.client.query({ query: "SELECT version()" }),
         this.client.query({ query: "SELECT uptime()" }),
         this.client.query({ query: "SELECT count() FROM system.databases" }),
-        this.client.query({ query: "SELECT count() FROM system.tables WHERE database NOT IN ('system', 'information_schema')" }),
-        this.client.query({ query: "SELECT formatReadableSize(sum(bytes_on_disk)) as size, sum(rows) as rows FROM system.parts WHERE active" }),
+        this.client.query({ query: "SELECT count() FROM system.tables" }),
+        this.client.query({ query: "SELECT coalesce(sum(total_bytes), 0) as size, coalesce(sum(total_rows), 0) as rows FROM system.tables" }),
         this.client.query({
           query: `
             SELECT
@@ -461,7 +461,7 @@ export class ClickHouseService {
         databaseCount: Number(dbCount.data[0]?.["count()"] || 0),
         tableCount: Number(tableCount.data[0]?.["count()"] || 0),
         totalRows: Number(sizeData.data[0]?.rows || 0),
-        totalSize: sizeData.data[0]?.size || "0 B",
+        totalSize: formatSize(Number(sizeData.data[0]?.size || 0)),
         memoryUsage: formatSize(memResident),
         memoryTotal: formatSize(memTotal),
         memoryPercentage: memTotal > 0 ? (memResident / memTotal) * 100 : 0,

--- a/packages/server/src/services/fleetMetrics.ts
+++ b/packages/server/src/services/fleetMetrics.ts
@@ -89,16 +89,16 @@ export const FLEET_METRICS = {
 
   /**
    * One-row schema census for the node: how many databases, tables,
-   * views, and rows it holds (all databases, including system ones).
+   * views, rows, and bytes it holds. Uses a subquery against system.databases
+   * so empty databases (no tables yet) are still counted. All engines and
+   * databases are included — no system/information_schema exclusion — so the
+   * numbers match the Home and Metrics pages exactly.
    * Views = engine containing "View" (View + MaterializedView); everything
-   * else counts as a table. Single full aggregate over system.tables
-   * (metadata only — total_rows is a cached column, no data scan).
-   * The fleet page sums these across nodes for an at-a-glance
-   * "what's in my fleet" strip.
+   * else is a table. Metadata only — total_rows is a cached column, no scan.
    */
   schema_totals: `
     SELECT
-      count(DISTINCT database) AS databases,
+      (SELECT count() FROM system.databases) AS databases,
       countIf(engine NOT LIKE '%View%') AS tables,
       countIf(engine LIKE '%View%') AS views,
       coalesce(sum(total_rows), 0) AS rows,

--- a/src/hooks/useQuery.ts
+++ b/src/hooks/useQuery.ts
@@ -1088,10 +1088,10 @@ export function useMetrics(
             (SELECT count() FROM system.processes) as activeQueries,
             (SELECT sum(value) FROM system.metrics WHERE metric IN ('TCPConnection', 'HTTPConnection')) as connections,
             (SELECT value FROM system.asynchronous_metrics WHERE metric = 'Uptime' LIMIT 1) as uptime,
-            (SELECT sum(rows) FROM system.parts WHERE active) as totalRows,
-            (SELECT sum(bytes_on_disk) FROM system.parts WHERE active) as totalBytes,
+            (SELECT coalesce(sum(total_rows), 0) FROM system.tables) as totalRows,
+            (SELECT coalesce(sum(total_bytes), 0) FROM system.tables) as totalBytes,
             (SELECT count() FROM system.databases) as databasesCount,
-            (SELECT count() FROM system.tables WHERE database NOT IN ('system', 'information_schema')) as tablesCount,
+            (SELECT count() FROM system.tables) as tablesCount,
             (SELECT count() FROM system.parts WHERE active) as partsCount
         `);
         if (statsResult.length > 0) {


### PR DESCRIPTION
## Description

Fleet Inventory, the Home page, and the Metrics page all display database/table/view/row/byte counts, but each was using a different SQL query with different inclusion rules — causing users to see mismatched numbers across the UI (e.g. 11 databases on Home but only 8 on Fleet).

All three pages now use the same canonical counting logic:

```sql
SELECT
  (SELECT count() FROM system.databases) AS databases,
  countIf(engine NOT LIKE '%View%') AS tables,
  countIf(engine LIKE '%View%') AS views,
  coalesce(sum(total_rows), 0) AS rows,
  coalesce(sum(total_bytes), 0) AS bytes
FROM system.tables
```

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issue

Closes #

## Changes Made

### Root causes fixed

| Page | Old issue | Fix |
|------|-----------|-----|
| **Fleet** | `count(DISTINCT database) FROM system.tables` — missed empty databases. Also excluded `system`/`information_schema` from table/view counts. | Subquery against `system.databases`; removed exclusion filters. |
| **Home** | Table count excluded `system`/`information_schema`. Rows/bytes came from `system.parts WHERE active` (different source). | `count() FROM system.tables` (no filter); switched to `sum(total_rows/total_bytes) FROM system.tables`. |
| **Metrics** | Same `system.parts WHERE active` discrepancy for rows/bytes; table count excluded system dbs. | Same `system.tables` alignment as Home. |

### Files changed

- `packages/server/src/services/fleetMetrics.ts` — `schema_totals` query
- `packages/server/src/services/clickhouse.ts` — `getSystemStats()` table count + size queries; `totalSize` now uses existing `formatSize()` helper instead of ClickHouse's `formatReadableSize`
- `src/hooks/useQuery.ts` — Metrics page current-stats subqueries

## Testing

- [x] I have tested this locally

### Test Steps

1. Open Home page — note databases, tables, total rows, storage
2. Open Fleet page — Fleet Inventory strip numbers should match Home for the same connection
3. Open Metrics page — databasesCount / tablesCount / totalRows / totalBytes should match Home
4. Run `bun run typecheck` — no errors

## Checklist

- [x] My code follows the project's code style guidelines
- [x] I have performed a self-review of my code
- [x] I have updated the documentation accordingly (CHANGELOG.md, version bump to 2.17.4)
- [x] My changes generate no new warnings or errors

## Additional Notes

`system.tables.total_rows` and `total_bytes` are cached metadata columns — no data scan, same performance characteristics as the previous queries. The only subtle difference vs `system.parts WHERE active` is that `total_bytes` reflects the table-level metadata cache rather than summing individual active parts; the values are equivalent for practical purposes.