### PR TITLE
feat(admin): refresh roles/admin UI, fix role label bugs, polish preferences

### DIFF
--- a/changelogs/unreleased/247-admin-roles-ui-refresh.md
+++ b/changelogs/unreleased/247-admin-roles-ui-refresh.md
@@ -1,0 +1,15 @@
+type: minor
+
+### Added
+- **Role wizard** — Creating or editing a role is now a guided 3-step wizard (Details → Permissions → Data Access & Review), matching the Data Access Policies flow.
+- **Data Access on role cards** — Each role card surfaces its assigned data access policies: a count badge in the stat row and named policy chips in the expanded view.
+- **Roles in Identity & access** — The Preferences Identity & access card now lists the signed-in user's roles.
+
+### Changed
+- **Admin navigation** — The Admin header is now a two-tier nav: grouped section chips on top with the active group's sections shown below as sub-tabs.
+- **Data Access section header** — Now uses the standard icon + title + count header to match the other admin sections.
+- **Preferences cards** — Row-one cards are equal height; the ClickHouse node rows align the card with Identity & access. Monitoring's title and refresh controls gained breathing room from the header divider.
+
+### Fixed
+- **"Other" permission label** — `data_access` permissions now display as "Data Access" instead of "Other" on role cards.
+- **Inconsistent role labels** — User-list cards always show a readable role display name instead of occasionally leaking the raw role key.

