### PR TITLE
fix: increase Docker healthcheck timeout and start period

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -112,7 +112,7 @@ EXPOSE 5521
 USER ch-user
 
 # Health check - verify both API and static serving work
-HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+HEALTHCHECK --interval=30s --timeout=10s --start-period=15s --retries=3 \
     CMD wget --no-verbose --tries=1 --spider http://localhost:5521/api/health || exit 1
 
 # Start the server

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
     <img src="https://img.shields.io/github/actions/workflow/status/daun-gatal/chouse-ui/github-pages.yml?label=GitHub%20Pages" alt="GitHub Pages" />
   </a>
   <a href="https://github.com/daun-gatal/chouse-ui/actions/workflows/release.yml">
-    <img src="https://img.shields.io/github/actions/workflow/status/daun-gatal/chouse-ui/release.yml?label=Release" alt="Release" />
+    <img src="https://img.shields.io/github/actions/workflow/status/daun-gatal/chouse-ui/auto-release.yml?label=Release" alt="Release" />
   </a>
 </p>
 

--- a/changelogs/unreleased/test-healthcheck-timeout.md
+++ b/changelogs/unreleased/test-healthcheck-timeout.md
@@ -1,0 +1,4 @@
+type: patch
+
+### Fixed
+- **Docker healthcheck** — increased timeout from 5s to 10s and start period from 10s to 15s to reduce false-positive unhealthy states on slower hosts

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -279,4 +279,4 @@ export default function App() {
   );
 }
 
-// Dummy changes for rebuild at 2026-06-11 at 12.55 UTC
+// Dummy changes for rebuild at 2026-06-11 at 15.30 UTC


### PR DESCRIPTION
## Description

Increases the Docker healthcheck timeout from 5s to 10s and the start period from 10s to 15s to reduce false-positive unhealthy states on slower hosts during container startup.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issue

Closes #

## Changes Made

- `Dockerfile`: `--timeout=5s` → `--timeout=10s`, `--start-period=10s` → `--start-period=15s`

## Testing

- [x] I have tested this locally
- [x] All existing tests pass

## Changelog Fragment

- [x] Added `changelogs/unreleased/test-healthcheck-timeout.md`

## Checklist

- [x] My code follows the project's code style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors

## Additional Notes

This is a test PR to validate the release approval gate flow (assemble → review summary → approve → docker → publish + deploy-docs).