### PR TITLE
feat(sso): view and unlink a user's linked SSO identities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
-
-### Added
-
-- SSO identity management on the user's Security tab: shows each linked provider with its email and last sign-in, and lets admins unlink an identity (`USERS_UPDATE`), with a warning that an SSO-only user will be locked out until their password is reset.
-
 ## [v3.0.0] - 2026-06-12
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- SSO identity management on the user's Security tab: shows each linked provider with its email and last sign-in, and lets admins unlink an identity (`USERS_UPDATE`), with a warning that an SSO-only user will be locked out until their password is reset.
+
 ## [v3.0.0] - 2026-06-12
 
 ### Added

--- a/changelogs/unreleased/243-sso-identity-management.md
+++ b/changelogs/unreleased/243-sso-identity-management.md
@@ -1,0 +1,4 @@
+type: minor
+
+### Added
+- **SSO identity management** — the user's **Security** tab now lists each linked SSO provider (display name, the email it was linked by, and last sign-in) and lets admins unlink an identity. Backed by new `GET`/`DELETE /rbac/users/:id/identities` endpoints (`users:view` to list, `users:update` to unlink, with super-admin targets protected), and a new `user.sso_identity_unlink` audit action. Unlinking warns that an SSO-only user will be locked out until their password is reset.

--- a/packages/server/src/rbac/routes/users.ts
+++ b/packages/server/src/rbac/routes/users.ts
@@ -17,6 +17,8 @@ import {
   createAuditLogWithContext,
 } from '../services/rbac';
 import { validatePasswordStrength, generateSecurePassword } from '../services/password';
+import { listUserIdentities, deleteUserIdentity } from '../sso/identity';
+import { getSsoConfig } from '../sso/config';
 import { AUDIT_ACTIONS, PERMISSIONS } from '../schema/base';
 import {
   rbacAuthMiddleware,
@@ -386,6 +388,81 @@ userRoutes.post('/:id/assign-roles', requirePermission(PERMISSIONS.ROLES_ASSIGN)
   return c.json({
     success: true,
     data: { user },
+  });
+});
+
+/**
+ * GET /rbac/users/:id/identities
+ * List a user's linked SSO identities (provider, link/last-login metadata).
+ * Secrets are never returned. displayName is resolved from the live SSO
+ * config and falls back to the raw provider id if that provider was removed.
+ */
+userRoutes.get('/:id/identities', requirePermission(PERMISSIONS.USERS_VIEW), async (c) => {
+  const id = c.req.param('id');
+
+  const existingUser = await getUserById(id);
+  if (!existingUser) {
+    throw AppError.notFound('User not found');
+  }
+
+  const config = getSsoConfig();
+  const identities = await listUserIdentities(id);
+
+  return c.json({
+    success: true,
+    data: {
+      identities: identities.map((identity) => ({
+        id: identity.id,
+        provider: identity.provider,
+        displayName: config.providers.get(identity.provider)?.displayName ?? identity.provider,
+        email: identity.email,
+        createdAt: identity.createdAt,
+        lastLoginAt: identity.lastLoginAt,
+      })),
+    },
+  });
+});
+
+/**
+ * DELETE /rbac/users/:id/identities/:identityId
+ * Unlink an SSO identity from a user. After unlinking, an SSO-only user has
+ * no usable password and must have their password reset to sign in again.
+ */
+userRoutes.delete('/:id/identities/:identityId', requirePermission(PERMISSIONS.USERS_UPDATE), async (c) => {
+  const id = c.req.param('id');
+  const identityId = c.req.param('identityId');
+  const currentUser = getRbacUser(c);
+  const ipAddress = getClientIp(c);
+
+  const existingUser = await getUserById(id);
+  if (!existingUser) {
+    throw AppError.notFound('User not found');
+  }
+
+  // Prevent modifying super admin unless you're also super admin.
+  if (existingUser.roles.includes('super_admin') && !isSuperAdmin(c)) {
+    throw AppError.forbidden('Cannot modify super administrator');
+  }
+
+  // Ensure the identity belongs to this user before deleting it.
+  const identities = await listUserIdentities(id);
+  const target = identities.find((identity) => identity.id === identityId);
+  if (!target) {
+    throw AppError.notFound('SSO identity not found for this user');
+  }
+
+  await deleteUserIdentity(identityId);
+
+  await createAuditLogWithContext(c, AUDIT_ACTIONS.SSO_IDENTITY_UNLINK, currentUser.sub, {
+    resourceType: 'user',
+    resourceId: id,
+    details: { provider: target.provider, identityId },
+    ipAddress,
+  });
+
+  return c.json({
+    success: true,
+    data: { message: 'SSO identity unlinked successfully' },
   });
 });
 