--- a/src/features/admin/components/DataAccessPolicies/index.tsx
+++ b/src/features/admin/components/DataAccessPolicies/index.tsx
@@ -340,12 +340,16 @@ export const DataAccessPolicies: React.FC = () => {
   return (
     <div className="space-y-4 p-4">
       <div className="flex items-center justify-between">
-        <div className="flex flex-col gap-1">
-          <span className="inline-flex items-center gap-2 font-mono text-[10px] uppercase tracking-[0.18em] text-paper-dim">
-            <span className="h-px w-6 bg-ink-700" />
-            <span>Data access policies</span>
+        <div className="flex items-center gap-3">
+          <span className="grid h-9 w-9 place-items-center rounded-xs border border-ink-500 bg-ink-100 text-paper-muted">
+            <Database className="h-4 w-4" aria-hidden />
           </span>
-          <p className="text-[12px] text-paper-muted">Reusable database/table access rules attached to roles.</p>
+          <div className="flex flex-col gap-0.5">
+            <h2 className="text-[18px] font-semibold tracking-tight text-paper">Data access policies</h2>
+            <p className="font-mono text-[10px] uppercase tracking-[0.14em] text-paper-faint">
+              {policies?.length ?? 0} polic{(policies?.length ?? 0) === 1 ? 'y' : 'ies'} defined
+            </p>
+          </div>
         </div>
         {canCreate && (
           <Button size="sm" onClick={openCreate} className="h-9 gap-2 rounded-xs bg-brand px-3 font-mono text-[11px] font-semibold uppercase tracking-[0.14em] text-ink-50 hover:bg-brand-soft">

--- a/src/features/admin/components/UserManagement/index.tsx
+++ b/src/features/admin/components/UserManagement/index.tsx
@@ -268,11 +268,17 @@ const UserManagement: React.FC = () => {
 
   const hasActiveFilters = searchQuery.trim() !== "" || roleFilter !== "all" || statusFilter !== "all";
 
-  // Get role display info
+  // Get role display info. Always resolves to a display-name-style label: the
+  // role's real displayName when known, otherwise the raw name humanised
+  // (snake_case → Title Case) so a card never falls back to the raw role key.
   const getRoleDisplay = (roleName: string) => {
     const role = roles.find((r) => r.name === roleName);
+    const humanised = roleName
+      .split("_")
+      .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+      .join(" ");
     return {
-      displayName: role?.displayName || roleName,
+      displayName: role?.displayName || humanised,
       code: ROLE_CODES[roleName] || roleName.slice(0, 2).toUpperCase(),
     };
   };

--- a/src/features/rbac/components/RbacRolesTable.tsx
+++ b/src/features/rbac/components/RbacRolesTable.tsx
@@ -5,7 +5,7 @@
  * Beautiful, interactive UI with smooth animations.
  */
 
-import React, { useState } from 'react';
+import React, { useState, useMemo } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import {
   Shield,
@@ -20,6 +20,7 @@ import {
   ChevronRight,
   Sparkles,
   CheckCircle2,
+  Database,
 } from 'lucide-react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
@@ -49,7 +50,7 @@ import {
 import { Skeleton } from '@/components/ui/skeleton';
 import ConfirmationDialog from '@/components/common/ConfirmationDialog';
 
-import { rbacRolesApi, type RbacRole } from '@/api/rbac';
+import { rbacRolesApi, rbacDataAccessPoliciesApi, type RbacRole } from '@/api/rbac';
 import { useRbacStore, RBAC_PERMISSIONS } from '@/stores/rbac';
 import { cn } from '@/lib/utils';
 import { RoleFormDialog } from './RoleFormDialog';
@@ -107,6 +108,7 @@ const PERMISSION_CATEGORIES: Record<string, string> = {
   'live_queries': 'Live Queries',
   'ai': 'AI Assistant',
   'ai_models': 'AI Models',
+  'data_access': 'Data Access',
 };
 
 const getPermissionCategory = (permission: string): string => {
@@ -145,6 +147,20 @@ export const RbacRolesTable: React.FC<RbacRolesTableProps> = ({
     queryKey: ['rbac-roles'],
     queryFn: () => rbacRolesApi.list(),
   });
+
+  // Data access policies — to resolve the names of policies attached to a role.
+  // Gated on permission so users who can see roles but not policies don't 403.
+  const { data: policies = [] } = useQuery({
+    queryKey: ['rbac-data-access-policies'],
+    queryFn: () => rbacDataAccessPoliciesApi.list(),
+    enabled: hasPermission(RBAC_PERMISSIONS.DATA_ACCESS_VIEW),
+  });
+
+  const policyNameById = useMemo(() => {
+    const map = new Map<string, string>();
+    policies.forEach((policy) => map.set(policy.id, policy.name));
+    return map;
+  }, [policies]);
 
   // Mutation
   const deleteMutation = useMutation({
@@ -255,6 +271,10 @@ export const RbacRolesTable: React.FC<RbacRolesTableProps> = ({
               const style = getRoleStyle(role.name);
               const isExpanded = expandedRoles.has(role.id);
               const groupedPermissions = groupPermissions(role.permissions);
+              const policyCount = role.dataAccessPolicyIds.length;
+              const rolePolicies = role.dataAccessPolicyIds
+                .map((id) => policyNameById.get(id))
+                .filter((name): name is string => !!name);
 
               return (
                 <motion.div
@@ -315,6 +335,13 @@ export const RbacRolesTable: React.FC<RbacRolesTableProps> = ({
                             <span className="text-paper">{role.permissions.length}</span>
                             <span className="uppercase tracking-[0.14em] text-paper-faint">perms</span>
                           </span>
+                          {policyCount > 0 && (
+                            <span className="inline-flex items-center gap-1.5 rounded-xs border border-ink-500 bg-ink-200 px-2 py-1 font-mono text-[11px]">
+                              <Database className="h-3 w-3 text-paper-dim" />
+                              <span className="text-paper">{policyCount}</span>
+                              <span className="uppercase tracking-[0.14em] text-paper-faint">access</span>
+                            </span>
+                          )}
                         </div>
 
                         {/* Actions */}
@@ -363,7 +390,7 @@ export const RbacRolesTable: React.FC<RbacRolesTableProps> = ({
                         animate={{ height: 'auto', opacity: 1 }}
                         exit={{ height: 0, opacity: 0 }}
                         transition={{ duration: 0.3 }}
-                        className="px-5 pb-5 pt-0"
+                        className="space-y-4 px-5 pb-5 pt-0"
                       >
                         <div className="p-5 rounded-xs bg-ink-200 border border-ink-500 space-y-4">
                           <div className="flex items-center gap-2">
@@ -396,6 +423,33 @@ export const RbacRolesTable: React.FC<RbacRolesTableProps> = ({
                             ))}
                           </div>
                         </div>
+
+                        {/* Data access — policies attached to this role */}
+                        {policyCount > 0 && (
+                          <div className="p-5 rounded-xs bg-ink-200 border border-ink-500 space-y-3">
+                            <div className="flex items-center gap-2">
+                              <Database className="h-4 w-4 text-brand" />
+                              <h4 className="text-sm font-semibold text-paper">Data access</h4>
+                            </div>
+                            {rolePolicies.length > 0 ? (
+                              <div className="flex flex-wrap gap-1.5">
+                                {rolePolicies.map((name) => (
+                                  <span
+                                    key={name}
+                                    className="inline-flex items-center gap-1.5 rounded-xs border border-ink-500 bg-ink-100 px-2 py-0.5 font-mono text-[11px] text-paper-muted transition-colors hover:border-ink-700 hover:text-paper"
+                                  >
+                                    <Database className="h-3 w-3 text-paper-faint" />
+                                    {name}
+                                  </span>
+                                ))}
+                              </div>
+                            ) : (
+                              <p className="font-mono text-[11px] uppercase tracking-[0.14em] text-paper-faint">
+                                {policyCount} polic{policyCount === 1 ? 'y' : 'ies'} attached
+                              </p>
+                            )}
+                          </div>
+                        )}
                       </motion.div>
                     </CollapsibleContent>
                   </Collapsible>

--- a/src/features/rbac/components/RoleFormDialog.tsx
+++ b/src/features/rbac/components/RoleFormDialog.tsx
@@ -1,10 +1,3 @@
-/**
- * Role Form Dialog Component
- * 
- * Dialog for creating and editing RBAC roles with permission selection.
- * Beautiful, interactive UI with smooth animations.
- */
-
 import React, { useState, useEffect, useMemo } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
@@ -22,7 +15,6 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
 import { Checkbox } from '@/components/ui/checkbox';
-import { ScrollArea } from '@/components/ui/scroll-area';
 import { Skeleton } from '@/components/ui/skeleton';
 import {
   Collapsible,
@@ -39,6 +31,11 @@ import {
   ChevronsDown,
   ChevronsUp,
   Users,
+  ArrowLeft,
+  ArrowRight,
+  Check,
+  Loader2,
+  Database,
 } from 'lucide-react';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 
@@ -50,7 +47,6 @@ import {
   type CreateRoleInput,
   type UpdateRoleInput,
 } from '@/api/rbac';
-import { Database } from 'lucide-react';
 import { useRbacStore, RBAC_PERMISSIONS } from '@/stores/rbac';
 import { cn } from '@/lib/utils';
 
@@ -61,7 +57,7 @@ import { cn } from '@/lib/utils';
 interface RoleFormDialogProps {
   isOpen: boolean;
   onClose: () => void;
-  role?: RbacRole | null; // null = create mode, RbacRole = edit mode
+  role?: RbacRole | null;
   onSuccess?: () => void;
 }
 
@@ -78,11 +74,13 @@ export const RoleFormDialog: React.FC<RoleFormDialogProps> = ({
   const queryClient = useQueryClient();
   const { hasPermission, isSuperAdmin } = useRbacStore();
 
-  // Permissions
   const canCreate = hasPermission(RBAC_PERMISSIONS.ROLES_CREATE);
   const canUpdate = hasPermission(RBAC_PERMISSIONS.ROLES_UPDATE);
 
-  // State
+  // Step state (1 = Details, 2 = Permissions, 3 = Data Access & Review)
+  const [step, setStep] = useState<1 | 2 | 3>(1);
+
+  // Form state
   const [name, setName] = useState('');
   const [displayName, setDisplayName] = useState('');
   const [description, setDescription] = useState('');
@@ -92,24 +90,20 @@ export const RoleFormDialog: React.FC<RoleFormDialogProps> = ({
   const [expandedCategories, setExpandedCategories] = useState<Set<string>>(new Set());
   const [searchQuery, setSearchQuery] = useState('');
 
-  // Fetch permissions
   const { data: permissionsByCategory, isLoading: loadingPermissions } = useQuery({
     queryKey: ['rbac-permissions-by-category'],
     queryFn: () => rbacRolesApi.getPermissionsByCategory(),
     enabled: isOpen,
   });
 
-  // Fetch data access policies
   const { data: policies } = useQuery({
     queryKey: ['rbac-data-access-policies'],
     queryFn: () => rbacDataAccessPoliciesApi.list(),
     enabled: isOpen,
   });
 
-  // Create a mapping from permission names to IDs
   const permissionNameToIdMap = useMemo(() => {
     if (!permissionsByCategory) return new Map<string, string>();
-
     const map = new Map<string, string>();
     Object.values(permissionsByCategory).forEach((permissions) => {
       permissions.forEach((perm) => {
@@ -119,26 +113,20 @@ export const RoleFormDialog: React.FC<RoleFormDialogProps> = ({
     return map;
   }, [permissionsByCategory]);
 
-  // Initialize form when role changes
   useEffect(() => {
     if (isOpen) {
+      setStep(1);
       if (role) {
-        // Edit mode
         setName(role.name);
         setDisplayName(role.displayName);
         setDescription(role.description || '');
-
-        // Map permission names to IDs
-        // role.permissions contains permission names, but we need IDs
         const permissionIds = role.permissions
           .map((permName) => permissionNameToIdMap.get(permName))
           .filter((id): id is string => id !== undefined);
-
         setSelectedPermissionIds(new Set(permissionIds));
         setSelectedPolicyIds(new Set(role.dataAccessPolicyIds || []));
         setIsDefault(role.isDefault);
       } else {
-        // Create mode
         setName('');
         setDisplayName('');
         setDescription('');
@@ -147,14 +135,12 @@ export const RoleFormDialog: React.FC<RoleFormDialogProps> = ({
         setIsDefault(false);
       }
       setSearchQuery('');
-      // Expand all categories by default
       if (permissionsByCategory) {
         setExpandedCategories(new Set(Object.keys(permissionsByCategory)));
       }
     }
   }, [isOpen, role, permissionsByCategory, permissionNameToIdMap]);
 
-  // Mutations
   const createMutation = useMutation({
     mutationFn: (input: CreateRoleInput) => rbacRolesApi.create(input),
     onSuccess: () => {
@@ -186,30 +172,25 @@ export const RoleFormDialog: React.FC<RoleFormDialogProps> = ({
     },
   });
 
-  // Validation
   const isEditing = !!role;
   const isSystemRole = role?.isSystem || false;
   const canEditSystemRole = isSuperAdmin();
   const canModify = isEditing ? (isSystemRole ? canEditSystemRole : canUpdate) : canCreate;
-
-  // Custom (non-system) roles are the primary way to grant data access and must
-  // attach at least one policy. System roles are exempt (admin/super_admin bypass access).
   const requiresPolicy = !isSystemRole;
-  const isValid =
-    (isEditing ? true : name.trim().length >= 2) &&
-    displayName.trim().length >= 2 &&
-    selectedPermissionIds.size > 0 &&
-    (!requiresPolicy || selectedPolicyIds.size > 0);
 
-  // Filter permissions by search query
+  // Per-step validation
+  const step1Valid = isEditing
+    ? displayName.trim().length >= 2
+    : name.trim().length >= 2 && displayName.trim().length >= 2;
+  const step2Valid = selectedPermissionIds.size > 0;
+  const step3Valid = !requiresPolicy || selectedPolicyIds.size > 0;
+
   const filteredCategories = React.useMemo(() => {
     if (!permissionsByCategory || !searchQuery.trim()) {
       return permissionsByCategory || {};
     }
-
     const query = searchQuery.toLowerCase();
     const filtered: Record<string, RbacPermission[]> = {};
-
     Object.entries(permissionsByCategory).forEach(([category, permissions]) => {
       const matching = permissions.filter(
         (p) =>
@@ -217,23 +198,16 @@ export const RoleFormDialog: React.FC<RoleFormDialogProps> = ({
           p.name.toLowerCase().includes(query) ||
           (p.description && p.description.toLowerCase().includes(query))
       );
-      if (matching.length > 0) {
-        filtered[category] = matching;
-      }
+      if (matching.length > 0) filtered[category] = matching;
     });
-
     return filtered;
   }, [permissionsByCategory, searchQuery]);
 
-  // Handlers
   const toggleCategory = (category: string) => {
     setExpandedCategories((prev) => {
       const newSet = new Set(prev);
-      if (newSet.has(category)) {
-        newSet.delete(category);
-      } else {
-        newSet.add(category);
-      }
+      if (newSet.has(category)) newSet.delete(category);
+      else newSet.add(category);
       return newSet;
     });
   };
@@ -242,11 +216,8 @@ export const RoleFormDialog: React.FC<RoleFormDialogProps> = ({
     if (!canModify) return;
     setSelectedPermissionIds((prev) => {
       const newSet = new Set(prev);
-      if (newSet.has(permissionId)) {
-        newSet.delete(permissionId);
-      } else {
-        newSet.add(permissionId);
-      }
+      if (newSet.has(permissionId)) newSet.delete(permissionId);
+      else newSet.add(permissionId);
       return newSet;
     });
   };
@@ -265,14 +236,10 @@ export const RoleFormDialog: React.FC<RoleFormDialogProps> = ({
     if (!canModify || !filteredCategories) return;
     const categoryPermissions = filteredCategories[category] || [];
     const allSelected = categoryPermissions.every((p) => selectedPermissionIds.has(p.id));
-
     setSelectedPermissionIds((prev) => {
       const newSet = new Set(prev);
-      if (allSelected) {
-        categoryPermissions.forEach((p) => newSet.delete(p.id));
-      } else {
-        categoryPermissions.forEach((p) => newSet.add(p.id));
-      }
+      if (allSelected) categoryPermissions.forEach((p) => newSet.delete(p.id));
+      else categoryPermissions.forEach((p) => newSet.add(p.id));
       return newSet;
     });
   };
@@ -281,14 +248,10 @@ export const RoleFormDialog: React.FC<RoleFormDialogProps> = ({
     if (!canModify || !filteredCategories) return;
     const allPermissions = Object.values(filteredCategories).flat();
     const allSelected = allPermissions.every((p) => selectedPermissionIds.has(p.id));
-
     setSelectedPermissionIds((prev) => {
       const newSet = new Set(prev);
-      if (allSelected) {
-        allPermissions.forEach((p) => newSet.delete(p.id));
-      } else {
-        allPermissions.forEach((p) => newSet.add(p.id));
-      }
+      if (allSelected) allPermissions.forEach((p) => newSet.delete(p.id));
+      else allPermissions.forEach((p) => newSet.add(p.id));
       return newSet;
     });
   };
@@ -297,25 +260,16 @@ export const RoleFormDialog: React.FC<RoleFormDialogProps> = ({
     if (!filteredCategories) return;
     const categoryKeys = Object.keys(filteredCategories);
     const allExpanded = categoryKeys.every((key) => expandedCategories.has(key));
-
-    if (allExpanded) {
-      // Collapse all
-      setExpandedCategories(new Set());
-    } else {
-      // Expand all
-      setExpandedCategories(new Set(categoryKeys));
-    }
+    setExpandedCategories(allExpanded ? new Set() : new Set(categoryKeys));
   };
 
   const handleSubmit = () => {
-    if (!isValid || !canModify) return;
+    if (!step3Valid || !canModify) return;
 
     const permissionIds = Array.from(selectedPermissionIds);
     const dataAccessPolicyIds = Array.from(selectedPolicyIds);
 
     if (isEditing && role) {
-      // Update role — always persist the selected policies (system roles can carry
-      // policies too; the >=1 requirement is only enforced for non-system roles).
       const input: UpdateRoleInput = {
         displayName: displayName.trim(),
         description: description.trim() || null,
@@ -325,7 +279,6 @@ export const RoleFormDialog: React.FC<RoleFormDialogProps> = ({
       };
       updateMutation.mutate({ id: role.id, input });
     } else {
-      // Create role
       const input: CreateRoleInput = {
         name: name.trim(),
         displayName: displayName.trim(),
@@ -342,14 +295,26 @@ export const RoleFormDialog: React.FC<RoleFormDialogProps> = ({
   const totalPermissions = Object.values(filteredCategories || {}).flat().length;
   const selectedCount = selectedPermissionIds.size;
   const allSelected = totalPermissions > 0 && selectedCount === totalPermissions;
-
-  // Determine if all categories are expanded
   const categoryKeys = filteredCategories ? Object.keys(filteredCategories) : [];
   const allExpanded = categoryKeys.length > 0 && categoryKeys.every((key) => expandedCategories.has(key));
 
+  // Summary for step 3 review
+  const permissionSummaryByCategory = useMemo(() => {
+    if (!permissionsByCategory) return [];
+    return Object.entries(permissionsByCategory)
+      .map(([category, perms]) => ({
+        category,
+        selected: perms.filter((p) => selectedPermissionIds.has(p.id)).length,
+        total: perms.length,
+      }))
+      .filter((c) => c.selected > 0);
+  }, [permissionsByCategory, selectedPermissionIds]);
+
+  const STEPS = ['Details', 'Permissions', 'Data Access'];
+
   return (
     <Dialog open={isOpen} onOpenChange={onClose}>
-      <DialogContent className="max-w-5xl h-[90vh] flex flex-col p-0 rounded-xs border-ink-500 bg-ink-100 overflow-hidden">
+      <DialogContent className="flex max-h-[90vh] max-w-2xl flex-col overflow-hidden rounded-xs border-ink-500 bg-ink-100 p-0">
         <DialogHeader className="flex-shrink-0 px-6 pt-6 pb-4 border-b border-ink-500">
           <DialogTitle asChild>
             <div className="flex items-center gap-3">
@@ -372,22 +337,51 @@ export const RoleFormDialog: React.FC<RoleFormDialogProps> = ({
               )}
             </div>
           </DialogTitle>
-          <DialogDescription className="mt-2 text-[12px] text-paper-muted">
-            {isEditing
-              ? 'Update role details and permissions. System roles can only be modified by super admins.'
-              : 'Create a new custom role with specific permissions.'}
+          <DialogDescription className="mt-1 text-[12px] text-paper-muted">
+            {step === 1 && 'Step 1 of 3 — set the role name and basic details.'}
+            {step === 2 && 'Step 2 of 3 — choose which permissions this role grants.'}
+            {step === 3 && 'Step 3 of 3 — assign data access policies and review.'}
           </DialogDescription>
+
+          {/* Stepper */}
+          <div className="mt-3 flex items-center gap-2 px-1">
+            {STEPS.map((label, i) => {
+              const n = (i + 1) as 1 | 2 | 3;
+              return (
+                <div key={label} className="flex items-center gap-2">
+                  <span
+                    className={cn(
+                      'grid h-5 w-5 place-items-center rounded-full font-mono text-[10px]',
+                      step === n
+                        ? 'bg-brand text-ink-50'
+                        : step > n
+                          ? 'bg-emerald-600 text-ink-50'
+                          : 'bg-ink-300 text-paper-faint'
+                    )}
+                  >
+                    {step > n ? <Check className="h-3 w-3" /> : n}
+                  </span>
+                  <span
+                    className={cn(
+                      'font-mono text-[10px] uppercase tracking-[0.14em]',
+                      step === n ? 'text-paper' : 'text-paper-faint'
+                    )}
+                  >
+                    {label}
+                  </span>
+                  {n < 3 && <span className="mx-1 h-px w-4 bg-ink-500" />}
+                </div>
+              );
+            })}
+          </div>
         </DialogHeader>
 
-        <ScrollArea className="flex-1 min-h-0 px-6">
-          <div className="py-4">
-            <motion.div
-              initial={{ opacity: 0, y: 10 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ delay: 0.1 }}
-              className="space-y-6"
-            >
-              {/* System Role Warning */}
+        {/* Step content */}
+        <div className="min-h-0 flex-1 overflow-y-auto px-6 py-4">
+
+          {/* ── Step 1: Details ── */}
+          {step === 1 && (
+            <div className="space-y-4">
               <AnimatePresence>
                 {isEditing && isSystemRole && !canEditSystemRole && (
                   <motion.div
@@ -404,342 +398,326 @@ export const RoleFormDialog: React.FC<RoleFormDialogProps> = ({
                 )}
               </AnimatePresence>
 
-              {/* Basic Information */}
-              <motion.div
-                initial={{ opacity: 0, y: 10 }}
-                animate={{ opacity: 1, y: 0 }}
-                transition={{ delay: 0.15 }}
-                className="space-y-4 rounded-xs border border-ink-500 bg-ink-100 p-4"
-              >
-                <div className="flex items-center justify-between">
-                  <span className="inline-flex items-center gap-2 font-mono text-[10px] uppercase tracking-[0.18em] text-paper-dim">
-                    <span className="h-px w-6 bg-ink-700" aria-hidden />
-                    <span>Basic information</span>
+              {isEditing && role && (
+                <div className="flex items-center justify-end">
+                  <span className="inline-flex items-center gap-1.5 rounded-xs border border-ink-500 bg-ink-200 px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-[0.14em] text-paper-muted">
+                    <Users className="h-3 w-3 text-paper-dim" aria-hidden />
+                    <span>{role.userCount || 0} users assigned</span>
                   </span>
-                  {isEditing && role && (
-                    <span className="inline-flex items-center gap-1.5 rounded-xs border border-ink-500 bg-ink-200 px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-[0.14em] text-paper-muted">
-                      <Users className="h-3 w-3 text-paper-dim" aria-hidden />
-                      <span>{role.userCount || 0} users assigned</span>
-                    </span>
-                  )}
                 </div>
+              )}
 
-                {/* Name (only for create) */}
-                {!isEditing && (
-                  <div className="space-y-2">
-                    <Label htmlFor="name" className="font-mono text-[10px] uppercase tracking-[0.14em] text-paper-dim">
-                      Role name <span className="text-red-400">*</span>
-                    </Label>
-                    <Input
-                      id="name"
-                      value={name}
-                      onChange={(e) => setName(e.target.value)}
-                      placeholder="e.g., custom_role"
-                      disabled={!canModify}
-                      className="rounded-xs border-ink-500 bg-ink-200 text-paper placeholder:text-paper-faint focus-visible:border-brand focus-visible:ring-0"
-                    />
-                    <p className="text-[11px] text-paper-faint">
-                      Must start with a letter and contain only letters, numbers, underscores, and hyphens.
-                      This cannot be changed after creation.
-                    </p>
-                  </div>
-                )}
-
-                {/* Display Name */}
+              {!isEditing && (
                 <div className="space-y-2">
-                  <Label htmlFor="displayName" className="font-mono text-[10px] uppercase tracking-[0.14em] text-paper-dim">
-                    Display name <span className="text-red-400">*</span>
+                  <Label htmlFor="name" className="font-mono text-[10px] uppercase tracking-[0.14em] text-paper-dim">
+                    Role name <span className="text-red-400">*</span>
                   </Label>
                   <Input
-                    id="displayName"
-                    value={displayName}
-                    onChange={(e) => setDisplayName(e.target.value)}
-                    placeholder="e.g., Custom Role"
+                    id="name"
+                    value={name}
+                    onChange={(e) => setName(e.target.value)}
+                    placeholder="e.g., custom_role"
                     disabled={!canModify}
                     className="rounded-xs border-ink-500 bg-ink-200 text-paper placeholder:text-paper-faint focus-visible:border-brand focus-visible:ring-0"
                   />
+                  <p className="text-[11px] text-paper-faint">
+                    Must start with a letter and contain only letters, numbers, underscores, and hyphens.
+                    Cannot be changed after creation.
+                  </p>
                 </div>
+              )}
 
-                {/* Description */}
+              <div className="space-y-2">
+                <Label htmlFor="displayName" className="font-mono text-[10px] uppercase tracking-[0.14em] text-paper-dim">
+                  Display name <span className="text-red-400">*</span>
+                </Label>
+                <Input
+                  id="displayName"
+                  value={displayName}
+                  onChange={(e) => setDisplayName(e.target.value)}
+                  placeholder="e.g., Custom Role"
+                  disabled={!canModify}
+                  className="rounded-xs border-ink-500 bg-ink-200 text-paper placeholder:text-paper-faint focus-visible:border-brand focus-visible:ring-0"
+                />
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="description" className="font-mono text-[10px] uppercase tracking-[0.14em] text-paper-dim">
+                  Description
+                </Label>
+                <Textarea
+                  id="description"
+                  value={description}
+                  onChange={(e) => setDescription(e.target.value)}
+                  placeholder="Describe the role's purpose and responsibilities..."
+                  disabled={!canModify}
+                  rows={3}
+                  className="resize-none rounded-xs border-ink-500 bg-ink-200 text-paper placeholder:text-paper-faint focus-visible:border-brand focus-visible:ring-0"
+                />
+              </div>
+
+              <div className="flex items-center gap-3 rounded-xs border border-ink-500 bg-ink-200 p-3">
+                <Checkbox
+                  id="isDefault"
+                  checked={isDefault}
+                  onCheckedChange={(checked) => setIsDefault(checked === true)}
+                  disabled={!canModify}
+                  className="border-ink-500 data-[state=checked]:border-brand data-[state=checked]:bg-brand data-[state=checked]:text-ink-50"
+                />
+                <Label htmlFor="isDefault" className="cursor-pointer text-[12px] text-paper">
+                  Set as default role for new users
+                </Label>
+              </div>
+            </div>
+          )}
+
+          {/* ── Step 2: Permissions ── */}
+          {step === 2 && (
+            <div className="space-y-4">
+              <div className="flex items-center justify-between">
+                <span className="inline-flex items-center gap-2 font-mono text-[10px] uppercase tracking-[0.18em] text-paper-dim">
+                  <span className="h-px w-6 bg-ink-700" aria-hidden />
+                  <span>Permissions</span>
+                  <span className="text-red-400">*</span>
+                </span>
+                <div className="flex items-center gap-2">
+                  {selectedCount > 0 && (
+                    <span className="inline-flex items-center gap-1 rounded-xs border border-brand/40 px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-[0.14em] text-brand">
+                      {selectedCount} selected
+                    </span>
+                  )}
+                  {categoryKeys.length > 0 && (
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="sm"
+                      onClick={handleToggleExpandAll}
+                      className="h-7 gap-1.5 rounded-xs px-2 font-mono text-[10px] uppercase tracking-[0.14em] text-paper-dim hover:bg-ink-200 hover:text-paper"
+                    >
+                      {allExpanded ? (
+                        <><ChevronsUp className="h-3.5 w-3.5" /> Collapse all</>
+                      ) : (
+                        <><ChevronsDown className="h-3.5 w-3.5" /> Expand all</>
+                      )}
+                    </Button>
+                  )}
+                  {canModify && totalPermissions > 0 && (
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="sm"
+                      onClick={handleSelectAll}
+                      className="h-7 rounded-xs px-2 font-mono text-[10px] uppercase tracking-[0.14em] text-paper-dim hover:bg-ink-200 hover:text-paper"
+                    >
+                      {allSelected ? 'Deselect all' : 'Select all'}
+                    </Button>
+                  )}
+                </div>
+              </div>
+
+              {!loadingPermissions && totalPermissions > 5 && (
+                <div className="relative">
+                  <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-paper-faint" aria-hidden />
+                  <Input
+                    placeholder="Search permissions"
+                    value={searchQuery}
+                    onChange={(e) => setSearchQuery(e.target.value)}
+                    className="h-9 rounded-xs border-ink-500 bg-ink-200 pl-9 pr-9 font-mono text-[12px] text-paper placeholder:text-paper-faint focus-visible:border-brand focus-visible:ring-0"
+                  />
+                  {searchQuery && (
+                    <button
+                      onClick={() => setSearchQuery('')}
+                      className="absolute right-3 top-1/2 -translate-y-1/2 text-paper-faint transition-colors hover:text-paper"
+                      aria-label="Clear search"
+                    >
+                      <X className="h-4 w-4" />
+                    </button>
+                  )}
+                </div>
+              )}
+
+              {loadingPermissions ? (
                 <div className="space-y-2">
-                  <Label htmlFor="description" className="font-mono text-[10px] uppercase tracking-[0.14em] text-paper-dim">
-                    Description
-                  </Label>
-                  <Textarea
-                    id="description"
-                    value={description}
-                    onChange={(e) => setDescription(e.target.value)}
-                    placeholder="Describe the role's purpose and responsibilities..."
-                    disabled={!canModify}
-                    rows={3}
-                    className="resize-none rounded-xs border-ink-500 bg-ink-200 text-paper placeholder:text-paper-faint focus-visible:border-brand focus-visible:ring-0"
-                  />
+                  {Array.from({ length: 5 }).map((_, i) => (
+                    <Skeleton key={i} className="h-20 w-full rounded-xs bg-ink-200" />
+                  ))}
                 </div>
+              ) : !filteredCategories || Object.keys(filteredCategories).length === 0 ? (
+                <Alert className="rounded-xs border-ink-500 bg-ink-100">
+                  <AlertDescription className="text-[12px] text-paper-muted">
+                    {searchQuery ? 'No permissions found matching your search.' : 'No permissions available.'}
+                  </AlertDescription>
+                </Alert>
+              ) : (
+                <div className="space-y-2">
+                  <AnimatePresence mode="popLayout">
+                    {Object.entries(filteredCategories).map(([category, permissions], index) => {
+                      const isExpanded = expandedCategories.has(category);
+                      const categorySelected = permissions.filter((p) =>
+                        selectedPermissionIds.has(p.id)
+                      );
+                      const catAllSelected = categorySelected.length === permissions.length;
+                      const someSelected = categorySelected.length > 0 && !catAllSelected;
 
-                {/* Is Default */}
-                <div className="flex items-center gap-3 rounded-xs border border-ink-500 bg-ink-200 p-3">
-                  <Checkbox
-                    id="isDefault"
-                    checked={isDefault}
-                    onCheckedChange={(checked) => setIsDefault(checked === true)}
-                    disabled={!canModify}
-                    className="border-ink-500 data-[state=checked]:border-brand data-[state=checked]:bg-brand data-[state=checked]:text-ink-50"
-                  />
-                  <Label htmlFor="isDefault" className="cursor-pointer text-[12px] text-paper">
-                    Set as default role for new users
-                  </Label>
+                      return (
+                        <motion.div
+                          key={category}
+                          initial={{ opacity: 0, y: 10 }}
+                          animate={{ opacity: 1, y: 0 }}
+                          exit={{ opacity: 0, y: -10 }}
+                          transition={{ delay: index * 0.03 }}
+                        >
+                          <Collapsible
+                            open={isExpanded}
+                            onOpenChange={() => toggleCategory(category)}
+                          >
+                            <div className="overflow-hidden rounded-xs border border-ink-500 bg-ink-100 transition-colors hover:border-ink-700">
+                              <div className="flex items-center justify-between transition-colors hover:bg-ink-200">
+                                <CollapsibleTrigger className="group flex flex-1 items-center gap-3 p-4 text-left">
+                                  <motion.div
+                                    animate={{ rotate: isExpanded ? 90 : 0 }}
+                                    transition={{ duration: 0.2 }}
+                                  >
+                                    <ChevronRight className="h-4 w-4 text-paper-dim transition-colors group-hover:text-paper" />
+                                  </motion.div>
+                                  <span className="text-[13px] font-semibold text-paper">{category}</span>
+                                  <span
+                                    className={cn(
+                                      'inline-flex items-center rounded-xs border px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-[0.14em] transition-colors',
+                                      catAllSelected
+                                        ? 'border-brand/40 text-brand'
+                                        : someSelected
+                                          ? 'border-brand/30 text-brand/80'
+                                          : 'border-ink-500 bg-ink-200 text-paper-muted'
+                                    )}
+                                  >
+                                    {categorySelected.length}/{permissions.length}
+                                  </span>
+                                </CollapsibleTrigger>
+                                {canModify && (
+                                  <Button
+                                    type="button"
+                                    variant="ghost"
+                                    size="sm"
+                                    onClick={() => handleSelectAllInCategory(category)}
+                                    className="mr-2 h-7 shrink-0 rounded-xs px-2 font-mono text-[10px] uppercase tracking-[0.14em] text-paper-dim hover:bg-ink-300 hover:text-paper"
+                                  >
+                                    {catAllSelected ? 'Deselect all' : 'Select all'}
+                                  </Button>
+                                )}
+                              </div>
+                              <CollapsibleContent>
+                                <div className="px-4 pb-4 pt-2 space-y-2">
+                                  {permissions.map((permission) => {
+                                    const isSelected = selectedPermissionIds.has(permission.id);
+                                    return (
+                                      <div
+                                        key={permission.id}
+                                        role="checkbox"
+                                        aria-checked={isSelected}
+                                        aria-label={permission.displayName}
+                                        aria-disabled={canModify ? undefined : true}
+                                        tabIndex={canModify ? 0 : -1}
+                                        onClick={() => togglePermission(permission.id)}
+                                        onKeyDown={(e) => {
+                                          if (!canModify) return;
+                                          if (e.key === ' ' || e.key === 'Enter') {
+                                            e.preventDefault();
+                                            togglePermission(permission.id);
+                                          }
+                                        }}
+                                        className={cn(
+                                          'flex items-start gap-3 rounded-xs border p-3 transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-brand',
+                                          canModify ? 'cursor-pointer' : 'cursor-default opacity-70',
+                                          isSelected
+                                            ? 'border-brand/40 bg-ink-200'
+                                            : 'border-ink-500 bg-ink-100',
+                                          !isSelected && canModify && 'hover:border-ink-700 hover:bg-ink-200'
+                                        )}
+                                      >
+                                        <Checkbox
+                                          checked={isSelected}
+                                          disabled={!canModify}
+                                          tabIndex={-1}
+                                          aria-hidden
+                                          className="pointer-events-none mt-0.5 border-ink-500 data-[state=checked]:border-brand data-[state=checked]:bg-brand data-[state=checked]:text-ink-50"
+                                        />
+                                        <div className="min-w-0 flex-1">
+                                          <span
+                                            className={cn(
+                                              'block text-[12px]',
+                                              isSelected ? 'font-medium text-paper' : 'text-paper-muted'
+                                            )}
+                                          >
+                                            {permission.displayName}
+                                          </span>
+                                          {permission.description && (
+                                            <p className="mt-1 text-[11px] text-paper-faint">
+                                              {permission.description}
+                                            </p>
+                                          )}
+                                        </div>
+                                        {isSelected && (
+                                          <span className="text-brand" aria-hidden>
+                                            <CheckCircle2 className="h-4 w-4" />
+                                          </span>
+                                        )}
+                                      </div>
+                                    );
+                                  })}
+                                </div>
+                              </CollapsibleContent>
+                            </div>
+                          </Collapsible>
+                        </motion.div>
+                      );
+                    })}
+                  </AnimatePresence>
                 </div>
-              </motion.div>
+              )}
 
-              {/* Permissions */}
-              <motion.div
-                initial={{ opacity: 0, y: 10 }}
-                animate={{ opacity: 1, y: 0 }}
-                transition={{ delay: 0.2 }}
-                className="space-y-4"
-              >
-                <div className="flex items-center justify-between">
+              {selectedPermissionIds.size === 0 && (
+                <Alert variant="destructive" className="rounded-xs border-red-500/40 bg-red-500/10">
+                  <AlertDescription className="font-mono text-[11px] uppercase tracking-[0.14em] text-red-300">
+                    At least one permission is required for the role.
+                  </AlertDescription>
+                </Alert>
+              )}
+            </div>
+          )}
+
+          {/* ── Step 3: Data Access & Review ── */}
+          {step === 3 && (
+            <div className="space-y-4">
+              {/* Permissions summary */}
+              {permissionSummaryByCategory.length > 0 && (
+                <div className="space-y-2">
                   <span className="inline-flex items-center gap-2 font-mono text-[10px] uppercase tracking-[0.18em] text-paper-dim">
                     <span className="h-px w-6 bg-ink-700" aria-hidden />
-                    <span>Permissions</span>
-                    <span className="text-red-400">*</span>
+                    <span>Permissions summary</span>
+                    <span className="rounded-xs border border-brand/40 px-1.5 py-0.5 text-brand">
+                      {selectedPermissionIds.size} selected
+                    </span>
                   </span>
-                  <div className="flex items-center gap-2">
-                    {selectedCount > 0 && (
-                      <span className="inline-flex items-center gap-1 rounded-xs border border-brand/40 px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-[0.14em] text-brand">
-                        {selectedCount} selected
-                      </span>
-                    )}
-                    {categoryKeys.length > 0 && (
-                      <Button
-                        type="button"
-                        variant="ghost"
-                        size="sm"
-                        onClick={handleToggleExpandAll}
-                        className="h-7 gap-1.5 rounded-xs px-2 font-mono text-[10px] uppercase tracking-[0.14em] text-paper-dim hover:bg-ink-200 hover:text-paper"
-                        title={allExpanded ? "Collapse all categories" : "Expand all categories"}
-                      >
-                        {allExpanded ? (
-                          <>
-                            <ChevronsUp className="h-3.5 w-3.5" />
-                            Collapse all
-                          </>
-                        ) : (
-                          <>
-                            <ChevronsDown className="h-3.5 w-3.5" />
-                            Expand all
-                          </>
-                        )}
-                      </Button>
-                    )}
-                    {canModify && totalPermissions > 0 && (
-                      <Button
-                        type="button"
-                        variant="ghost"
-                        size="sm"
-                        onClick={handleSelectAll}
-                        className="h-7 rounded-xs px-2 font-mono text-[10px] uppercase tracking-[0.14em] text-paper-dim hover:bg-ink-200 hover:text-paper"
-                      >
-                        {allSelected ? 'Deselect all' : 'Select all'}
-                      </Button>
-                    )}
+                  <div className="rounded-xs border border-ink-500 bg-ink-200 p-3">
+                    <div className="flex flex-wrap gap-1.5">
+                      {permissionSummaryByCategory.map(({ category, selected, total }) => (
+                        <span
+                          key={category}
+                          className="inline-flex items-center gap-1 rounded-xs border border-ink-500 bg-ink-100 px-2 py-0.5 font-mono text-[10px] text-paper-muted"
+                        >
+                          <span className="text-brand">{selected}</span>
+                          <span className="text-paper-faint">/{total}</span>
+                          <span className="ml-1 text-paper-dim">{category}</span>
+                        </span>
+                      ))}
+                    </div>
                   </div>
                 </div>
-
-                {/* Search */}
-                {!loadingPermissions && totalPermissions > 5 && (
-                  <div className="relative">
-                    <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-paper-faint" aria-hidden />
-                    <Input
-                      placeholder="Search permissions"
-                      value={searchQuery}
-                      onChange={(e) => setSearchQuery(e.target.value)}
-                      className="h-9 rounded-xs border-ink-500 bg-ink-200 pl-9 pr-9 font-mono text-[12px] text-paper placeholder:text-paper-faint focus-visible:border-brand focus-visible:ring-0"
-                    />
-                    {searchQuery && (
-                      <button
-                        onClick={() => setSearchQuery('')}
-                        className="absolute right-3 top-1/2 -translate-y-1/2 text-paper-faint transition-colors hover:text-paper"
-                        aria-label="Clear search"
-                      >
-                        <X className="h-4 w-4" />
-                      </button>
-                    )}
-                  </div>
-                )}
-
-                {loadingPermissions ? (
-                  <div className="space-y-2">
-                    {Array.from({ length: 5 }).map((_, i) => (
-                      <Skeleton key={i} className="h-20 w-full rounded-xs bg-ink-200" />
-                    ))}
-                  </div>
-                ) : !filteredCategories || Object.keys(filteredCategories).length === 0 ? (
-                  <Alert className="rounded-xs border-ink-500 bg-ink-100">
-                    <AlertDescription className="text-[12px] text-paper-muted">
-                      {searchQuery ? 'No permissions found matching your search.' : 'No permissions available.'}
-                    </AlertDescription>
-                  </Alert>
-                ) : (
-                  <div className="space-y-2">
-                    <AnimatePresence mode="popLayout">
-                      {Object.entries(filteredCategories).map(([category, permissions], index) => {
-                        const isExpanded = expandedCategories.has(category);
-                        const categorySelected = permissions.filter((p) =>
-                          selectedPermissionIds.has(p.id)
-                        );
-                        const allSelected = categorySelected.length === permissions.length;
-                        const someSelected = categorySelected.length > 0 && !allSelected;
-
-                        return (
-                          <motion.div
-                            key={category}
-                            initial={{ opacity: 0, y: 10 }}
-                            animate={{ opacity: 1, y: 0 }}
-                            exit={{ opacity: 0, y: -10 }}
-                            transition={{ delay: index * 0.05 }}
-                          >
-                            <Collapsible
-                              open={isExpanded}
-                              onOpenChange={() => toggleCategory(category)}
-                            >
-                              <div className="overflow-hidden rounded-xs border border-ink-500 bg-ink-100 transition-colors hover:border-ink-700">
-                                {/* Trigger and the per-category Select-all are SIBLINGS — a button
-                                    must never nest inside another button (invalid DOM + a11y). */}
-                                <div className="flex items-center justify-between transition-colors hover:bg-ink-200">
-                                  <CollapsibleTrigger className="group flex flex-1 items-center gap-3 p-4 text-left">
-                                    <motion.div
-                                      animate={{ rotate: isExpanded ? 90 : 0 }}
-                                      transition={{ duration: 0.2 }}
-                                    >
-                                      <ChevronRight className="h-4 w-4 text-paper-dim transition-colors group-hover:text-paper" />
-                                    </motion.div>
-                                    <span className="text-[13px] font-semibold text-paper">{category}</span>
-                                    <span
-                                      className={cn(
-                                        'inline-flex items-center rounded-xs border px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-[0.14em] transition-colors',
-                                        allSelected
-                                          ? 'border-brand/40 text-brand'
-                                          : someSelected
-                                            ? 'border-brand/30 text-brand/80'
-                                            : 'border-ink-500 bg-ink-200 text-paper-muted'
-                                      )}
-                                    >
-                                      {categorySelected.length}/{permissions.length}
-                                    </span>
-                                  </CollapsibleTrigger>
-                                  {canModify && (
-                                    <Button
-                                      type="button"
-                                      variant="ghost"
-                                      size="sm"
-                                      onClick={() => handleSelectAllInCategory(category)}
-                                      className="mr-2 h-7 shrink-0 rounded-xs px-2 font-mono text-[10px] uppercase tracking-[0.14em] text-paper-dim hover:bg-ink-300 hover:text-paper"
-                                    >
-                                      {allSelected ? 'Deselect all' : 'Select all'}
-                                    </Button>
-                                  )}
-                                </div>
-                                <CollapsibleContent>
-                                  <motion.div
-                                    initial={{ height: 0, opacity: 0 }}
-                                    animate={{ height: 'auto', opacity: 1 }}
-                                    exit={{ height: 0, opacity: 0 }}
-                                    transition={{ duration: 0.2 }}
-                                    className="px-4 pb-4 pt-2 space-y-2"
-                                  >
-                                    {permissions.map((permission) => {
-                                      const isSelected = selectedPermissionIds.has(permission.id);
-                                      // The whole row IS the accessible checkbox: a single click toggles
-                                      // once (no row-onClick + control-onChange double-fire), and it's
-                                      // keyboard-operable. The inner Checkbox is purely presentational.
-                                      return (
-                                        <motion.div
-                                          key={permission.id}
-                                          role="checkbox"
-                                          aria-checked={isSelected}
-                                          aria-label={permission.displayName}
-                                          aria-disabled={canModify ? undefined : true}
-                                          tabIndex={canModify ? 0 : -1}
-                                          onClick={() => togglePermission(permission.id)}
-                                          onKeyDown={(e) => {
-                                            if (!canModify) return;
-                                            if (e.key === ' ' || e.key === 'Enter') {
-                                              e.preventDefault();
-                                              togglePermission(permission.id);
-                                            }
-                                          }}
-                                          className={cn(
-                                            'flex items-start gap-3 rounded-xs border p-3 transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-brand',
-                                            canModify ? 'cursor-pointer' : 'cursor-default opacity-70',
-                                            isSelected
-                                              ? 'border-brand/40 bg-ink-200'
-                                              : 'border-ink-500 bg-ink-100',
-                                            !isSelected && canModify && 'hover:border-ink-700 hover:bg-ink-200'
-                                          )}
-                                        >
-                                          <Checkbox
-                                            checked={isSelected}
-                                            disabled={!canModify}
-                                            tabIndex={-1}
-                                            aria-hidden
-                                            className="pointer-events-none mt-0.5 border-ink-500 data-[state=checked]:border-brand data-[state=checked]:bg-brand data-[state=checked]:text-ink-50"
-                                          />
-                                          <div className="min-w-0 flex-1">
-                                            <span
-                                              className={cn(
-                                                'block text-[12px]',
-                                                isSelected ? 'font-medium text-paper' : 'text-paper-muted'
-                                              )}
-                                            >
-                                              {permission.displayName}
-                                            </span>
-                                            {permission.description && (
-                                              <p className="mt-1 text-[11px] text-paper-faint">
-                                                {permission.description}
-                                              </p>
-                                            )}
-                                          </div>
-                                          {isSelected && (
-                                            <span className="text-brand" aria-hidden>
-                                              <CheckCircle2 className="h-4 w-4" />
-                                            </span>
-                                          )}
-                                        </motion.div>
-                                      );
-                                    })}
-                                  </motion.div>
-                                </CollapsibleContent>
-                              </div>
-                            </Collapsible>
-                          </motion.div>
-                        );
-                      })}
-                    </AnimatePresence>
-                  </div>
-                )}
-
-                {selectedPermissionIds.size === 0 && (
-                  <motion.div
-                    initial={{ opacity: 0 }}
-                    animate={{ opacity: 1 }}
-                  >
-                    <Alert variant="destructive" className="rounded-xs border-red-500/40 bg-red-500/10">
-                      <AlertDescription className="font-mono text-[11px] uppercase tracking-[0.14em] text-red-300">
-                        At least one permission is required for the role.
-                      </AlertDescription>
-                    </Alert>
-                  </motion.div>
-                )}
-              </motion.div>
+              )}
 
               {/* Data Access Policies */}
-              <motion.div
-                initial={{ opacity: 0, y: 10 }}
-                animate={{ opacity: 1, y: 0 }}
-                transition={{ delay: 0.25 }}
-                className="space-y-4"
-              >
+              <div className="space-y-3">
                 <div className="flex items-center justify-between">
                   <span className="inline-flex items-center gap-2 font-mono text-[10px] uppercase tracking-[0.18em] text-paper-dim">
                     <span className="h-px w-6 bg-ink-700" aria-hidden />
@@ -828,41 +806,42 @@ export const RoleFormDialog: React.FC<RoleFormDialogProps> = ({
                     </AlertDescription>
                   </Alert>
                 )}
-              </motion.div>
-            </motion.div>
-          </div>
-        </ScrollArea>
+              </div>
+            </div>
+          )}
+        </div>
 
-        <DialogFooter className="flex-shrink-0 border-t border-ink-500 px-6 py-4">
+        <DialogFooter className="flex flex-shrink-0 items-center justify-between gap-2 border-t border-ink-500 px-6 py-4">
           <Button
-            variant="outline"
-            onClick={onClose}
+            variant="ghost"
+            onClick={() => (step === 1 ? onClose() : setStep((step - 1) as 1 | 2 | 3))}
             disabled={isLoading}
-            className="h-9 gap-2 rounded-xs border-ink-500 bg-ink-100 px-3 font-mono text-[11px] uppercase tracking-[0.14em] text-paper hover:border-ink-700 hover:bg-ink-200"
+            className="h-9 gap-1 rounded-xs font-mono text-[11px] uppercase tracking-[0.14em] text-paper-muted hover:bg-ink-200 hover:text-paper"
           >
-            Cancel
+            {step === 1 ? 'Cancel' : <><ArrowLeft className="h-3.5 w-3.5" /> Back</>}
           </Button>
-          <Button
-            onClick={handleSubmit}
-            disabled={!isValid || !canModify || isLoading}
-            className="h-9 gap-2 rounded-xs bg-brand px-3 font-mono text-[11px] font-semibold uppercase tracking-[0.14em] text-ink-50 hover:bg-brand-soft disabled:cursor-not-allowed disabled:opacity-50"
-          >
-            {isLoading ? (
-              <>
-                <motion.div
-                  animate={{ rotate: 360 }}
-                  transition={{ duration: 1, repeat: Infinity, ease: 'linear' }}
-                  className="h-3.5 w-3.5 rounded-full border-2 border-ink-50 border-t-transparent"
-                />
-                {isEditing ? 'Updating' : 'Creating'}
-              </>
-            ) : (
-              <>
-                <CheckCircle2 className="h-3.5 w-3.5" />
-                {isEditing ? 'Update role' : 'Create role'}
-              </>
-            )}
-          </Button>
+
+          {step < 3 ? (
+            <Button
+              onClick={() => setStep((step + 1) as 2 | 3)}
+              disabled={step === 1 ? !step1Valid : !step2Valid}
+              className="h-9 gap-1 rounded-xs bg-brand px-3 font-mono text-[11px] font-semibold uppercase tracking-[0.14em] text-ink-50 hover:bg-brand-soft disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              Next <ArrowRight className="h-3.5 w-3.5" />
+            </Button>
+          ) : (
+            <Button
+              onClick={handleSubmit}
+              disabled={!step3Valid || !canModify || isLoading}
+              className="h-9 gap-2 rounded-xs bg-brand px-3 font-mono text-[11px] font-semibold uppercase tracking-[0.14em] text-ink-50 hover:bg-brand-soft disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              {isLoading ? (
+                <><Loader2 className="h-3.5 w-3.5 animate-spin" /> {isEditing ? 'Updating' : 'Creating'}</>
+              ) : (
+                <><CheckCircle2 className="h-3.5 w-3.5" /> {isEditing ? 'Update role' : 'Create role'}</>
+              )}
+            </Button>
+          )}
         </DialogFooter>
       </DialogContent>
     </Dialog>

--- a/src/pages/Admin.tsx
+++ b/src/pages/Admin.tsx
@@ -77,62 +77,89 @@ const ADMIN_TAB_CONFIG: Record<AdminTabKey, AdminTabConfig> = {
   },
 };
 
-interface TabCardProps {
-  tabKey: AdminTabKey;
-  isActive: boolean;
-  onClick: () => void;
-  disabled?: boolean;
+// Two-tier navigation. Sections are clustered into labelled groups; the group
+// row is the top level, and the active group's sections appear below as a
+// sub-tab strip (mirroring Monitoring's top-pill → in-page sub-tab pattern).
+// The top row stays at a handful of groups no matter how many sections exist —
+// a new feature slots into an existing group (or a new one) instead of crowding
+// a flat row.
+interface AdminTabGroup {
+  label: string;
+  icon: LucideIcon;
+  tabs: AdminTabKey[];
 }
 
-function TabCard({ tabKey, isActive, onClick, disabled }: TabCardProps) {
-  const config = ADMIN_TAB_CONFIG[tabKey];
-  const Icon = config.icon;
+const ADMIN_TAB_GROUPS: AdminTabGroup[] = [
+  { label: "Access control", icon: Shield, tabs: ["users", "roles", "data-access"] },
+  { label: "Data sources", icon: Server, tabs: ["connections", "clickhouse-users"] },
+  { label: "Intelligence", icon: Bot, tabs: ["ai-models"] },
+  { label: "Security", icon: FileText, tabs: ["audit"] },
+];
+
+// Top-level group selector — segmented chip (icon + label), active one filled.
+interface GroupChipProps {
+  group: AdminTabGroup;
+  isActive: boolean;
+  onClick: () => void;
+}
+
+function GroupChip({ group, isActive, onClick }: GroupChipProps) {
+  const Icon = group.icon;
 
   return (
     <button
       type="button"
       onClick={onClick}
-      disabled={disabled}
       aria-current={isActive ? "page" : undefined}
       className={cn(
-        "group @container relative flex flex-1 min-w-[160px] items-center gap-3 border border-ink-500 px-4 py-3 text-left transition-colors",
-        "rounded-xs",
-        "focus:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2 focus-visible:ring-offset-ink-50",
+        "inline-flex h-8 shrink-0 items-center gap-2 rounded-xs border px-3 font-mono text-[11px] uppercase tracking-[0.14em] transition-colors",
+        "focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-brand",
         isActive
-          ? "border-ink-700 bg-ink-200 text-paper"
-          : "bg-ink-100 text-paper-muted hover:border-ink-700 hover:bg-ink-200 hover:text-paper",
-        disabled && "cursor-not-allowed opacity-50"
+          ? "border-ink-500 bg-ink-200 text-paper"
+          : "border-transparent text-paper-muted hover:bg-ink-100 hover:text-paper"
       )}
     >
-      <span
-        className={cn(
-          "grid h-8 w-8 shrink-0 place-items-center rounded-xs border transition-colors",
-          isActive
-            ? "border-brand bg-ink-100 text-brand"
-            : "border-ink-500 bg-ink-200 text-paper-muted group-hover:border-ink-700"
-        )}
-      >
-        <Icon className="h-4 w-4" aria-hidden />
-      </span>
+      <Icon
+        className={cn("h-3.5 w-3.5", isActive ? "text-brand" : "text-paper-dim")}
+        aria-hidden
+      />
+      <span>{group.label}</span>
+    </button>
+  );
+}
 
-      <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+// Second-level section selector — Monitoring's in-page sub-tab style: label +
+// hint, brand underline on the active one.
+interface SectionTabProps {
+  tabKey: AdminTabKey;
+  isActive: boolean;
+  onClick: () => void;
+}
+
+function SectionTab({ tabKey, isActive, onClick }: SectionTabProps) {
+  const config = ADMIN_TAB_CONFIG[tabKey];
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-current={isActive ? "page" : undefined}
+      className={cn(
+        "group relative flex shrink-0 items-center gap-2 px-3 py-2 font-mono text-[11px] uppercase tracking-[0.14em] transition-colors",
+        "focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-brand",
+        isActive ? "text-paper" : "text-paper-muted hover:text-paper"
+      )}
+    >
+      <span>{config.label}</span>
+      <span className="hidden font-mono text-[9px] tracking-[0.14em] text-paper-faint sm:inline">
+        · {config.description}
+      </span>
+      {isActive && (
         <span
-          className={cn(
-            "truncate text-[13px] font-semibold",
-            isActive ? "text-paper" : "text-paper-muted group-hover:text-paper"
-          )}
-        >
-          {config.label}
-        </span>
-        {/* Description appears only when the card itself is wide enough
-            to render it without truncation — driven by container queries
-            on the button so each card decides for itself, regardless of
-            viewport. 240px is roughly the point where mono-uppercase
-            10px at tracking-0.14em stops needing ellipsis. */}
-        <span className="hidden truncate font-mono text-[10px] uppercase tracking-[0.14em] text-paper-faint @[240px]:block">
-          {config.description}
-        </span>
-      </div>
+          className="absolute -bottom-px left-0 right-0 h-px bg-brand"
+          aria-hidden
+        />
+      )}
     </button>
   );
 }
@@ -171,6 +198,17 @@ export default function Admin() {
 
   const activeTab = getInitialTab();
 
+  // Resolve groups against the user's permissions: drop sections they can't see,
+  // then drop any group left empty. The active group is derived from the active
+  // section so the URL stays section-based (/admin/<section>).
+  const visibleGroups = ADMIN_TAB_GROUPS.map((group) => ({
+    ...group,
+    tabs: group.tabs.filter((tabKey) => availableTabs.includes(tabKey)),
+  })).filter((group) => group.tabs.length > 0);
+
+  const activeGroup =
+    visibleGroups.find((group) => group.tabs.includes(activeTab)) ?? visibleGroups[0];
+
   useEffect(() => {
     if (!tab || !availableTabs.includes(tab as AdminTabKey)) {
       if (availableTabs.length > 0) {
@@ -181,23 +219,42 @@ export default function Admin() {
 
   return (
     <div className="flex h-full w-full flex-col overflow-hidden bg-ink-50">
-      {/* ─── Header ─── */}
-      <header className="flex-none border-b border-ink-500 px-6 pb-4 pt-6">
-        <div className="mb-5 flex items-center justify-between gap-4">
-          <div className="flex items-center gap-4">
-            <span className="grid h-10 w-10 shrink-0 place-items-center rounded-xs border border-ink-500 bg-ink-100 text-paper-muted">
-              <ShieldCheck className="h-4 w-4" aria-hidden />
+      {/* ─── Header — two tiers: group selector on top, section sub-tabs below ─── */}
+      <header className="flex-none border-b border-ink-500 px-6 pt-4">
+        {/* Tier 1 — title + group selector + controls */}
+        <div className="flex flex-wrap items-center justify-between gap-3 pb-3">
+          <div className="flex items-center gap-3">
+            <span className="grid h-8 w-8 shrink-0 place-items-center rounded-xs border border-ink-500 bg-ink-100 text-paper-muted">
+              <ShieldCheck className="h-3.5 w-3.5" aria-hidden />
             </span>
-            <div className="flex flex-col gap-1">
-              <span className="inline-flex items-center gap-3 font-mono text-[10px] uppercase tracking-[0.18em] text-paper-faint">
-                <span className="h-px w-6 bg-ink-700" aria-hidden />
-                <span>Administration</span>
+            <div className="flex flex-col gap-0">
+              <span className="font-mono text-[9px] uppercase tracking-[0.18em] text-paper-faint">
+                Administration
               </span>
-              <h1 className="text-2xl font-semibold tracking-tight text-paper">
+              <h1 className="text-[18px] font-semibold leading-tight tracking-tight text-paper">
                 Who can do what, where.
               </h1>
             </div>
           </div>
+
+          {/* Group selector — segmented chips */}
+          <nav
+            aria-label="Admin groups"
+            className="scrollbar-hide flex items-center gap-1 overflow-x-auto"
+          >
+            {visibleGroups.map((group) => (
+              <GroupChip
+                key={group.label}
+                group={group}
+                isActive={group === activeGroup}
+                onClick={() => {
+                  if (group !== activeGroup) {
+                    navigate(`/admin/${group.tabs[0]}`);
+                  }
+                }}
+              />
+            ))}
+          </nav>
 
           <Button
             variant="ghost"
@@ -210,17 +267,22 @@ export default function Admin() {
           </Button>
         </div>
 
-        {/* Tab cards */}
-        <div className="scrollbar-hide flex gap-2 overflow-x-auto pb-0.5">
-          {availableTabs.map((tabKey) => (
-            <TabCard
-              key={tabKey}
-              tabKey={tabKey}
-              isActive={activeTab === tabKey}
-              onClick={() => navigate(`/admin/${tabKey}`)}
-            />
-          ))}
-        </div>
+        {/* Tier 2 — sections of the active group, flush to the header's bottom border */}
+        {activeGroup && (
+          <nav
+            aria-label={`${activeGroup.label} sections`}
+            className="scrollbar-hide -mb-px flex items-center gap-1 overflow-x-auto"
+          >
+            {activeGroup.tabs.map((tabKey) => (
+              <SectionTab
+                key={tabKey}
+                tabKey={tabKey}
+                isActive={activeTab === tabKey}
+                onClick={() => navigate(`/admin/${tabKey}`)}
+              />
+            ))}
+          </nav>
+        )}
       </header>
 
       {/* ─── Content ─── */}

--- a/src/pages/Monitoring.tsx
+++ b/src/pages/Monitoring.tsx
@@ -216,7 +216,7 @@ export default function Monitoring() {
       {/* ─── Header — compact: title + tabs + controls share one row ─── */}
       <header className="flex-none border-b border-ink-500 px-6 pt-4">
         <div className="flex flex-wrap items-end justify-between gap-4 pb-0">
-          <div className="flex items-center gap-3">
+          <div className="flex items-center gap-3 pb-2">
             <span className="grid h-8 w-8 shrink-0 place-items-center rounded-xs border border-ink-500 bg-ink-100 text-paper-muted">
               <Activity className="h-3.5 w-3.5" aria-hidden />
             </span>
@@ -245,7 +245,7 @@ export default function Monitoring() {
             ))}
           </nav>
 
-          <div className="flex items-center gap-2">
+          <div className="flex items-center gap-2 pb-2">
             <DataControls
               lastUpdated={lastUpdated}
               isRefreshing={isRefreshing}

--- a/src/pages/Preferences.tsx
+++ b/src/pages/Preferences.tsx
@@ -43,6 +43,13 @@ const EYEBROW = "inline-flex items-center gap-2 font-mono text-[10px] uppercase 
 const MONO_LABEL = "font-mono text-[10px] uppercase tracking-[0.14em] text-paper-dim";
 const MONO_FAINT = "font-mono text-[10px] uppercase tracking-[0.14em] text-paper-faint";
 
+// Resolve a role's human-readable display name from the user's role metadata,
+// falling back to the raw role name when metadata is unavailable.
+const roleDisplayName = (
+  roleName: string,
+  meta?: Array<{ name: string; displayName: string }>,
+): string => meta?.find((m) => m.name === roleName)?.displayName ?? roleName;
+
 // ============================================
 // Types & Components
 // ============================================
@@ -89,10 +96,16 @@ interface InfoRowProps {
   label: string;
   value: string | React.ReactNode;
   icon?: React.ElementType;
+  className?: string;
 }
 
-const InfoRow: React.FC<InfoRowProps> = ({ label, value, icon: Icon }) => (
-  <div className="flex items-center justify-between rounded-xs border border-ink-500 bg-ink-200 px-3 py-2.5">
+const InfoRow: React.FC<InfoRowProps> = ({ label, value, icon: Icon, className }) => (
+  <div
+    className={cn(
+      "flex items-center justify-between rounded-xs border border-ink-500 bg-ink-200 px-3 py-2.5",
+      className,
+    )}
+  >
     <div className="flex items-center gap-2">
       {Icon && <Icon className="h-3.5 w-3.5 text-paper-dim" aria-hidden />}
       <span className={MONO_LABEL}>{label}</span>
@@ -109,10 +122,16 @@ const StatusFooter: React.FC<{
   label: string;
   meta: string;
   tone?: "brand" | "emerald";
-}> = ({ label, meta, tone = "brand" }) => {
+  className?: string;
+}> = ({ label, meta, tone = "brand", className }) => {
   const dot = tone === "emerald" ? "bg-emerald-400" : "bg-brand";
   return (
-    <div className="flex items-center justify-between rounded-xs border border-ink-500 bg-ink-200 px-3 py-2">
+    <div
+      className={cn(
+        "flex items-center justify-between rounded-xs border border-ink-500 bg-ink-200 px-3 py-2",
+        className,
+      )}
+    >
       <div className="flex items-center gap-2">
         <span className={cn("h-1.5 w-1.5 rounded-full", dot)} aria-hidden />
         <span className={MONO_LABEL}>{label}</span>
@@ -312,7 +331,7 @@ const IdentityCard: React.FC = () => {
       delay={0.1}
       className="md:col-span-1"
     >
-      <div className="space-y-2">
+      <div className="flex h-full flex-col gap-2">
         <InfoRow label="Username" icon={User} value={user?.username || "N/A"} />
         <InfoRow
           label="RBAC ID"
@@ -323,7 +342,27 @@ const IdentityCard: React.FC = () => {
             </span>
           }
         />
-        <StatusFooter label="Session active" meta="Secure" tone="emerald" />
+        {user?.roles && user.roles.length > 0 && (
+          <div className="flex items-center justify-between gap-3 rounded-xs border border-ink-500 bg-ink-200 px-3 py-2.5">
+            <div className="flex items-center gap-2">
+              <Shield className="h-3.5 w-3.5 text-paper-dim" aria-hidden />
+              <span className={MONO_LABEL}>Roles</span>
+            </div>
+            <div className="flex flex-wrap justify-end gap-1.5">
+              {user.roles.map((role) => (
+                <span
+                  key={role}
+                  className="inline-flex items-center rounded-xs border border-brand/40 bg-brand/5 px-1.5 py-0.5 font-mono text-[10px] tracking-[0.14em] text-brand"
+                >
+                  {role}
+                </span>
+              ))}
+            </div>
+          </div>
+        )}
+        <div className="mt-auto">
+          <StatusFooter label="Session active" meta="Secure" tone="emerald" />
+        </div>
       </div>
     </SettingCard>
   );
@@ -354,8 +393,9 @@ const ConnectionDetailsCard: React.FC<{ url: string | null; version: string | nu
       delay={0.2}
       className="md:col-span-2"
     >
-      <div className="space-y-2">
+      <div className="flex h-full flex-col gap-2">
         <InfoRow
+          className="flex-1"
           label="Endpoint"
           icon={Server}
           value={
@@ -382,8 +422,8 @@ const ConnectionDetailsCard: React.FC<{ url: string | null; version: string | nu
             )
           }
         />
-        <InfoRow label="Version" icon={Cpu} value={version || "N/A"} />
-        <StatusFooter label="Node operational" meta="Online" tone="emerald" />
+        <InfoRow className="flex-1" label="Version" icon={Cpu} value={version || "N/A"} />
+        <StatusFooter className="flex-1" label="Node operational" meta="Online" tone="emerald" />
       </div>
     </SettingCard>
   );
@@ -647,16 +687,6 @@ export default function Preferences() {
   const user = profile?.user || storeUser;
   const connections = profile?.connections || [];
   const allRules = profile?.dataAccessRules || [];
-  const rolesMetadata = user?.rolesMetadata || [];
-
-  const getRoleDisplayName = (roleName: string) => {
-    const meta = rolesMetadata.find((m) => m.name === roleName);
-    if (meta?.displayName) return meta.displayName;
-    return roleName
-      .split("_")
-      .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
-      .join(" ");
-  };
 
   // Initials chip from displayName/username
   const initials = useMemo(() => {
@@ -796,10 +826,10 @@ export default function Preferences() {
                     {user.roles.map((role) => (
                       <span
                         key={role}
-                        className="inline-flex items-center gap-1.5 rounded-xs border border-brand/40 bg-brand/5 px-2 py-1 font-mono text-[10px] uppercase tracking-[0.14em] text-brand"
+                        className="inline-flex items-center gap-1.5 rounded-xs border border-brand/40 bg-brand/5 px-2 py-1 font-mono text-[10px] tracking-[0.14em] text-brand"
                       >
                         <Shield className="h-3 w-3" aria-hidden />
-                        {getRoleDisplayName(role)}
+                        {roleDisplayName(role, user?.rolesMetadata)}
                       </span>
                     ))}
                   </div>
@@ -809,7 +839,7 @@ export default function Preferences() {
           </motion.div>
 
           {/* Preferences Grid */}
-          <div className="grid items-start gap-6 md:grid-cols-3">
+          <div className="grid items-stretch gap-6 md:grid-cols-3">
             {/* Row 1: Identity + Connection */}
             <IdentityCard />
             <ConnectionDetailsCard url={url} version={version} />


### PR DESCRIPTION
## Description

A focused refresh of the Admin / RBAC UI plus several role-label bug fixes and Preferences polish. No backend or schema changes — UI only.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Code refactoring

## Related Issue

Closes #

## Changes Made

**Roles tab**
- **Fix:** `data_access` permissions were rendering as **Other** on role cards — added the missing `data_access → Data Access` category mapping.
- Role **create/edit** is now a 3-step wizard (**Details → Permissions → Data Access & Review**) with a stepper and per-step validation, mirroring the Data Access Policies wizard instead of one long scroll.
- Each role card now surfaces its assigned **Data Access** policies: an at-a-glance count badge in the stat row, plus named policy chips in the expanded view (policies fetched only when the viewer has `DATA_ACCESS_VIEW`).

**Admin layout**
- Re-laid the Admin header into a **two-tier nav**: grouped section chips on top (Access control / Data sources / Intelligence / Security), with the active group's sections shown below as Monitoring-style sub-tabs. The active group is derived from the URL section, so `/admin/<section>` deep links still work.
- Gave the **Data Access** section the standard icon + `h2` + count header so it matches the other admin sections.

**Users**
- User-list cards always render a display-name-style role label, humanising raw names (`super_admin → Super Admin`) instead of leaking snake_case when a role isn't in the global list.

**Preferences**
- Header role chips now show the role **display name**; the **Identity & access** card lists the user's roles.
- Made the row-1 cards equal height — the **ClickHouse node** rows grow to align the card with **Identity & access**.

**Monitoring**
- Lifted the title and refresh/auto-refresh controls off the header divider for breathing room (tab underline stays flush).

## Testing

- [x] I have tested this locally
- [ ] I have added/updated tests
- [x] All existing tests pass

### Test Steps
- `bun run typecheck` and `bun run lint` both pass clean.
- Admin → Roles: expand a role with policies → group label reads **Data Access**; the card shows the access badge + policy chips.
- Create/Edit a role → wizard steps Details → Permissions → Data Access & Review; Back/Next gating works; Edit preloads values.
- Admin header: group chips switch the section sub-tab strip; `/admin/<section>` deep links select the right group + section.
- Preferences: role chips show display names; Identity & access lists roles; ClickHouse node card bottom-aligns with Identity & access.

## Screenshots

<!-- UI-only change; happy to add screenshots if useful -->

## Changelog Fragment

- [x] Added `changelogs/unreleased/<pr-number>-<slug>.md`
