### PR TITLE
fix(auth/ux): deactivate instead of delete, fix SSO password UI, widen audit log coverage

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -78,6 +78,17 @@ jobs:
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "Assembled version: $VERSION"
 
+      - name: Trim CHANGELOG to latest 10 releases
+        run: |
+          COUNT_BEFORE=$(grep -c '^## \[v' CHANGELOG.md || true)
+          awk '
+            /^## \[v/ { count++ }
+            count > 10 { next }
+            { print }
+          ' CHANGELOG.md > CHANGELOG.tmp && mv CHANGELOG.tmp CHANGELOG.md
+          COUNT_AFTER=$(grep -c '^## \[v' CHANGELOG.md || true)
+          echo "CHANGELOG entries: $COUNT_BEFORE before → $COUNT_AFTER after (kept latest 10)"
+
       - name: Check for code changes since last tag
         id: code_check
         run: |
@@ -131,6 +142,7 @@ jobs:
         run: |
           VERSION="v${{ steps.release.outputs.version }}"
           BRANCH="${{ steps.branch.outputs.name }}"
+          ENTRY_COUNT=$(grep -c '^## \[v' CHANGELOG.md || true)
           {
             echo "## Release Preview: $VERSION"
             echo ""
@@ -147,6 +159,18 @@ jobs:
               }
               found { print }
             ' CHANGELOG.md
+            echo ""
+            echo "---"
+            echo ""
+            echo "<details>"
+            echo "<summary>Full retained CHANGELOG ($ENTRY_COUNT entries — click to expand)</summary>"
+            echo ""
+            echo '```markdown'
+            # Print all versioned sections (skip the preamble header lines)
+            awk '/^## \[v/{found=1} found{print}' CHANGELOG.md
+            echo '```'
+            echo ""
+            echo "</details>"
           } >> $GITHUB_STEP_SUMMARY
 
   # ── Step 2: approval gate — push assembled changes to main ────────────────

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,8 +6,8 @@ We provide security updates for the following versions:
 
 | Version | Supported |
 | ------- | :-------: |
-| 2.x.x   | ✅        |
-| < 2.0   | ❌        |
+| 3.x.x   | ✅        |
+| < 3.0   | ❌        |
 
 ## Reporting a Vulnerability
 

--- a/changelogs/unreleased/248-auth-ux-fleet-audit.md
+++ b/changelogs/unreleased/248-auth-ux-fleet-audit.md
@@ -1,0 +1,10 @@
+type: minor
+
+### Changed
+- **User management** — replaced hard user deletion on the user card with an Activate/Deactivate action; deactivated users keep their data but cannot sign in until an admin reactivates them.
+- **Audit log coverage** — added audit entries for fleet alert-config updates, AI doctor scans/schedule changes/report deletions, and query EXPLAIN; migrated live-query kill logging to capture full client context.
+
+### Fixed
+- **SSO users** — the "Reset password" action is now hidden for SSO-linked accounts (both on the user card and the edit-user screen), since they have no local password.
+- **Inactive login message** — password sign-in by an inactive account now returns a clear "account is inactive, contact an administrator" message (after password verification, to avoid user enumeration); SSO wording aligned.
+- **Fleet doctor** — the "analyzing…" progress now reflects the selected investigation window instead of always showing "6h".

