### PR TITLE
feat: auto-enable AI optimizer, server-backed preferences, fix empty query bug

### DIFF
--- a/.config.example.yaml
+++ b/.config.example.yaml
@@ -13,6 +13,8 @@
 # Core Server Settings
 # ============================================
 port: 5521
+# version is set automatically by the build; override only for custom builds
+# version: "dev"
 node_env: development
 static_path: ./dist
 cors_origin: "*"
@@ -58,6 +60,15 @@ rbac:
     password: Password1!
 
 # ============================================
+# ClickHouse Connection Defaults
+# ============================================
+# Pre-fill the connection form in the UI for faster setup.
+clickhouse:
+  default_url: ""
+  default_user: default
+  preset_urls: ""   # comma-separated list of preset URLs
+
+# ============================================
 # JWT Authentication
 # ============================================
 jwt:
@@ -68,6 +79,25 @@ jwt:
   # Token expiration times (m: minutes, h: hours, d: days)
   access_expiry: 4h
   refresh_expiry: 7d
+
+  # Optional: override issuer/audience claims
+  # issuer: chouseui
+  # audience: chouseui-client
+
+# ============================================
+# Fleet Monitoring — optional
+# ============================================
+fleet:
+  poller_enabled: false
+  poll_interval_seconds: 30
+  alert_config_file: /app/data/alert-config.json
+
+# ============================================
+# AI SRE / Doctor — optional
+# ============================================
+doctor:
+  schedule_file: /app/data/doctor-schedule.json
+  auto_rca_cooldown_minutes: 60
 
 # ============================================
 # SSO (OIDC / OAuth2) — optional
@@ -80,8 +110,8 @@ auth:
     default_role: viewer # role for JIT-provisioned users
     auto_link_by_email: true # link to existing users when IdP asserts email_verified
     providers:
-      #       okta:                                   # provider id (login URL slug)
-      #         type: oidc                            # 'oidc' = discovery via issuer/.well-known
+      #       okta:                                   # provider id used in login URL slug
+      #         type: oidc                            # 'oidc' = auto-discovers endpoints from issuer
       #         display_name: "Okta"
       #         issuer: https://corp.okta.com
       #         client_id: "..."
@@ -92,16 +122,14 @@ auth:
       #         # role_mapping_claim: groups
       #         # role_mapping: "idp-group-a:admin,idp-group-b:developer"
       google:
-        type: oauth2 # plain OAuth2: explicit endpoints + userinfo
-        # Caveat: GitHub's /user endpoint returns `email: null` for accounts
-        # with a private email, even with the user:email scope, so JIT
-        # provisioning may fail. Make an email public on GitHub, or use a
-        # provider that exposes email in its userinfo response.
-        display_name: "GitHub"
-        authorization_endpoint: https://accounts.google.com/o/oauth2/v2/auth
-        token_endpoint: https://oauth2.googleapis.com/token
-        userinfo_endpoint: https://openidconnect.googleapis.com/v1/userinfo
-        client_id: "1***v.apps.googleusercontent.com "
-        client_secret: "G****G"
-        scopes: "read:user user:email"
-        claim_mapping: "subject:id,email:email,username:login"
+        type: oidc                                      # OIDC: auto-discovers endpoints from issuer
+        display_name: "Google"
+        issuer: https://accounts.google.com
+        client_id: "${GOOGLE_CLIENT_ID}"               # set GOOGLE_CLIENT_ID in env or replace here
+        client_secret: "${GOOGLE_CLIENT_SECRET}"       # set GOOGLE_CLIENT_SECRET in env or replace here
+        scopes: "openid profile email"
+        # Optional: override auto-discovered endpoints
+        # authorization_endpoint: https://accounts.google.com/o/oauth2/v2/auth
+        # token_endpoint: https://oauth2.googleapis.com/token
+        # userinfo_endpoint: https://openidconnect.googleapis.com/v1/userinfo
+        # claim_mapping: "subject:sub,email:email,username:name"