--- a/packages/server/src/rbac/schema/base.ts
+++ b/packages/server/src/rbac/schema/base.ts
@@ -338,6 +338,7 @@ export const AUDIT_ACTIONS = {
   USER_DELETE: 'user.delete',
   USER_ROLE_ASSIGN: 'user.role_assign',
   USER_ROLE_REVOKE: 'user.role_revoke',
+  SSO_IDENTITY_UNLINK: 'user.sso_identity_unlink',
 
   // Role Management
   ROLE_CREATE: 'role.create',

--- a/packages/server/src/rbac/sso/identity.test.ts
+++ b/packages/server/src/rbac/sso/identity.test.ts
@@ -95,10 +95,22 @@ function makeUpdateBuilder(): Record<string, unknown> {
   return builder;
 }
 
+function makeDeleteBuilder(): Record<string, unknown> {
+  const builder: Record<string, unknown> = {
+    where: mock((cond: unknown) => {
+      capturedWhereArg = cond;
+      return builder;
+    }),
+    then: mock((resolve: (v: unknown) => void) => resolve(undefined)),
+  };
+  return builder;
+}
+
 const mockDb = {
   select: mock((_projection?: unknown) => makeSelectBuilder()),
   insert: mock((_table: unknown) => makeInsertBuilder()),
   update: mock((_table: unknown) => makeUpdateBuilder()),
+  delete: mock((_table: unknown) => makeDeleteBuilder()),
 };
 
 // ------------------------------------------------------------------
@@ -120,6 +132,8 @@ import {
   getUserIdentity,
   userHasSsoIdentity,
   touchUserIdentity,
+  listUserIdentities,
+  deleteUserIdentity,
 } from "./identity";
 
 // ------------------------------------------------------------------
@@ -152,6 +166,7 @@ describe("SSO Identity Store", () => {
     mockDb.select.mockClear();
     mockDb.insert.mockClear();
     mockDb.update.mockClear();
+    mockDb.delete.mockClear();
   });
 
   // ----------------------------------------------------------------
@@ -340,6 +355,49 @@ describe("SSO Identity Store", () => {
       const row2 = insertedRows.find((r) => r.subject === "s2");
       expect(row2).toBeDefined();
       expect(row2!.userId).toBe("u2");
+    });
+  });
+
+  // ----------------------------------------------------------------
+  describe("listUserIdentities", () => {
+    it("returns every identity seeded for the user", async () => {
+      await createUserIdentity({ userId: "u1", provider: "okta", subject: "s1", email: "a@b.co" });
+      await createUserIdentity({ userId: "u1", provider: "github", subject: "s2" });
+
+      seedSelectByUserId("u1");
+      const rows = await listUserIdentities("u1");
+
+      expect(rows).toHaveLength(2);
+      expect(rows.map((r) => r.provider).sort()).toEqual(["github", "okta"]);
+    });
+
+    it("returns an empty array when the user has no identities", async () => {
+      seededSelectRows = [];
+      const rows = await listUserIdentities("u-none");
+      expect(rows).toEqual([]);
+    });
+
+    it("passes the correct where-condition (userId column)", async () => {
+      seededSelectRows = [];
+      await listUserIdentities("u-sentinel");
+
+      const expectedCond = eq(mockSchema.userIdentities.userId as never, "u-sentinel");
+      expect(capturedWhereArg).toEqual(expectedCond);
+    });
+  });
+
+  // ----------------------------------------------------------------
+  describe("deleteUserIdentity", () => {
+    it("calls db.delete", async () => {
+      await deleteUserIdentity("identity-1");
+      expect(mockDb.delete).toHaveBeenCalled();
+    });
+
+    it("passes the correct where-condition (id column)", async () => {
+      await deleteUserIdentity("identity-42");
+
+      const expectedCond = eq(mockSchema.userIdentities.id as never, "identity-42");
+      expect(capturedWhereArg).toEqual(expectedCond);
     });
   });
 });