--- a/packages/server/src/rbac/schema/base.ts
+++ b/packages/server/src/rbac/schema/base.ts
@@ -351,6 +351,7 @@ export const AUDIT_ACTIONS = {
   CH_USER_DELETE: 'clickhouse.user_delete',
   CH_USER_SYNC: 'clickhouse.user_sync',
   CH_QUERY_EXECUTE: 'clickhouse.query_execute',
+  CH_QUERY_EXPLAIN: 'clickhouse.query_explain',
   CH_DATABASE_CREATE: 'clickhouse.database_create',
   CH_DATABASE_DROP: 'clickhouse.database_drop',
   CH_TABLE_CREATE: 'clickhouse.table_create',
@@ -400,6 +401,12 @@ export const AUDIT_ACTIONS = {
   SAVED_QUERY_CREATE: 'saved_query.create',
   SAVED_QUERY_UPDATE: 'saved_query.update',
   SAVED_QUERY_DELETE: 'saved_query.delete',
+
+  // Fleet & Doctor (AI SRE)
+  FLEET_ALERT_CONFIG_UPDATE: 'fleet.alert_config_update',
+  DOCTOR_SCAN_RUN: 'doctor.scan_run',
+  DOCTOR_SCHEDULE_UPDATE: 'doctor.schedule_update',
+  DOCTOR_REPORT_DELETE: 'doctor.report_delete',
 } as const;
 
 export type AuditAction = typeof AUDIT_ACTIONS[keyof typeof AUDIT_ACTIONS];

--- a/packages/server/src/rbac/schema/index.ts
+++ b/packages/server/src/rbac/schema/index.ts
@@ -57,6 +57,8 @@ export interface UserResponse {
   displayName: string | null;
   avatarUrl: string | null;
   isActive: boolean;
+  /** True when the user has at least one linked SSO identity (no usable local password). */
+  hasSsoIdentity: boolean;
   roles: string[];
   permissions: string[];
   lastLoginAt: Date | null;

--- a/packages/server/src/rbac/services/rbac.test.ts
+++ b/packages/server/src/rbac/services/rbac.test.ts
@@ -289,6 +289,19 @@ describe("RBAC Service", () => {
             const result = await authenticateUser("superadmin@example.com", "Valid#Pass1");
             expect(result).not.toBeNull();
         });
+
+        it("throws an explicit inactive-account error when a valid password is given for an inactive user", async () => {
+            // arrange: correct password (verifyPassword mock -> true) but account is inactive.
+            // The inactive message must only surface AFTER password verification.
+            mockUser.isActive = false;
+            try {
+                await expect(
+                    authenticateUser("test@example.com", "Valid#Pass1")
+                ).rejects.toThrow(/inactive/i);
+            } finally {
+                mockUser.isActive = true;
+            }
+        });
     });
 
 });

