### PR TITLE
feat(sso): log providers at startup and provider error detail on fail…

### DIFF
--- a/changelogs/unreleased/244-sso-observability.md
+++ b/changelogs/unreleased/244-sso-observability.md
@@ -1,0 +1,4 @@
+type: patch
+
+### Changed
+- **SSO logging is more diagnosable** — the server now logs the configured providers at startup (`SSO enabled — N provider(s) loaded` with id/type/display name, or `SSO disabled`), and start/callback failures now include the identity provider's own `error`, `error_description`, `code`, and `cause` instead of only the wrapped error message. No behaviour or API change; secrets are never logged.

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -301,6 +301,21 @@ initializeRbac().then(async () => {
   // is enabled in the UI; cheap to run (checks a config file every 60s).
   const { DoctorScheduler } = await import("./services/doctorScheduler");
   DoctorScheduler.getInstance().start();
+  // Warm the SSO config so the provider summary (or a config error) is logged
+  // at boot rather than lazily on the first login request. Isolated so an SSO
+  // misconfiguration can't take down the rest of startup.
+  try {
+    const { getSsoConfig } = await import("./rbac/sso/config");
+    const ssoConfig = getSsoConfig();
+    if (!ssoConfig.enabled) {
+      logger.info({ module: "SSO" }, "SSO disabled");
+    }
+  } catch (error) {
+    logger.error(
+      { module: "SSO", err: error instanceof Error ? error.message : String(error) },
+      "SSO configuration is invalid"
+    );
+  }
 }).catch((error) => {
   logger.error({ phase: "startup", err: error instanceof Error ? error.message : String(error) }, "Failed to initialize RBAC");
   // Continue without RBAC - it's optional for backward compatibility

--- a/packages/server/src/rbac/sso/config.ts
+++ b/packages/server/src/rbac/sso/config.ts
@@ -142,6 +142,20 @@ export function loadSsoConfig(env: Record<string, string | undefined> = process.
     providers.set(id, { ...parsed.data, id });
   }
 
+  // Startup summary so operators can confirm which providers loaded.
+  // Only non-secret fields (id/type/display name) are logged.
+  logger.info(
+    {
+      module: 'SSO',
+      providers: [...providers.values()].map((p) => ({
+        id: p.id,
+        type: p.type,
+        displayName: p.displayName,
+      })),
+    },
+    `SSO enabled — ${providers.size} provider(s) loaded`
+  );
+
   return {
     enabled: true,
     baseUrl,

--- a/packages/server/src/rbac/sso/errors.test.ts
+++ b/packages/server/src/rbac/sso/errors.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from "bun:test";
+import { describeSsoError } from "./errors";
+
+describe("describeSsoError", () => {
+  it("extracts oauth fields from a ResponseBodyError-like error", () => {
+    const err = Object.assign(new Error("authorization response error"), {
+      code: "OAUTH_RESPONSE_BODY_ERROR",
+      error: "invalid_grant",
+      error_description: "Malformed auth code.",
+    });
+
+    expect(describeSsoError(err)).toEqual({
+      err: "authorization response error",
+      code: "OAUTH_RESPONSE_BODY_ERROR",
+      oauthError: "invalid_grant",
+      oauthErrorDescription: "Malformed auth code.",
+    });
+  });
+
+  it("captures a nested Error cause", () => {
+    const err = new Error("discovery failed", { cause: new Error("ENOTFOUND accounts.google.com") });
+    const result = describeSsoError(err);
+    expect(result.err).toBe("discovery failed");
+    expect(result.cause).toBe("ENOTFOUND accounts.google.com");
+  });
+
+  it("captures a string cause", () => {
+    const err = Object.assign(new Error("boom"), { cause: "raw cause string" });
+    expect(describeSsoError(err).cause).toBe("raw cause string");
+  });
+
+  it("returns just the message for a plain Error with no extra fields", () => {
+    expect(describeSsoError(new Error("plain"))).toEqual({ err: "plain" });
+  });
+
+  it("ignores non-string structured fields", () => {
+    const err = Object.assign(new Error("x"), { code: 500, error: { nested: true } });
+    expect(describeSsoError(err)).toEqual({ err: "x" });
+  });
+
+  it("stringifies a non-Error value", () => {
+    expect(describeSsoError("just a string")).toEqual({ err: "just a string" });
+    expect(describeSsoError(undefined)).toEqual({ err: "undefined" });
+  });
+});

--- a/packages/server/src/rbac/sso/errors.ts
+++ b/packages/server/src/rbac/sso/errors.ts
@@ -1,0 +1,30 @@
+/**
+ * SSO Error Description
+ *
+ * openid-client (via oauth4webapi) wraps provider failures in structured
+ * errors whose `.message` is generic while the real reason lives in
+ * `error` (e.g. "invalid_grant"), `error_description`, `code`, and `cause`.
+ * This flattens whatever is present into a loggable object so SSO failures
+ * carry the identity provider's own diagnostics. Never returns secrets.
+ */
+export function describeSsoError(error: unknown): Record<string, unknown> {
+  if (!(error instanceof Error)) {
+    return { err: String(error) };
+  }
+
+  // The structured fields are non-standard library properties; read them
+  // defensively (every access is typeof-guarded below).
+  const e = error as Error & Record<string, unknown>;
+  const out: Record<string, unknown> = { err: error.message };
+
+  if (typeof e.code === "string") out.code = e.code;
+  if (typeof e.error === "string") out.oauthError = e.error;
+  if (typeof e.error_description === "string") {
+    out.oauthErrorDescription = e.error_description;
+  }
+
+  if (error.cause instanceof Error) out.cause = error.cause.message;
+  else if (typeof error.cause === "string") out.cause = error.cause;
+
+  return out;
+}

--- a/packages/server/src/rbac/sso/routes.ts
+++ b/packages/server/src/rbac/sso/routes.ts
@@ -9,6 +9,7 @@ import { z } from "zod";
 import { getSsoConfig } from "./config";
 import { buildAuthorizationRedirect, exchangeCodeForIdentity } from "./client";
 import { provisionSsoUser } from "./service";
+import { describeSsoError } from "./errors";
 import {
   signStatePayload,
   verifyStatePayload,
@@ -80,11 +81,7 @@ ssoRoutes.get("/:provider/start", async (c) => {
   } catch (error) {
     // Discovery/metadata failure: degrade gracefully, never crash the server.
     requestLogger(c.get("requestId")).error(
-      {
-        module: "SSO",
-        provider: provider.id,
-        err: error instanceof Error ? error.message : String(error),
-      },
+      { module: "SSO", provider: provider.id, ...describeSsoError(error) },
       "SSO provider discovery failed"
     );
     return c.redirect(
@@ -201,12 +198,14 @@ ssoRoutes.post("/callback", zValidator("json", CallbackSchema), async (c) => {
       },
     });
   } catch (error) {
+    // Flatten the provider's own diagnostics once; reuse for audit + log.
+    const detail = describeSsoError(error);
     await createAuditLogWithContext(
       c,
       AUDIT_ACTIONS.SSO_LOGIN_FAILED,
       undefined,
       {
-        details: { provider: payload?.provider ?? "unknown" },
+        details: { provider: payload?.provider ?? "unknown", ...detail },
         ipAddress,
         status: "failure",
         errorMessage:
@@ -215,11 +214,7 @@ ssoRoutes.post("/callback", zValidator("json", CallbackSchema), async (c) => {
     );
     // Warn with provider context for ALL failures, AppError or not.
     requestLogger(c.get("requestId")).warn(
-      {
-        module: "SSO",
-        provider: payload?.provider ?? "unknown",
-        err: error instanceof Error ? error.message : String(error),
-      },
+      { module: "SSO", provider: payload?.provider ?? "unknown", ...detail },
       "SSO callback failed"
     );
     if (error instanceof AppError) throw error;


### PR DESCRIPTION
## Description

Makes SSO failures and config load self-diagnosable in the server logs. No API or behavior change; secrets are never logged.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [x] Other (please describe): Observability / logging improvement (patch)

## Related Issue

Closes #244 

## Changes Made

- Add `describeSsoError()` (`sso/errors.ts`) that flattens the identity provider's own diagnostics (`error`, `error_description`, `code`, `cause`) from openid-client errors. Previously only the wrapped `error.message` was logged, so callback failures showed a generic message with no provider detail.
- Use it at both SSO catch sites in `sso/routes.ts`: provider discovery failure (`/start`) and code-exchange/userinfo failure (`/callback`). The callback also folds the detail into the audit log `details`, so the reason is visible in Admin, Audit.
- Log a non-secret provider summary when SSO config loads (`sso/config.ts`): `SSO enabled - N provider(s) loaded` with each provider's id, type, and display name. Successfully loaded providers were never logged before, only the per-provider error on a dropped provider.
- Eager-load the SSO config at boot (`index.ts`), inside its own try/catch, so the summary (or a config error) appears at startup instead of lazily on the first login request. Logs `SSO disabled` when off.

## Testing

- [x] I have tested this locally
- [x] I have added/updated tests
- [x] All existing tests pass

### Test Steps

1. `cd packages/server && bun test src/rbac/sso/errors.test.ts` (6 new tests pass).
2. `bun run typecheck` and `bun run lint` are clean.
3. `./scripts/test-isolated-server.sh` passes (52/52).
4. Deployed to production with Google SSO. The startup summary listed the provider, and a failing Google login surfaced the exact provider cause in the callback log, which pinpointed an issuer mismatch that the old generic message hid. Switching the provider to `type: oidc` then resolved the login.

## Screenshots

Startup summary (new), no secrets:

    {"level":"info","module":"SSO","providers":[{"id":"google","type":"oidc","displayName":"Google"}],"msg":"SSO enabled — 1 provider(s) loaded"}

Callback failure before this change (generic, no provider detail):

    {"level":"warn","module":"SSO","provider":"google","err":"invalid response encountered","msg":"SSO callback failed"}

Callback failure after this change (provider code + cause exposed):

    {"level":"warn","module":"SSO","provider":"google","err":"invalid response encountered","code":"OAUTH_INVALID_RESPONSE","cause":"unexpected \"iss\" (issuer) response parameter value","msg":"SSO callback failed"}

## Changelog Fragment

- [x] Added `changelogs/unreleased/244-sso-observability.md`

## Checklist

- [x] My code follows the project's code style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have checked for breaking changes and documented them (if applicable)
- [x] I have tested the changes in the relevant environment (development/production)

## Additional Notes

The fragment is `type: patch`; No user-facing UI or API changes;