--- a/packages/server/src/rbac/sso/identity.ts
+++ b/packages/server/src/rbac/sso/identity.ts
@@ -81,3 +81,23 @@ export async function userHasSsoIdentity(userId: string): Promise<boolean> {
     .limit(1);
   return rows.length > 0;
 }
+
+export async function listUserIdentities(
+  userId: string
+): Promise<UserIdentity[]> {
+  const db = getDatabase() as AnyDb;
+  const schema = getSchema();
+  const rows = await db
+    .select()
+    .from(schema.userIdentities)
+    .where(eq(schema.userIdentities.userId, userId));
+  return rows as UserIdentity[];
+}
+
+export async function deleteUserIdentity(id: string): Promise<void> {
+  const db = getDatabase() as AnyDb;
+  const schema = getSchema();
+  await db
+    .delete(schema.userIdentities)
+    .where(eq(schema.userIdentities.id, id));
+}

--- a/src/api/rbac.test.ts
+++ b/src/api/rbac.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { describe, it, expect, afterEach, beforeEach } from 'vitest';
-import { ssoApi, rbacDataAccessPoliciesApi } from './rbac';
+import { ssoApi, rbacDataAccessPoliciesApi, rbacUsersApi } from './rbac';
 import { RBAC_ACCESS_TOKEN_KEY, RBAC_REFRESH_TOKEN_KEY } from './client';
 import { server } from '../test/mocks/server';
 import { http, HttpResponse } from 'msw';