--- a/packages/server/src/rbac/services/rbac.ts
+++ b/packages/server/src/rbac/services/rbac.ts
@@ -735,13 +735,20 @@ export async function authenticateUser(
 ): Promise<{ user: UserResponse; tokens: TokenPair } | null> {
   const user = await getUserByEmailOrUsername(identifier);
 
-  if (!user || !user.isActive) {
+  if (!user) {
     return null;
   }
 
+  // Verify the password before revealing anything about account state — an
+  // inactive-account message must only reach someone who supplied the correct
+  // credentials, to avoid leaking which accounts exist (user enumeration).
   const isValid = await verifyPassword(password, user.passwordHash);
   if (!isValid) {
     return null;
+  }
+
+  if (!user.isActive) {
+    throw AppError.unauthorized('This account is inactive. Contact an administrator to reactivate it.');
   }
 
   // SSO-linked accounts must use SSO — except admins (break-glass access).
@@ -1176,9 +1183,11 @@ export async function getAuditMetadata(): Promise<{
  * Expand user to UserResponse format
  */
 async function expandUserResponse(user: User): Promise<UserResponse> {
-  const [roles, permissions] = await Promise.all([
+  const { userHasSsoIdentity } = await import('../sso/identity');
+  const [roles, permissions, hasSsoIdentity] = await Promise.all([
     getUserRoles(user.id),
     getUserPermissions(user.id),
+    userHasSsoIdentity(user.id),
   ]);
 
   return {
@@ -1188,6 +1197,7 @@ async function expandUserResponse(user: User): Promise<UserResponse> {
     displayName: user.displayName,
     avatarUrl: user.avatarUrl,
     isActive: user.isActive,
+    hasSsoIdentity,
     roles,
     permissions,
     lastLoginAt: user.lastLoginAt,

--- a/packages/server/src/rbac/sso/service.ts
+++ b/packages/server/src/rbac/sso/service.ts
@@ -54,7 +54,7 @@ export async function provisionSsoUser(
     user = rows[0] || null;
     // Fix 5 (path 1): check isActive before any side effects
     if (user && !user.isActive) {
-      throw AppError.unauthorized('This account is inactive.');
+      throw AppError.unauthorized('This account is inactive. Contact an administrator to reactivate it.');
     }
     if (user) await touchUserIdentity(existing.id);
   }
@@ -65,7 +65,7 @@ export async function provisionSsoUser(
     if (byEmail) {
       // Fix 5 (path 2): check isActive before createUserIdentity side effect
       if (!byEmail.isActive) {
-        throw AppError.unauthorized('This account is inactive.');
+        throw AppError.unauthorized('This account is inactive. Contact an administrator to reactivate it.');
       }
       await createUserIdentity({
         userId: byEmail.id,
@@ -146,7 +146,7 @@ export async function provisionSsoUser(
 
   // backstop — final guard before session creation
   if (!user || !user.isActive) {
-    throw AppError.unauthorized('This account is inactive.');
+    throw AppError.unauthorized('This account is inactive. Contact an administrator to reactivate it.');
   }
 
   // Optional role sync

--- a/packages/server/src/routes/fleet.ts
+++ b/packages/server/src/routes/fleet.ts
@@ -21,7 +21,8 @@ import {
   requireAnyPermission,
   getRbacUser,
 } from "../rbac/middleware/rbacAuth";
-import { PERMISSIONS } from "../rbac/schema/base";
+import { PERMISSIONS, AUDIT_ACTIONS } from "../rbac/schema/base";
+import { createAuditLogWithContext } from "../rbac/services/rbac";
 import {
   getUserConnections,
   listConnections,
@@ -587,6 +588,20 @@ fleet.put("/alert-config", zValidator("json", alertConfigSchema), async (c) => {
     return c.json({ success: false, error: "Failed to save config" }, 500);
   }
   logger.info({ module: "FleetAlerter", by: getRbacUser(c).sub }, "Alert delivery config updated");
+  await createAuditLogWithContext(c, AUDIT_ACTIONS.FLEET_ALERT_CONFIG_UPDATE, getRbacUser(c).sub, {
+    resourceType: "fleet_alert_config",
+    details: {
+      enabled: next.enabled,
+      aiRcaOnBreach: next.aiRcaOnBreach,
+      rules: next.rules,
+      channels: {
+        slack: next.slack?.enabled ?? false,
+        googleChat: next.googleChat?.enabled ?? false,
+        email: next.email?.enabled ?? false,
+      },
+    },
+    status: "success",
+  });
   return c.json({ success: true, data: { ok: true } });
 });
 
@@ -652,6 +667,12 @@ fleet.post("/doctor/scan", requirePermission(PERMISSIONS.DOCTOR_RUN), zValidator
     // Persist (+ prune to retention) so the report gets its own page and lands
     // in the history rail. Best-effort — never fails the scan response.
     await saveDoctorReport(report, createdBy, "manual");
+    await createAuditLogWithContext(c, AUDIT_ACTIONS.DOCTOR_SCAN_RUN, createdBy, {
+      resourceType: "doctor_report",
+      resourceId: report.id,
+      details: { hours, modelId, connectionIds: connectionIds ?? null, trigger: "manual" },
+      status: "success",
+    });
     return c.json({ success: true, data: { ...report, createdBy, trigger: "manual" } });
   } catch (e) {
     if (e instanceof AppError) throw e;
@@ -707,6 +728,13 @@ fleet.post("/doctor/reports/delete", zValidator("json", doctorDeleteSchema), asy
   } else if (ids && ids.length > 0) {
     await deleteDoctorReports(ids);
   }
+  if (all || (ids && ids.length > 0)) {
+    await createAuditLogWithContext(c, AUDIT_ACTIONS.DOCTOR_REPORT_DELETE, getRbacUser(c).sub, {
+      resourceType: "doctor_report",
+      details: all ? { all: true } : { ids },
+      status: "success",
+    });
+  }
   return c.json({ success: true, data: { ok: true } });
 });
 
@@ -732,6 +760,18 @@ fleet.put("/doctor/schedule", requirePermission(PERMISSIONS.DOCTOR_RUN), zValida
   // Stamp lastRunAt = now so enabling/editing fires at the NEXT occurrence,
   // not a backfill of a slot that already passed today.
   saveSchedule({ ...body, lastRunAt: Date.now() } as DoctorSchedule);
+  await createAuditLogWithContext(c, AUDIT_ACTIONS.DOCTOR_SCHEDULE_UPDATE, getRbacUser(c).sub, {
+    resourceType: "doctor_schedule",
+    details: {
+      enabled: body.enabled,
+      frequency: body.frequency,
+      hour: body.hour,
+      deliver: body.deliver,
+      hours: body.hours,
+      modelId: body.modelId ?? null,
+    },
+    status: "success",
+  });
   return c.json({ success: true, data: { ok: true } });
 });
 

--- a/packages/server/src/routes/live-queries.ts
+++ b/packages/server/src/routes/live-queries.ts
@@ -14,7 +14,7 @@ import { optionalRbacMiddleware } from "../middleware/dataAccess";
 import { getSession } from "../services/clickhouse";
 import { getUserConnections, getConnectionWithPassword } from "../rbac/services/connections";
 import { ClickHouseService } from "../services/clickhouse";
-import { createAuditLog, userHasPermission, getUserById } from "../rbac/services/rbac";
+import { createAuditLogWithContext, userHasPermission, getUserById } from "../rbac/services/rbac";
 import { AUDIT_ACTIONS, PERMISSIONS, SYSTEM_ROLES } from "../rbac/schema/base";
 import { getClientIp } from "../rbac/middleware/rbacAuth";
 import { requestLogger } from "../utils/logger";
@@ -397,7 +397,8 @@ liveQueries.post("/kill", zValidator("json", killQuerySchema), async (c) => {
 
         // Create audit log
         try {
-            await createAuditLog(
+            await createAuditLogWithContext(
+                c,
                 AUDIT_ACTIONS.LIVE_QUERY_KILL,
                 rbacUserId!,
                 {
@@ -413,7 +414,6 @@ liveQueries.post("/kill", zValidator("json", killQuerySchema), async (c) => {
                         requestUsername: currentUsername
                     },
                     ipAddress: getClientIp(c),
-                    userAgent: c.req.header('User-Agent'),
                     status: 'success',
                 }
             );
@@ -435,7 +435,8 @@ liveQueries.post("/kill", zValidator("json", killQuerySchema), async (c) => {
 
         // Create failed audit log
         try {
-            await createAuditLog(
+            await createAuditLogWithContext(
+                c,
                 AUDIT_ACTIONS.LIVE_QUERY_KILL,
                 rbacUserId!,
                 {
@@ -447,7 +448,6 @@ liveQueries.post("/kill", zValidator("json", killQuerySchema), async (c) => {
                         error: error instanceof Error ? error.message : String(error),
                     },
                     ipAddress: getClientIp(c),
-                    userAgent: c.req.header('User-Agent'),
                     status: 'failure',
                 }
             );

--- a/packages/server/src/routes/query.ts
+++ b/packages/server/src/routes/query.ts
@@ -585,6 +585,27 @@ query.post("/explain", zValidator("json", ExplainRequestSchema), async (c) => {
   const service = c.get("service");
   const plan = await service.getExplainPlan(sql, explainType);
 
+  // Audit log (best-effort, mirrors /execute)
+  if (rbacUserId) {
+    createAuditLogWithContext(c, AUDIT_ACTIONS.CH_QUERY_EXPLAIN, rbacUserId, {
+      resourceType: "query",
+      details: {
+        explainType,
+        query: sql.substring(0, 500),
+        queryLength: sql.length,
+        connectionId: c.get("rbacConnectionId"),
+        timestamp: Date.now(),
+      },
+      ipAddress: getClientIp(c),
+      status: "success",
+    }).catch((err: unknown) => {
+      requestLogger(c.get("requestId")).error(
+        { module: "Query", err: err instanceof Error ? err.message : String(err) },
+        "Failed to create audit log for explain"
+      );
+    });
+  }
+
   return c.json({
     success: true,
     data: plan,

--- a/src/api/rbac.ts
+++ b/src/api/rbac.ts
@@ -28,6 +28,8 @@ export interface RbacUser {
   displayName: string | null;
   avatarUrl: string | null;
   isActive: boolean;
+  /** True when the user has at least one linked SSO identity (no usable local password). */
+  hasSsoIdentity: boolean;
   roles: string[];
   rolesMetadata?: Array<{
     name: string;

--- a/src/features/admin/components/EditUser/index.tsx
+++ b/src/features/admin/components/EditUser/index.tsx
@@ -132,7 +132,10 @@ const EditUser: React.FC = () => {
   const [isDeleting, setIsDeleting] = useState(false);
 
   // SSO identity state
-  const [identities, setIdentities] = useState<SsoIdentityInfo[]>([]);
+  // null = still loading; [] = loaded, no SSO; [...] = loaded, has SSO.
+  // Avoids a flash where the reset-password button appears briefly before we
+  // know the user has SSO identities.
+  const [identities, setIdentities] = useState<SsoIdentityInfo[] | null>(null);
   const [identityToUnlink, setIdentityToUnlink] = useState<SsoIdentityInfo | null>(null);
   const [isUnlinking, setIsUnlinking] = useState(false);
 
@@ -330,7 +333,7 @@ const EditUser: React.FC = () => {
 
     try {
       await rbacUsersApi.unlinkIdentity(userId, identityToUnlink.id);
-      setIdentities((prev) => prev.filter((i) => i.id !== identityToUnlink.id));
+      setIdentities((prev) => (prev ?? []).filter((i) => i.id !== identityToUnlink.id));
       toast.success(`Unlinked ${identityToUnlink.displayName} sign-in`);
       setIdentityToUnlink(null);
     } catch (err) {
@@ -727,14 +730,30 @@ const EditUser: React.FC = () => {
               <h3 className="font-mono text-[11px] uppercase tracking-[0.14em] text-paper">Security</h3>
             </div>
             <div className="space-y-4 p-4">
-              {/* Password Reset */}
+              {/* Password Reset — only for password-based users. SSO accounts
+                  have no usable local password. */}
               <div className="rounded-xs border border-ink-500 bg-ink-200 p-4">
                 <div className="flex items-center justify-between gap-3">
                   <div>
                     <h4 className="text-[13px] font-semibold text-paper">Password</h4>
-                    <p className="mt-1 text-[12px] text-paper-muted">Reset the user's password.</p>
+                    <p className="mt-1 text-[12px] text-paper-muted">
+                      {identities === null
+                        ? "Loading…"
+                        : identities.length === 0
+                        ? "Reset the user's password."
+                        : (() => {
+                            const providers = identities.map((i) =>
+                              i.provider.charAt(0).toUpperCase() + i.provider.slice(1)
+                            );
+                            const providerList =
+                              providers.length === 1
+                                ? providers[0]
+                                : `${providers.slice(0, -1).join(", ")} and ${providers.at(-1)}`;
+                            return `This user authenticates via ${providerList}. Manage credentials through the identity provider.`;
+                          })()}
+                    </p>
                   </div>
-                  {canUpdateUsers && (
+                  {canUpdateUsers && identities !== null && identities.length === 0 && (
                     <Button
                       variant="outline"
                       onClick={() => {
@@ -756,7 +775,9 @@ const EditUser: React.FC = () => {
               {/* SSO Identity */}
               <div className="rounded-xs border border-ink-500 bg-ink-200 p-4">
                 <h4 className="mb-3 font-mono text-[10px] uppercase tracking-[0.14em] text-paper-dim">SSO identity</h4>
-                {identities.length === 0 ? (
+                {identities === null ? (
+                  <p className="text-[12px] italic text-paper-faint">Loading…</p>
+                ) : identities.length === 0 ? (
                   <p className="text-[12px] italic text-paper-faint">
                     No SSO identity linked. This user signs in with a password.
                   </p>

--- a/src/features/admin/components/UserManagement/index.tsx
+++ b/src/features/admin/components/UserManagement/index.tsx
@@ -13,7 +13,6 @@ import {
   Users,
   RefreshCw,
   Plus,
-  Trash2,
   Edit,
   Shield,
   Search,
@@ -145,16 +144,15 @@ const UserManagement: React.FC = () => {
 
   // User management state
   const [selectedUser, setSelectedUser] = useState<RbacUser | null>(null);
-  const [showDeleteDialog, setShowDeleteDialog] = useState(false);
+  const [showToggleActiveDialog, setShowToggleActiveDialog] = useState(false);
   const [showResetPasswordDialog, setShowResetPasswordDialog] = useState(false);
-  const [isDeleting, setIsDeleting] = useState(false);
+  const [isTogglingActive, setIsTogglingActive] = useState(false);
   const [isResettingPassword, setIsResettingPassword] = useState(false);
   const [generatedPassword, setGeneratedPassword] = useState<string | null>(null);
 
   // Permission checks
   const canCreateUsers = hasPermission(RBAC_PERMISSIONS.USERS_CREATE);
   const canUpdateUsers = hasPermission(RBAC_PERMISSIONS.USERS_UPDATE);
-  const canDeleteUsers = hasPermission(RBAC_PERMISSIONS.USERS_DELETE);
 
   // Fetch roles on mount
   useEffect(() => {
@@ -205,20 +203,21 @@ const UserManagement: React.FC = () => {
     setCurrentPage(newPage);
   };
 
-  const handleDeleteUser = async () => {
+  const handleToggleActive = async () => {
     if (!selectedUser) return;
-    setIsDeleting(true);
+    setIsTogglingActive(true);
+    const nextActive = !selectedUser.isActive;
 
     try {
-      await rbacUsersApi.delete(selectedUser.id);
-      toast.success(`User "${selectedUser.username}" deleted successfully`);
-      setShowDeleteDialog(false);
+      await rbacUsersApi.update(selectedUser.id, { isActive: nextActive });
+      toast.success(`User "${selectedUser.username}" ${nextActive ? "activated" : "deactivated"}`);
+      setShowToggleActiveDialog(false);
       setSelectedUser(null);
       fetchUsers();
     } catch (err) {
-      toast.error(`Failed to delete user: ${(err as Error).message}`);
+      toast.error(`Failed to update user: ${(err as Error).message}`);
     } finally {
-      setIsDeleting(false);
+      setIsTogglingActive(false);
     }
   };
 
@@ -249,9 +248,9 @@ const UserManagement: React.FC = () => {
     }
   };
 
-  const openDeleteDialog = (user: RbacUser) => {
+  const openToggleActiveDialog = (user: RbacUser) => {
     setSelectedUser(user);
-    setShowDeleteDialog(true);
+    setShowToggleActiveDialog(true);
   };
 
   const openResetPasswordDialog = (user: RbacUser) => {
@@ -464,8 +463,12 @@ const UserManagement: React.FC = () => {
               const userIsSuperAdmin = user.roles.includes('super_admin');
               // Basic admins cannot edit super admins
               const canEditThisUser = canUpdateUsers && (isSuperAdmin() || !userIsSuperAdmin);
-              const canDeleteThisUser = canDeleteUsers && !isCurrentUser && (isSuperAdmin() || !userIsSuperAdmin);
-              const hasActions = canEditThisUser || canDeleteThisUser;
+              // Reset password is only meaningful for password-based users — SSO
+              // accounts have no usable local password.
+              const canResetPassword = canEditThisUser && !user.hasSsoIdentity;
+              // Deactivation replaces deletion; you can't deactivate yourself.
+              const canToggleActive = canEditThisUser && !isCurrentUser;
+              const hasActions = canResetPassword || canToggleActive;
 
               return (
                 <div
@@ -547,21 +550,31 @@ const UserManagement: React.FC = () => {
                           </Button>
                         </DropdownMenuTrigger>
                         <DropdownMenuContent align="end" className="rounded-xs border-ink-500 bg-ink-100 text-paper">
-                          {canEditThisUser && (
+                          {canResetPassword && (
                             <DropdownMenuItem onClick={() => openResetPasswordDialog(user)} className="cursor-pointer focus:bg-ink-200">
                               <Key className="mr-2 h-3.5 w-3.5" />
                               Reset password
                             </DropdownMenuItem>
                           )}
-                          {canEditThisUser && canDeleteThisUser && <DropdownMenuSeparator className="bg-ink-500" />}
-                          {canDeleteThisUser && (
-                            <DropdownMenuItem
-                              className="cursor-pointer text-red-400 hover:bg-red-950/40 focus:bg-red-950/40 focus:text-red-300"
-                              onClick={() => openDeleteDialog(user)}
-                            >
-                              <Trash2 className="mr-2 h-3.5 w-3.5" />
-                              Delete user
-                            </DropdownMenuItem>
+                          {canResetPassword && canToggleActive && <DropdownMenuSeparator className="bg-ink-500" />}
+                          {canToggleActive && (
+                            user.isActive ? (
+                              <DropdownMenuItem
+                                className="cursor-pointer text-amber-400 hover:bg-amber-950/40 focus:bg-amber-950/40 focus:text-amber-300"
+                                onClick={() => openToggleActiveDialog(user)}
+                              >
+                                <UserX className="mr-2 h-3.5 w-3.5" />
+                                Deactivate user
+                              </DropdownMenuItem>
+                            ) : (
+                              <DropdownMenuItem
+                                className="cursor-pointer text-emerald-400 hover:bg-emerald-950/40 focus:bg-emerald-950/40 focus:text-emerald-300"
+                                onClick={() => openToggleActiveDialog(user)}
+                              >
+                                <UserCheck className="mr-2 h-3.5 w-3.5" />
+                                Activate user
+                              </DropdownMenuItem>
+                            )
                           )}
                         </DropdownMenuContent>
                       </DropdownMenu>
@@ -712,33 +725,51 @@ const UserManagement: React.FC = () => {
         </>
       )}
 
-      {/* Delete Confirmation Dialog */}
-      <AlertDialog open={showDeleteDialog} onOpenChange={setShowDeleteDialog}>
+      {/* Activate / Deactivate Confirmation Dialog */}
+      <AlertDialog open={showToggleActiveDialog} onOpenChange={setShowToggleActiveDialog}>
         <AlertDialogContent>
           <AlertDialogHeader>
             <AlertDialogTitle className="flex items-center gap-2">
-              <AlertTriangle className="h-5 w-5 text-red-500" />
-              Delete User
+              {selectedUser?.isActive ? (
+                <>
+                  <UserX className="h-5 w-5 text-amber-500" />
+                  Deactivate user
+                </>
+              ) : (
+                <>
+                  <UserCheck className="h-5 w-5 text-emerald-500" />
+                  Activate user
+                </>
+              )}
             </AlertDialogTitle>
             <AlertDialogDescription>
-              Are you sure you want to delete user <strong>{selectedUser?.username}</strong>?
-              This action cannot be undone. The user will lose all access to the system.
+              {selectedUser?.isActive ? (
+                <>
+                  Deactivate user <strong>{selectedUser?.username}</strong>? They will be unable to
+                  sign in until an administrator reactivates the account. No data is deleted.
+                </>
+              ) : (
+                <>
+                  Reactivate user <strong>{selectedUser?.username}</strong>? They will be able to
+                  sign in again.
+                </>
+              )}
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
-            <AlertDialogCancel disabled={isDeleting}>Cancel</AlertDialogCancel>
+            <AlertDialogCancel disabled={isTogglingActive}>Cancel</AlertDialogCancel>
             <AlertDialogAction
-              onClick={handleDeleteUser}
-              className="bg-red-600 hover:bg-red-700"
-              disabled={isDeleting}
+              onClick={handleToggleActive}
+              className={selectedUser?.isActive ? "bg-amber-600 hover:bg-amber-700" : "bg-emerald-600 hover:bg-emerald-700"}
+              disabled={isTogglingActive}
             >
-              {isDeleting ? (
+              {isTogglingActive ? (
                 <>
                   <Loader2 className="h-4 w-4 mr-2 animate-spin" />
-                  Deleting...
+                  {selectedUser?.isActive ? "Deactivating..." : "Activating..."}
                 </>
               ) : (
-                "Delete User"
+                selectedUser?.isActive ? "Deactivate" : "Activate"
               )}
             </AlertDialogAction>
           </AlertDialogFooter>

--- a/src/pages/Doctor.tsx
+++ b/src/pages/Doctor.tsx
@@ -38,14 +38,29 @@ import DoctorHistoryList from "@/features/fleet/components/DoctorHistoryList";
 import DoctorScheduleDialog from "@/features/fleet/components/DoctorScheduleDialog";
 import { useRbacStore, RBAC_PERMISSIONS } from "@/stores";
 
-const INVESTIGATION_STEPS = [
-  "Reading the fleet overview",
-  "Drilling into nodes (read-only)",
-  "Checking the last 6h of heavy queries",
-  "Writing the root-cause report",
+const WINDOW_OPTIONS = [
+  { label: "1h", hours: 1 },
+  { label: "6h", hours: 6 },
+  { label: "24h", hours: 24 },
+  { label: "3d", hours: 72 },
 ];
 
-function InvestigatingPanel({ model }: { model?: string }) {
+/** Human label for a lookback window — reuses the picker labels, else `${n}h`. */
+function formatWindowLabel(hours: number): string {
+  return WINDOW_OPTIONS.find((opt) => opt.hours === hours)?.label ?? `${hours}h`;
+}
+
+function buildInvestigationSteps(hours: number): string[] {
+  return [
+    "Reading the fleet overview",
+    "Drilling into nodes (read-only)",
+    `Checking the last ${formatWindowLabel(hours)} of heavy queries`,
+    "Writing the root-cause report",
+  ];
+}
+
+function InvestigatingPanel({ model, hours }: { model?: string; hours: number }) {
+  const steps = buildInvestigationSteps(hours);
   return (
     <div className="flex flex-col items-center gap-5 py-16 text-center">
       <span className="relative grid h-16 w-16 place-items-center">
@@ -64,7 +79,7 @@ function InvestigatingPanel({ model }: { model?: string }) {
         </p>
       </div>
       <ul className="flex flex-col gap-1.5">
-        {INVESTIGATION_STEPS.map((step, i) => (
+        {steps.map((step, i) => (
           <li
             key={i}
             className="flex items-center gap-2 font-mono text-[11px] text-paper-muted"
@@ -78,13 +93,6 @@ function InvestigatingPanel({ model }: { model?: string }) {
     </div>
   );
 }
-
-const WINDOW_OPTIONS = [
-  { label: "1h", hours: 1 },
-  { label: "6h", hours: 6 },
-  { label: "24h", hours: 24 },
-  { label: "3d", hours: 72 },
-];
 
 /** Investigation window (lookback) selector — segmented button group. */
 function WindowSelect({
@@ -600,7 +608,7 @@ export default function Doctor() {
                 OpenAI-compatible — including a local model) to use Chouse AI.
               </p>
             ) : scan.isPending && viewingRunning ? (
-              <InvestigatingPanel model={models.find((m) => m.id === resolvedModelId)?.model} />
+              <InvestigatingPanel model={models.find((m) => m.id === resolvedModelId)?.model} hours={hours} />
             ) : reportId && reportQuery.data ? (
               <DoctorReportView report={reportQuery.data} />
             ) : reportId && reportQuery.isLoading ? (


### PR DESCRIPTION
## Description

A batch of auth/UX hardening fixes and audit log gaps closed on the `fix/auth-ux-fleet-audit` branch. Also adds CHANGELOG trimming + pre-approval visibility to the release workflow.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Other (please describe):

## Related Issue

Closes #248

## Changes Made

### Auth / security
- **Inactive account message** — password sign-in for an inactive account now returns a clear actionable message (`"This account is inactive. Contact an administrator to reactivate it."`) _after_ password verification, so the message is only reachable with correct credentials (prevents user enumeration). SSO `provisionSsoUser` wording aligned.
- **SSO break-glass** — existing behaviour preserved; admins can still sign in with a password even if SSO is configured.

### User management UI
- **Delete → Deactivate/Activate** — the destructive "Delete user" action in the user card dropdown is replaced by a reversible "Deactivate user" / "Activate user" toggle. Deactivated users are blocked from signing in but all data is retained. The confirmation dialog and button colours are context-aware (amber for deactivate, emerald for activate).
- **`hasSsoIdentity` field** — added to `UserResponse` (server), `RbacUser` (frontend API type), and populated via `expandUserResponse`. The user-card dropdown hides "Reset password" for SSO accounts; the edit-user Security tab shows a provider-aware message and hides the Reset button instead of flashing it before identities load.
- **SSO identities loading state** — `identities` state in `EditUser` is now `SsoIdentityInfo[] | null` (null = still loading) to eliminate the flash where the Reset Password button appears before identities are fetched.

### Audit log coverage
- `FLEET_ALERT_CONFIG_UPDATE` — fired on `PUT /fleet/alert-config`
- `DOCTOR_SCAN_RUN` — fired on `POST /fleet/doctor/scan`
- `DOCTOR_SCHEDULE_UPDATE` — fired on `PUT /fleet/doctor/schedule`
- `DOCTOR_REPORT_DELETE` — fired on `POST /fleet/doctor/reports/delete`
- `CH_QUERY_EXPLAIN` — best-effort (fire-and-forget) on `POST /query/explain`
- Live-query kill migrated to `createAuditLogWithContext` (removes the manual `userAgent` extraction that was already done inside the helper)

### Fleet Doctor UX
- The "analyzing…" progress panel's step list now reflects the selected lookback window (`"Checking the last 24h of heavy queries"`) instead of always showing `"6h"`. `WINDOW_OPTIONS` moved before `InvestigatingPanel` to fix the forward-reference.

### Release workflow (`auto-release.yml`)
- **Trim CHANGELOG to 10 entries** — a new `Trim CHANGELOG to latest 10 releases` step (after `Run release script`, before the commit) keeps only the 10 newest versioned sections, preventing unbounded file growth.
- **Pre-approval visibility** — the `Write release summary` step now appends a collapsible `<details>` block to the GitHub Actions step summary showing the full post-trim CHANGELOG (with entry count), so the approver can verify what will land on `main` before clicking Approve.

## Testing

- [x] I have tested this locally
- [x] I have added/updated tests (`rbac.services/rbac.test.ts` — inactive-account auth path)
- [x] All existing tests pass

### Test Steps
1. Create a user, deactivate them from the user card — confirm sign-in returns the inactive message and the account still exists.
2. Reactivate the account — confirm sign-in works again.
3. Link an SSO identity to a user — confirm "Reset password" is hidden on both the user card dropdown and the edit-user Security tab.
4. Trigger the release workflow — check step summary shows "Full retained CHANGELOG (N entries)" collapsible.

## Screenshots

N/A (no new visual surfaces; changes are in existing dialogs/dropdowns)

## Changelog Fragment

- [x] Added `changelogs/unreleased/248-auth-ux-fleet-audit.md`

## Checklist

- [x] My code follows the project's code style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] I have checked for breaking changes and documented them (if applicable)
- [x] I have tested the changes in the relevant environment (development/production)

## Additional Notes

The `hasSsoIdentity` field is additive — existing API consumers that don't destructure it are unaffected. The workflow trim is idempotent (if there are ≤ 10 entries, nothing changes).