--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,14 @@
 #   RBAC_ENCRYPTION_SALT: openssl rand -hex 32
 
 # ============================================
+# YAML Config Override (optional)
+# ============================================
+# Use a YAML file instead of (or on top of) individual env vars.
+# All env vars below can be expressed as nested YAML keys.
+# See .config.example.yaml for the equivalent structure.
+# CHOUSE_CONFIG_PATH=./.config.yaml
+
+# ============================================
 # Core Server Settings
 # ============================================
 PORT=5521
@@ -19,6 +27,16 @@ STATIC_PATH=./dist
 CORS_ORIGIN=*
 # Server log level: debug | info | warn | error (JSON logs via Pino)
 LOG_LEVEL=info
+
+# ============================================
+# ClickHouse Connection Defaults
+# ============================================
+# Pre-fill the connection form in the UI for faster setup.
+# CLICKHOUSE_DEFAULT_URL sets the default host URL.
+# CLICKHOUSE_PRESET_URLS provides a dropdown of preset URLs (comma-separated).
+CLICKHOUSE_DEFAULT_URL=
+CLICKHOUSE_DEFAULT_USER=default
+CLICKHOUSE_PRESET_URLS=
 
 # ============================================
 # RBAC Database Configuration
@@ -45,6 +63,10 @@ JWT_SECRET=your-super-secret-key-change-in-production-min-32-chars!
 JWT_ACCESS_EXPIRY=4h
 JWT_REFRESH_EXPIRY=7d
 
+# Optional: override issuer/audience claims (default: "chouseui" / "chouseui-client")
+# JWT_ISSUER=chouseui
+# JWT_AUDIENCE=chouseui-client
+
 # ============================================
 # Encryption
 # ============================================
@@ -65,6 +87,23 @@ RBAC_ENCRYPTION_SALT=
 RBAC_ADMIN_EMAIL=admin@localhost
 RBAC_ADMIN_USERNAME=admin
 RBAC_ADMIN_PASSWORD=admin123!
+
+# ============================================
+# Fleet Monitoring — optional
+# ============================================
+# Enable background polling of fleet connections.
+FLEET_POLLER_ENABLED=false
+FLEET_POLL_INTERVAL_SECONDS=30
+# Path to the alert configuration JSON file (Docker default shown)
+ALERT_CONFIG_FILE=/app/data/alert-config.json
+
+# ============================================
+# AI SRE / Doctor — optional
+# ============================================
+# Path to the doctor schedule JSON file (Docker default shown)
+DOCTOR_SCHEDULE_FILE=/app/data/doctor-schedule.json
+# Minimum minutes between automatic root-cause analysis runs per server
+DOCTOR_AUTO_RCA_COOLDOWN_MINUTES=60
 
 # ============================================
 # SSO (OIDC / OAuth2) — optional

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -22,6 +22,12 @@ jobs:
   build:
     name: Build Portfolio
     runs-on: ubuntu-latest
+    # Skip when triggered by the auto-release bot commit ("chore: release vX.Y.Z")
+    # — auto-release.yml has its own deploy-docs job that handles docs on release.
+    # Manual workflow_dispatch and regular docs/CHANGELOG pushes still run normally.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      !startsWith(github.event.head_commit.message, 'chore: release v')
     
     steps:
       - name: Checkout

--- a/AGENT.md
+++ b/AGENT.md
@@ -1,0 +1,1 @@
+See [CLAUDE.md](CLAUDE.md) for project instructions.

--- a/changelogs/unreleased/238-ai-optimizer-and-preferences.md
+++ b/changelogs/unreleased/238-ai-optimizer-and-preferences.md
@@ -1,0 +1,12 @@
+type: minor
+
+### Added
+- **Server-backed preferences** — theme and max result row limit now persist to the server (`workspacePreferences.app`) so they survive re-login and roam across devices
+- **Custom row limit input** — type any value up to 100,000 directly in Preferences in addition to the quick-pick preset buttons
+- **Extended row limit presets** — new options: 25k, 50k, 100k (server-side validation raised to match)
+
+### Changed
+- **AI Optimizer auto-enable** — removed the manual `AI_OPTIMIZER_ENABLED` env var; the optimizer now enables automatically whenever an active AI model is configured, matching the AI Chat behaviour
+
+### Fixed
+- **AI Optimizer empty query** — clicking "AI Optimize" from the hint strip no longer opens the dialog with an empty query