@@ -273,5 +273,78 @@ describe('rbacDataAccessPoliciesApi', () => {
     const tables = await rbacDataAccessPoliciesApi.listTables('conn-1', 'my db');
     expect(tables).toEqual(['events', 'users']);
     expect(capturedUrl).toContain('database=my%20db');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// rbacUsersApi.getIdentities
+// ---------------------------------------------------------------------------
+
+describe('rbacUsersApi.getIdentities', () => {
+  it('returns the identity list unwrapped from the data envelope', async () => {
+    const identity = {
+      id: 'idn-1',
+      provider: 'google',
+      displayName: 'Google',
+      email: 'user@example.com',
+      createdAt: '2026-06-10T00:00:00.000Z',
+      lastLoginAt: '2026-06-12T00:00:00.000Z',
+    };
+
+    server.use(
+      http.get('/api/rbac/users/user-1/identities', () => {
+        return HttpResponse.json({ success: true, data: { identities: [identity] } });
+      })
+    );
+
+    const identities = await rbacUsersApi.getIdentities('user-1');
+    expect(identities).toEqual([identity]);
+  });
+
+  it('returns an empty array when the user has no linked identities', async () => {
+    server.use(
+      http.get('/api/rbac/users/user-2/identities', () => {
+        return HttpResponse.json({ success: true, data: { identities: [] } });
+      })
+    );
+
+    expect(await rbacUsersApi.getIdentities('user-2')).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// rbacUsersApi.unlinkIdentity
+// ---------------------------------------------------------------------------
+
+describe('rbacUsersApi.unlinkIdentity', () => {
+  it('issues a DELETE to the identity endpoint', async () => {
+    let capturedMethod: string | null = null;
+
+    server.use(
+      http.delete('/api/rbac/users/user-1/identities/idn-1', ({ request }) => {
+        capturedMethod = request.method;
+        return HttpResponse.json({ success: true, data: { message: 'SSO identity unlinked successfully' } });
+      })
+    );
+
+    await rbacUsersApi.unlinkIdentity('user-1', 'idn-1');
+    expect(capturedMethod).toBe('DELETE');
+  });
+
+  it('throws ApiError with the server message when the identity is not found', async () => {
+    server.use(
+      http.delete('/api/rbac/users/user-1/identities/missing', () => {
+        return HttpResponse.json(
+          { success: false, error: { message: 'SSO identity not found for this user', code: 'NOT_FOUND' } },
+          { status: 404 }
+        );
+      })
+    );
+
+    await expect(rbacUsersApi.unlinkIdentity('user-1', 'missing')).rejects.toMatchObject({
+      name: 'ApiError',
+      message: 'SSO identity not found for this user',
+      statusCode: 404,
+    });
   });
 });

--- a/src/api/rbac.ts
+++ b/src/api/rbac.ts
@@ -475,6 +475,16 @@ export const rbacAuthApi = {
 // Users API
 // ============================================
 
+/** A user's linked SSO identity, as returned by the users API (no secrets). */
+export interface SsoIdentityInfo {
+  id: string;
+  provider: string;
+  displayName: string;
+  email: string | null;
+  createdAt: string;
+  lastLoginAt: string | null;
+}
+
 export const rbacUsersApi = {
   /**
    * List users
@@ -554,6 +564,21 @@ export const rbacUsersApi = {
       body: JSON.stringify({ roleIds }),
     });
     return result.user;
+  },
+
+  /**
+   * List a user's linked SSO identities
+   */
+  async getIdentities(id: string): Promise<SsoIdentityInfo[]> {
+    const result = await rbacFetch<{ identities: SsoIdentityInfo[] }>(`/users/${id}/identities`);
+    return result.identities;
+  },
+
+  /**
+   * Unlink an SSO identity from a user
+   */
+  async unlinkIdentity(id: string, identityId: string): Promise<void> {
+    await rbacFetch(`/users/${id}/identities/${identityId}`, { method: 'DELETE' });
   },
 };
 

--- a/src/features/admin/components/EditUser/index.tsx
+++ b/src/features/admin/components/EditUser/index.tsx
@@ -25,6 +25,8 @@ import {
   UserX,
   UserCheck,
   Database,
+  Link2,
+  Unlink,
 } from "lucide-react";
 import { useNavigate, useParams } from "react-router-dom";
 import { toast } from "sonner";
@@ -54,7 +56,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
-import { rbacUsersApi, rbacRolesApi, type RbacUser, type RbacRole, type UpdateUserInput } from "@/api/rbac";
+import { rbacUsersApi, rbacRolesApi, type RbacUser, type RbacRole, type UpdateUserInput, type SsoIdentityInfo } from "@/api/rbac";
 import { useRbacStore, RBAC_PERMISSIONS } from "@/stores";
 import { formatDistanceToNow, format } from "date-fns";
 
@@ -129,6 +131,11 @@ const EditUser: React.FC = () => {
   // Delete state
   const [isDeleting, setIsDeleting] = useState(false);
 
+  // SSO identity state
+  const [identities, setIdentities] = useState<SsoIdentityInfo[]>([]);
+  const [identityToUnlink, setIdentityToUnlink] = useState<SsoIdentityInfo | null>(null);
+  const [isUnlinking, setIsUnlinking] = useState(false);
+
   const isCurrentUser = user?.id === currentUser?.id;
 
   // Fetch user and roles
@@ -142,8 +149,9 @@ const EditUser: React.FC = () => {
     Promise.all([
       rbacUsersApi.get(userId),
       rbacRolesApi.list(),
+      rbacUsersApi.getIdentities(userId),
     ])
-      .then(([userData, rolesData]) => {
+      .then(([userData, rolesData, userIdentities]) => {
         // Check if basic admin is trying to edit super admin
         const userIsSuperAdmin = userData.roles.includes('super_admin');
         if (!isSuperAdmin() && userIsSuperAdmin) {
@@ -157,6 +165,7 @@ const EditUser: React.FC = () => {
         setUsername(userData.username);
         setDisplayName(userData.displayName || "");
         setIsActive(userData.isActive);
+        setIdentities(userIdentities);
 
         // Filter out super_admin if current user is not super_admin
         const filteredRoles = isSuperAdmin()
@@ -311,6 +320,24 @@ const EditUser: React.FC = () => {
       toast.error(`Failed to delete user: ${(err as Error).message}`);
     } finally {
       setIsDeleting(false);
+    }
+  };
+
+  const handleUnlinkIdentity = async () => {
+    if (!identityToUnlink || !userId) return;
+
+    setIsUnlinking(true);
+
+    try {
+      await rbacUsersApi.unlinkIdentity(userId, identityToUnlink.id);
+      setIdentities((prev) => prev.filter((i) => i.id !== identityToUnlink.id));
+      toast.success(`Unlinked ${identityToUnlink.displayName} sign-in`);
+      setIdentityToUnlink(null);
+    } catch (err) {
+      log.error("Failed to unlink SSO identity:", err);
+      toast.error(`Failed to unlink identity: ${(err as Error).message}`);
+    } finally {
+      setIsUnlinking(false);
     }
   };
 
@@ -726,6 +753,55 @@ const EditUser: React.FC = () => {
                 </div>
               </div>
 
+              {/* SSO Identity */}
+              <div className="rounded-xs border border-ink-500 bg-ink-200 p-4">
+                <h4 className="mb-3 font-mono text-[10px] uppercase tracking-[0.14em] text-paper-dim">SSO identity</h4>
+                {identities.length === 0 ? (
+                  <p className="text-[12px] italic text-paper-faint">
+                    No SSO identity linked. This user signs in with a password.
+                  </p>
+                ) : (
+                  <div className="space-y-2">
+                    {identities.map((identity) => (
+                      <div
+                        key={identity.id}
+                        className="flex items-center justify-between gap-3 rounded-xs border border-ink-500 bg-ink-100 px-3 py-2.5"
+                      >
+                        <div className="flex min-w-0 items-center gap-3">
+                          <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-xs border border-emerald-800 bg-emerald-950/30">
+                            <Link2 className="h-3.5 w-3.5 text-emerald-300" aria-hidden />
+                          </div>
+                          <div className="min-w-0">
+                            <div className="flex items-center gap-2">
+                              <span className="text-[13px] font-semibold text-paper">{identity.displayName}</span>
+                              <span className="inline-flex items-center rounded-xs border border-emerald-800 bg-emerald-950/30 px-1.5 py-0.5 font-mono text-[9px] uppercase tracking-[0.12em] text-emerald-300">
+                                Linked
+                              </span>
+                            </div>
+                            <p className="mt-0.5 truncate text-[11px] text-paper-muted">
+                              {identity.email || "no email"} · last sign-in{" "}
+                              {identity.lastLoginAt
+                                ? formatDistanceToNow(new Date(identity.lastLoginAt), { addSuffix: true })
+                                : "never"}
+                            </p>
+                          </div>
+                        </div>
+                        {canUpdateUsers && (
+                          <Button
+                            variant="outline"
+                            onClick={() => setIdentityToUnlink(identity)}
+                            className="h-8 shrink-0 gap-1.5 rounded-xs border-ink-500 bg-ink-100 px-2.5 text-[12px] text-paper hover:border-red-900/60 hover:bg-red-950/30 hover:text-red-200"
+                          >
+                            <Unlink className="h-3.5 w-3.5" />
+                            Unlink
+                          </Button>
+                        )}
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </div>
+
               {/* Permissions Summary */}
               <div className="rounded-xs border border-ink-500 bg-ink-200 p-4">
                 <h4 className="mb-3 font-mono text-[10px] uppercase tracking-[0.14em] text-paper-dim">Effective permissions</h4>
@@ -933,6 +1009,56 @@ const EditUser: React.FC = () => {
           )}
         </DialogContent>
       </Dialog>
+
+      {/* Unlink SSO identity confirmation */}
+      <AlertDialog
+        open={!!identityToUnlink}
+        onOpenChange={(open) => {
+          if (!open) setIdentityToUnlink(null);
+        }}
+      >
+        <AlertDialogContent className="rounded-xs border-ink-500 bg-ink-100">
+          <AlertDialogHeader>
+            <AlertDialogTitle className="flex items-center gap-2 text-paper">
+              <AlertTriangle className="h-4 w-4 text-red-300" />
+              Unlink SSO identity
+            </AlertDialogTitle>
+            <AlertDialogDescription className="text-paper-muted">
+              Remove the <strong className="text-paper">{identityToUnlink?.displayName}</strong> sign-in link from{" "}
+              <strong className="text-paper">{user?.username}</strong>? If this is their only sign-in method, they will be
+              locked out until you reset their password.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel
+              disabled={isUnlinking}
+              className="h-9 rounded-xs border-ink-500 bg-ink-200 text-paper hover:border-ink-700 hover:bg-ink-300"
+            >
+              Cancel
+            </AlertDialogCancel>
+            <AlertDialogAction
+              onClick={(e) => {
+                e.preventDefault();
+                handleUnlinkIdentity();
+              }}
+              disabled={isUnlinking}
+              className="h-9 gap-2 rounded-xs border border-red-900/60 bg-red-950/40 font-mono text-[11px] font-semibold uppercase tracking-[0.14em] text-red-200 hover:bg-red-950/60"
+            >
+              {isUnlinking ? (
+                <>
+                  <Loader2 className="mr-2 h-3.5 w-3.5 animate-spin" />
+                  Unlinking…
+                </>
+              ) : (
+                <>
+                  <Unlink className="h-3.5 w-3.5" />
+                  Unlink
+                </>
+              )}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </motion.div>
   );
 };


### PR DESCRIPTION
Add backend list/delete identity store functions, two user routes (GET/DELETE /rbac/users/:id/identities), an SSO_IDENTITY_UNLINK audit action, frontend ssoApi methods, and an SSO Identity card with unlink confirmation on the user Security tab.

## Description

SSO identity management on the user's Security tab: shows each linked provider with its email and last sign-in, and lets admins unlink an identity (`USERS_UPDATE`), with a warning that an SSO-only user will be locked out until their password is reset.

## Type of Change

<!-- Check all that apply -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Other (please describe):

## Related Issue
Closes #242 

## Changes Made

### Backend

- **`identity.ts`** — added `listUserIdentities(userId)` and `deleteUserIdentity(id)`.
- **`base.ts`** — added `AUDIT_ACTIONS.SSO_IDENTITY_UNLINK`.
- **`users.ts`** — two endpoints:
  - `GET /rbac/users/:id/identities` (`USERS_VIEW`) → returns `{ id, provider, displayName, email, createdAt, lastLoginAt }[]`, with `displayName` resolved from the live SSO config (falls back to the raw provider id if that provider was removed).
  - `DELETE /rbac/users/:id/identities/:identityId` (`USERS_UPDATE`) → verifies the identity belongs to the user, blocks super-admin modification by non-super-admins, deletes it, and audit-logs the unlink.

### Frontend

- **`rbac.ts`** — `SsoIdentityInfo` type + `rbacUsersApi.getIdentities()` / `unlinkIdentity()`.
- **`EditUser/index.tsx`** — a new SSO identity card in the Security tab showing each linked provider (name, "Linked" badge, email, last sign-in), an Unlink button gated on `USERS_UPDATE`, and a confirm dialog that warns an SSO-only user will be locked out until their password is reset. Shows "No SSO identity linked" when there are none.


## Testing
Extended `identity.test.ts` (list/delete) and `rbac.test.ts` (getIdentities/unlinkIdentity).

- [x] I have tested this locally
- [x] I have added/updated tests
- [x] All existing tests pass

## Screenshots

<img width="1082" height="697" alt="image" src="https://github.com/user-attachments/assets/68d915d0-c2c4-42eb-9cea-8310e7513979" />

<img width="1134" height="879" alt="image" src="https://github.com/user-attachments/assets/c34e2218-215a-49d6-ab4f-f1e7e9cc7f21" />


## Changelog Fragment

- [x] Added `changelogs/unreleased/<pr-number>-<slug>.md`

## Checklist

<!-- Check all that apply -->

- [x] My code follows the project's code style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have checked for breaking changes and documented them (if applicable)
- [x] I have tested the changes in the relevant environment (development/production)

## Additional Notes