--- a/packages/server/src/routes/ai.ts
+++ b/packages/server/src/routes/ai.ts
@@ -16,6 +16,7 @@ import { AppError } from "../types";
 import { queryAuthMiddleware, type Variables } from "./query";
 import { getCapability, CAPABILITIES, CAPABILITY_IDS } from "../services/ai/capabilities";
 import { runStructuredCapability, isStructured } from "../services/ai/engine";
+import { isAIEnabled } from "../services/aiConfig";
 import type { AgentRunContext } from "../services/ai/types";
 import { createAuditLogWithContext, userHasPermission } from "../rbac/services/rbac";
 import { AUDIT_ACTIONS } from "../rbac/schema/base";
@@ -75,17 +76,13 @@ ai.post("/invoke", async (c) => {
     throw AppError.badRequest(`Capability '${capId}' is streaming; use its dedicated endpoint.`);
   }
 
-  // Preserve the legacy AI_OPTIMIZER_ENABLED gate for the optimizer-family
-  // capabilities (config.ts exposes this flag to the frontend, which hides the
-  // Optimize/Debug UI when off). check-optimize degrades softly, debug throws —
-  // matching the previous /query/debug + /query/check-optimization behavior.
-  if (process.env.AI_OPTIMIZER_ENABLED !== "true") {
+  // Gate optimizer-family capabilities on whether an active AI model is configured.
+  // check-optimize degrades softly; debug-query throws — matching prior behavior.
+  if ((capId === "check-optimize" || capId === "debug-query") && !(await isAIEnabled().catch(() => false))) {
     if (capId === "check-optimize") {
-      return c.json({ success: true, data: { canOptimize: false, reason: "AI Optimizer disabled" } });
+      return c.json({ success: true, data: { canOptimize: false, reason: "No AI model configured" } });
     }
-    if (capId === "debug-query") {
-      throw AppError.badRequest("AI Optimizer is not enabled on this server.");
-    }
+    throw AppError.badRequest("AI Optimizer is not available — no AI model configured.");
   }
 
   await requireCapabilityPermission(c, cap.permission);

--- a/packages/server/src/routes/config.test.ts
+++ b/packages/server/src/routes/config.test.ts
@@ -1,6 +1,14 @@
 
-import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { describe, it, expect, beforeEach, afterEach, mock } from "bun:test";
 import { Hono } from "hono";
+
+// Control whether isAIEnabled() returns true or false per test
+let _mockAiEnabled = false;
+
+mock.module("../services/aiConfig", () => ({
+  isAIEnabled: async () => _mockAiEnabled,
+}));
+
 import configRoute from "./config";
 
 describe("Config Route", () => {
@@ -9,6 +17,7 @@ describe("Config Route", () => {
 
     beforeEach(() => {
         originalEnv = { ...process.env };
+        _mockAiEnabled = false;
         app = new Hono();
         app.route("/config", configRoute);
     });
@@ -31,7 +40,6 @@ describe("Config Route", () => {
         expect(body.data.clickhouse.presetUrls).toEqual([]);
         expect(body.data.clickhouse.defaultUrl).toBe("");
         expect(body.data.clickhouse.defaultUser).toBe("default");
-        expect(body.data.clickhouse.defaultUser).toBe("default");
         expect(body.data.app.version).toBe("dev");
         expect(body.data.features.aiOptimizer).toBe(false);
     });
@@ -41,7 +49,7 @@ describe("Config Route", () => {
         process.env.CLICKHOUSE_DEFAULT_URL = "http://localhost:8123";
         process.env.CLICKHOUSE_DEFAULT_USER = "admin";
         process.env.VERSION = "1.0.0";
-        process.env.AI_OPTIMIZER_ENABLED = "true";
+        _mockAiEnabled = true;
 
         const res = await app.request("/config");
         expect(res.status).toBe(200);

--- a/packages/server/src/routes/config.ts
+++ b/packages/server/src/routes/config.ts
@@ -1,4 +1,5 @@
 import { Hono } from "hono";
+import { isAIEnabled } from "../services/aiConfig";
 
 const config = new Hono();
 
@@ -7,7 +8,7 @@ const config = new Hono();
  * Returns public configuration for the frontend
  * This allows Docker environment variables to be accessed by the frontend
  */
-config.get("/", (c) => {
+config.get("/", async (c) => {
   // Parse preset URLs from comma-separated string
   const presetUrlsRaw = process.env.CLICKHOUSE_PRESET_URLS || "";
   const presetUrls = presetUrlsRaw
@@ -33,9 +34,9 @@ config.get("/", (c) => {
         name: "CHouse UI",
         version: process.env.VERSION || "dev",
       },
-      // Feature flags
+      // Feature flags — aiOptimizer is enabled whenever an active AI model is configured
       features: {
-        aiOptimizer: process.env.AI_OPTIMIZER_ENABLED === 'true',
+        aiOptimizer: await isAIEnabled().catch(() => false),
       },
     },
   });

--- a/packages/server/src/routes/query.ts
+++ b/packages/server/src/routes/query.ts
@@ -422,9 +422,9 @@ const QueryRequestSchemaWithType = z.object({
   queryId: z.string().optional(),
   /**
    * User-configured row cap.  0 = unlimited.  Absent = use server default.
-   * Validated server-side: must be 0 (unlimited) or in [100, 500_000].
+   * Validated server-side: must be 0 (unlimited) or in [100, 100_000].
    */
-  maxResultRows: z.number().int().min(0).max(10_000).optional(),
+  maxResultRows: z.number().int().min(0).max(100_000).optional(),
 });
 
 const ExplainRequestSchema = z.object({

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,12 +27,16 @@ import { api, rbacConnectionsApi } from "@/api";
 import { useAuthStore } from "@/stores/auth";
 import { toast } from "sonner";
 import { log } from "@/lib/log";
+import { useAppPreferences } from "@/hooks/useAppPreferences";
 
 // Storage key for dock mode (to sync with FloatingDock).
 const DOCK_MODE_KEY = "chouseui-dock-mode";
 
 // Layout for the main application (authenticated routes) - Floating Dock Design
 const MainLayout = () => {
+  // Sync server-backed preferences (theme, maxResultRows) on every authenticated mount
+  useAppPreferences();
+
   const [isSidebarMode, setIsSidebarMode] = useState(() => {
     try {
       return localStorage.getItem(DOCK_MODE_KEY) === "sidebar";

--- a/src/features/workspace/components/SqlTab.tsx
+++ b/src/features/workspace/components/SqlTab.tsx
@@ -226,7 +226,8 @@ const SqlTab: React.FC<SqlTabProps> = ({ tabId }) => {
 
   // Handle manual optimization trigger
   const handleOptimize = useCallback((query: string) => {
-    setOptimizerAutoStart(false); // Manual trigger usually implies fresh start or we can set true
+    setDebugQueryString(query);
+    setOptimizerAutoStart(false);
     setIsOptimizerOpen(true);
   }, []);
 

--- a/src/hooks/useAppPreferences.ts
+++ b/src/hooks/useAppPreferences.ts
@@ -1,0 +1,94 @@
+/**
+ * Hook for managing app-level preferences (theme, maxResultRows) backed by the
+ * server's workspacePreferences.app JSON field.
+ *
+ * On mount it fetches the stored value and hydrates the Zustand preferences
+ * store and the theme provider.  Writes are optimistic: local state updates
+ * immediately and then persists to the server in the background.
+ */
+
+import { useState, useEffect, useCallback } from "react";
+import { rbacUserPreferencesApi } from "@/api/rbac";
+import { useRbacStore } from "@/stores/rbac";
+import { usePreferencesStore } from "@/stores/preferences";
+import { useTheme } from "@/components/common/theme-provider";
+import { log } from "@/lib/log";
+
+export interface AppPreferences {
+  maxResultRows?: number;
+  theme?: "light" | "dark" | "system" | "auto";
+}
+
+export function useAppPreferences(): {
+  updateAppPreferences: (updates: Partial<AppPreferences>) => Promise<void>;
+  isLoading: boolean;
+} {
+  const { isAuthenticated } = useRbacStore();
+  const { setMaxResultRows } = usePreferencesStore();
+  const { setTheme } = useTheme();
+  const [isLoading, setIsLoading] = useState(true);
+  const [hasFetched, setHasFetched] = useState(false);
+
+  useEffect(() => {
+    if (!isAuthenticated || hasFetched) {
+      setIsLoading(false);
+      return;
+    }
+
+    const fetchPreferences = async (): Promise<void> => {
+      try {
+        const userPreferences = await rbacUserPreferencesApi.getPreferences();
+        const appPrefs = userPreferences.workspacePreferences?.app as AppPreferences | undefined;
+
+        if (appPrefs) {
+          if (appPrefs.maxResultRows !== undefined) {
+            setMaxResultRows(appPrefs.maxResultRows);
+          }
+          if (appPrefs.theme) {
+            setTheme(appPrefs.theme);
+          }
+        }
+      } catch (error) {
+        log.error("[useAppPreferences] Failed to fetch preferences", error);
+      } finally {
+        setHasFetched(true);
+        setIsLoading(false);
+      }
+    };
+
+    fetchPreferences().catch((error) => {
+      log.error("[useAppPreferences] Error fetching preferences", error);
+      setHasFetched(true);
+      setIsLoading(false);
+    });
+  }, [isAuthenticated, hasFetched, setMaxResultRows, setTheme]);
+
+  const updateAppPreferences = useCallback(
+    async (updates: Partial<AppPreferences>): Promise<void> => {
+      // Apply locally first (fast path)
+      if (updates.maxResultRows !== undefined) setMaxResultRows(updates.maxResultRows);
+      if (updates.theme) setTheme(updates.theme);
+
+      if (!isAuthenticated) return;
+
+      // Persist to server (best-effort)
+      try {
+        const currentPreferences = await rbacUserPreferencesApi.getPreferences();
+        await rbacUserPreferencesApi.updatePreferences({
+          workspacePreferences: {
+            ...currentPreferences.workspacePreferences,
+            app: {
+              ...((currentPreferences.workspacePreferences?.app as AppPreferences) ?? {}),
+              ...updates,
+            },
+          },
+        });
+      } catch (error) {
+        log.error("[useAppPreferences] Failed to sync preferences to server", error);
+      }
+    },
+    [isAuthenticated, setMaxResultRows, setTheme],
+  );
+
+  return { updateAppPreferences, isLoading };
+}

--- a/src/pages/Preferences.tsx
+++ b/src/pages/Preferences.tsx
@@ -25,6 +25,8 @@ import {
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { useAuthStore, useRbacStore, usePreferencesStore } from "@/stores";
+import { RESULT_ROWS_MIN, RESULT_ROWS_MAX, RESULT_ROWS_DEFAULT } from "@/stores/preferences";
+import { useAppPreferences } from "@/hooks/useAppPreferences";
 import { useNavigate } from "react-router-dom";
 import { cn } from "@/lib/utils";
 import { rbacAuthApi, rbacConnectionsApi } from "@/api/rbac";
@@ -139,15 +141,43 @@ const THEME_OPTIONS: Array<{
 ];
 
 const ROW_PRESETS: Array<{ value: number; label: string; hint: string }> = [
-  { value: 100,    label: "100",    hint: "Minimal preview" },
-  { value: 1_000,  label: "1,000",  hint: "Quick sample" },
-  { value: 5_000,  label: "5,000",  hint: "Standard" },
-  { value: 10_000, label: "10,000", hint: "Maximum · Default" },
+  { value: 100,     label: "100",     hint: "Minimal preview" },
+  { value: 1_000,   label: "1k",      hint: "Quick sample" },
+  { value: 5_000,   label: "5k",      hint: "Standard" },
+  { value: 10_000,  label: "10k",     hint: "Default" },
+  { value: 25_000,  label: "25k",     hint: "Large" },
+  { value: 50_000,  label: "50k",     hint: "Very large" },
+  { value: 100_000, label: "100k",    hint: "Maximum" },
 ];
 
 const AppearanceCard: React.FC = () => {
   const { theme, resolvedTheme, setTheme } = useTheme();
-  const { maxResultRows, setMaxResultRows, resetPreferences } = usePreferencesStore();
+  const { maxResultRows } = usePreferencesStore();
+  const { updateAppPreferences } = useAppPreferences();
+  const [customRowInput, setCustomRowInput] = useState("");
+
+  const handleThemeChange = (newTheme: ThemeMode): void => {
+    updateAppPreferences({ theme: newTheme }).catch(() => { /* best-effort */ });
+  };
+
+  const handleRowsChange = (value: number): void => {
+    setCustomRowInput("");
+    updateAppPreferences({ maxResultRows: value }).catch(() => { /* best-effort */ });
+  };
+
+  const handleCustomRowInput = (): void => {
+    const parsed = parseInt(customRowInput, 10);
+    if (!isNaN(parsed)) {
+      const clamped = Math.min(RESULT_ROWS_MAX, Math.max(RESULT_ROWS_MIN, parsed));
+      handleRowsChange(clamped);
+    }
+    setCustomRowInput("");
+  };
+
+  const handleReset = (): void => {
+    setCustomRowInput("");
+    updateAppPreferences({ maxResultRows: RESULT_ROWS_DEFAULT }).catch(() => { /* best-effort */ });
+  };
 
   return (
     <SettingCard
@@ -172,7 +202,7 @@ const AppearanceCard: React.FC = () => {
                 <button
                   key={opt.id}
                   type="button"
-                  onClick={() => setTheme(opt.id)}
+                  onClick={() => handleThemeChange(opt.id)}
                   aria-pressed={active}
                   title={opt.hint}
                   className={cn(
@@ -192,46 +222,61 @@ const AppearanceCard: React.FC = () => {
 
         <div className="h-px bg-ink-500" />
 
-        {/* Max result rows — compact inline selector */}
-        <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-          <div className="flex flex-col gap-0.5">
-            <p className={MONO_LABEL}>Max result rows</p>
-            <p className={cn(MONO_FAINT, "leading-relaxed")}>
-              SQL editor cap — add a{" "}
-              <code className="rounded-xs border border-ink-500 bg-ink-200 px-1 font-mono">LIMIT</code>{" "}
-              for fewer rows
-            </p>
-          </div>
-          <div className="flex shrink-0 items-center gap-2">
-            {ROW_PRESETS.map((opt) => {
-              const active = maxResultRows === opt.value;
-              return (
-                <button
-                  key={opt.value}
-                  type="button"
-                  onClick={() => setMaxResultRows(opt.value)}
-                  aria-pressed={active}
-                  title={opt.hint}
-                  className={cn(
-                    "rounded-xs border px-3 py-1.5 font-mono text-[12px] tabular-nums transition-colors",
-                    active
-                      ? "border-brand bg-brand/[0.08] text-brand"
-                      : "border-ink-500 bg-ink-200 text-paper-muted hover:border-ink-700 hover:text-paper"
-                  )}
-                >
-                  {opt.label}
-                </button>
-              );
-            })}
-            <button
-              type="button"
-              onClick={resetPreferences}
-              title="Reset to default"
-              aria-label="Reset to default"
-              className="rounded-xs border border-ink-500 bg-ink-100 p-1.5 text-paper-dim transition-colors hover:border-ink-700 hover:text-paper"
-            >
-              <RotateCcw className="h-3.5 w-3.5" aria-hidden />
-            </button>
+        {/* Max result rows — preset buttons + custom input */}
+        <div className="flex flex-col gap-3">
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+            <div className="flex flex-col gap-0.5">
+              <p className={MONO_LABEL}>Max result rows</p>
+              <p className={cn(MONO_FAINT, "leading-relaxed")}>
+                SQL editor cap — add a{" "}
+                <code className="rounded-xs border border-ink-500 bg-ink-200 px-1 font-mono">LIMIT</code>{" "}
+                for fewer rows
+              </p>
+            </div>
+            <div className="flex shrink-0 flex-wrap items-center gap-2">
+              {ROW_PRESETS.map((opt) => {
+                const active = maxResultRows === opt.value && customRowInput === "";
+                return (
+                  <button
+                    key={opt.value}
+                    type="button"
+                    onClick={() => handleRowsChange(opt.value)}
+                    aria-pressed={active}
+                    title={opt.hint}
+                    className={cn(
+                      "rounded-xs border px-3 py-1.5 font-mono text-[12px] tabular-nums transition-colors",
+                      active
+                        ? "border-brand bg-brand/[0.08] text-brand"
+                        : "border-ink-500 bg-ink-200 text-paper-muted hover:border-ink-700 hover:text-paper"
+                    )}
+                  >
+                    {opt.label}
+                  </button>
+                );
+              })}
+              {/* Custom number input */}
+              <input
+                type="number"
+                min={RESULT_ROWS_MIN}
+                max={RESULT_ROWS_MAX}
+                value={customRowInput}
+                onChange={(e) => setCustomRowInput(e.target.value)}
+                onBlur={handleCustomRowInput}
+                onKeyDown={(e) => { if (e.key === "Enter") handleCustomRowInput(); }}
+                placeholder="custom"
+                aria-label="Custom row limit"
+                className="w-20 rounded-xs border border-ink-500 bg-ink-200 px-2 py-1.5 font-mono text-[12px] tabular-nums text-paper-muted placeholder-paper-faint transition-colors focus:border-brand focus:outline-none"
+              />
+              <button
+                type="button"
+                onClick={handleReset}
+                title="Reset to default"
+                aria-label="Reset to default"
+                className="rounded-xs border border-ink-500 bg-ink-100 p-1.5 text-paper-dim transition-colors hover:border-ink-700 hover:text-paper"
+              >
+                <RotateCcw className="h-3.5 w-3.5" aria-hidden />
+              </button>
+            </div>
           </div>
         </div>
 

--- a/src/stores/preferences.ts
+++ b/src/stores/preferences.ts
@@ -16,9 +16,8 @@ import { useRbacStore } from "./rbac";
 /** Minimum rows the user can configure — prevents accidentally clearing the cap. */
 export const RESULT_ROWS_MIN = 100;
 
-/** Upper bound exposed in the UI input — keeps the browser from receiving
- *  runaway result sets even if the user sets the max very high. */
-export const RESULT_ROWS_MAX = 10_000;
+/** Upper bound exposed in the UI input — matches the server-side cap. */
+export const RESULT_ROWS_MAX = 100_000;
 
 /** Sensible out-of-the-box default. */
 export const RESULT_ROWS_DEFAULT = 10_000;


### PR DESCRIPTION
## Description

Four improvements across the AI optimizer, user preferences, and developer docs.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

## Related Issue

Closes #

## Changes Made

### 1. Remove `AI_OPTIMIZER_ENABLED` — use `isAIEnabled()` instead
The AI optimizer previously required a manual `AI_OPTIMIZER_ENABLED=true` env var. It now auto-enables whenever an active AI model is configured in the database, matching the existing AI Chat behaviour (`isAIEnabled()` from `aiConfig.ts`). The env var is no longer needed.

- `packages/server/src/routes/config.ts` — async handler, calls `isAIEnabled().catch(() => false)`
- `packages/server/src/routes/ai.ts` — replaces env check with `isAIEnabled()` for `check-optimize` / `debug-query` capabilities
- `packages/server/src/routes/config.test.ts` — mocks `isAIEnabled` via `mock.module` instead of setting the env var

### 2. Fix AI optimizer "query is empty" bug
Clicking **AI Optimize** from the hint strip opened the dialog with an empty query. Root cause: `handleOptimize` in `SqlTab.tsx` opened the dialog without calling `setDebugQueryString(query)`, so the dialog fell back to an empty string.

- `src/features/workspace/components/SqlTab.tsx` — one-line fix: call `setDebugQueryString(query)` before `setIsOptimizerOpen(true)`

### 3. Server-backed preferences (theme + max result rows)
Theme and max result row limit now persist to `rbac_user_preferences.workspacePreferences.app` on the server, so they survive re-login and roam across devices. LocalStorage (Zustand persist) is kept as a fast cache/offline fallback.

- `src/hooks/useAppPreferences.ts` — new hook following the `useLogsPreferences` pattern; fetches `workspacePreferences.app` on mount, hydrates Zustand store + theme provider; `updateAppPreferences()` updates locally then persists to server
- `src/App.tsx` — mounts `useAppPreferences()` in `MainLayout` (authenticated routes only, avoids login-page timing issues)
- `src/pages/Preferences.tsx` — theme and row limit changes now call `updateAppPreferences`; presets extended to 100k; free-form custom number input added
- `src/stores/preferences.ts` — `RESULT_ROWS_MAX` raised from 10k → 100k
- `packages/server/src/routes/query.ts` — Zod `.max()` raised from 10k → 100k to match

### 4. Document missing env vars
Several env vars were used by the server but absent from the example config files.

- `.env.example` — added `CHOUSE_CONFIG_PATH`, `CLICKHOUSE_DEFAULT_URL/USER/PRESET_URLS`, `JWT_ISSUER/AUDIENCE`, `FLEET_POLLER_ENABLED`, `FLEET_POLL_INTERVAL_SECONDS`, `ALERT_CONFIG_FILE`, `DOCTOR_SCHEDULE_FILE`, `DOCTOR_AUTO_RCA_COOLDOWN_MINUTES`
- `.config.example.yaml` — matching YAML sections; Google SSO example fixed from incorrect `oauth2` type to `oidc` with correct endpoints and env var placeholders (`${GOOGLE_CLIENT_ID}`, `${GOOGLE_CLIENT_SECRET}`)

### 5. Add `AGENT.md`
Added `AGENT.md` that points to `CLAUDE.md` so non-Claude agents can discover project instructions.

## Testing

- [x] I have tested this locally
- [x] I have added/updated tests
- [x] All existing tests pass

### Test Steps

1. **AI optimizer auto-enable** — configure an AI model in Admin → AI Models → optimizer buttons appear in SQL tab without any env var; remove the model → buttons disappear
2. **Empty query fix** — paste SQL into the editor, click "AI Optimize" from the hint strip → dialog opens pre-filled with the query
3. **Row limit** — set a custom value (e.g. 50,000) in Preferences → run a large query → results cap at 50k → preference survives page reload and re-login
4. **Theme persistence** — change theme in Preferences → log out and back in → theme is restored without needing to set it again
5. `bunx vitest run` and `bun run typecheck` — no new failures

## Changelog Fragment

- [x] Added `changelogs/unreleased/238-ai-optimizer-and-preferences.md`

## Checklist

- [x] My code follows the project's code style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] I have checked for breaking changes and documented them (if applicable)

## Additional Notes

The `AI_OPTIMIZER_ENABLED` env var is now unused. Deployments that had it set will continue to work (it's simply ignored), but it can be removed from env files.