### PR TITLE
feat(sso): provider brand icons + audit JIT provisioning & linking

### DIFF
--- a/changelogs/unreleased/252-sso-login-brand-icons.md
+++ b/changelogs/unreleased/252-sso-login-brand-icons.md
@@ -1,0 +1,6 @@
+type: minor
+
+### Changed
+- **SSO provider brand icons** — enabled SSO providers now show a recognisable brand logo (Google, Microsoft, Okta, GitHub, GitLab, Apple, Slack, AWS, Auth0, …) inferred automatically from the provider, falling back to a generic glyph for unrecognised providers. Icons adapt to light/dark themes and appear on the login page, the admin SSO providers list, and each user's linked SSO identities.
+- **Login page SSO** — providers render as compact labelled buttons with their brand icon; when more than three are enabled the extras collapse behind a "Show more" toggle so the password form stays in view.
+- **Admin → SSO** — the Single sign-on section now has a proper titled header, and the "Global settings" / "Providers" sub-sections use distinct, meaningful icons.

--- a/changelogs/unreleased/253-explorer-modal-theme-consistency.md
+++ b/changelogs/unreleased/253-explorer-modal-theme-consistency.md
@@ -1,0 +1,5 @@
+type: patch
+
+### Changed
+- **Explorer → Create Database** — the dialog now follows the same editorial layout as Create Table / Alter Table: themed `ink/paper` window surface, an icon + mono eyebrow title, mono-uppercase field labels, and a brand-coloured primary action, instead of the previous off-style card.
+- **Explorer → Import data (upload file)** — replaced the hardcoded emerald accent with the app's `brand` theme token across the dropzone, progress, step dots, buttons, and selects so the wizard matches the rest of the UI in both light and dark themes.

--- a/changelogs/unreleased/253-sso-audit-provisioning.md
+++ b/changelogs/unreleased/253-sso-audit-provisioning.md
@@ -1,0 +1,4 @@
+type: minor
+
+### Added
+- **SSO sign-in audit coverage** — first-time SSO sign-ins now record their outcome in the audit log: `sso.user_provision` when an account is just-in-time created, and `sso.identity_link` when an SSO identity is auto-linked to an existing user by verified email. These are written alongside the existing `auth.sso_login` entry, so JIT provisioning and account linking are no longer invisible to auditors.

--- a/packages/server/src/rbac/schema/base.ts
+++ b/packages/server/src/rbac/schema/base.ts
@@ -366,6 +366,9 @@ export const AUDIT_ACTIONS = {
   SSO_PROVIDER_UPDATE: 'sso.provider_update',
   SSO_PROVIDER_DELETE: 'sso.provider_delete',
   SSO_PROVIDER_TEST: 'sso.provider_test',
+  // SSO sign-in provisioning outcomes (recorded alongside SSO_LOGIN)
+  SSO_USER_PROVISION: 'sso.user_provision',
+  SSO_IDENTITY_LINK: 'sso.identity_link',
 
   // Role Management
   ROLE_CREATE: 'role.create',

--- a/packages/server/src/rbac/sso/routes.test.ts
+++ b/packages/server/src/rbac/sso/routes.test.ts
@@ -564,6 +564,7 @@ describe("SSO Routes", () => {
       mockProvisionSsoUser.mockResolvedValue({
         user: { id: "user-happy", username: "happyuser" },
         tokens: { accessToken: "access-tok", refreshToken: "refresh-tok" },
+        outcome: "authenticated",
       });
 
       const res = await app.request(`/sso/callback`, {
@@ -587,6 +588,84 @@ describe("SSO Routes", () => {
         expect.anything(),
         "auth.sso_login",
         "user-happy",
+        expect.objectContaining({ status: "success" })
+      );
+      // A plain sign-in on an existing link records only SSO_LOGIN.
+      const actions = mockCreateAuditLogWithContext.mock.calls.map((args) => args[1]);
+      expect(actions).not.toContain("sso.user_provision");
+      expect(actions).not.toContain("sso.identity_link");
+    });
+
+    it("records sso.user_provision alongside SSO_LOGIN when a user is JIT-provisioned", async () => {
+      mockGetSsoConfig.mockReturnValue(makeEnabledConfig());
+
+      const stateCookieValue = await buildStateCookie({ state: "state-jit" });
+      mockExchangeCodeForIdentity.mockResolvedValue({
+        provider: PROVIDER_ID,
+        subject: "sub-jit",
+        email: "jit@example.com",
+        emailVerified: true,
+        username: "jituser",
+        displayName: "JIT User",
+        claims: {},
+      });
+      mockProvisionSsoUser.mockResolvedValue({
+        user: { id: "user-jit", username: "jituser" },
+        tokens: { accessToken: "at-jit", refreshToken: "rt-jit" },
+        outcome: "created",
+      });
+
+      const res = await app.request(`/sso/callback`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Cookie: `${SSO_STATE_COOKIE}=${stateCookieValue}`,
+        },
+        body: JSON.stringify({ params: "code=code-jit&state=state-jit" }),
+      });
+
+      expect(res.status).toBe(200);
+      expect(mockCreateAuditLogWithContext).toHaveBeenCalledWith(
+        expect.anything(),
+        "sso.user_provision",
+        "user-jit",
+        expect.objectContaining({ status: "success", details: expect.objectContaining({ provider: PROVIDER_ID }) })
+      );
+    });
+
+    it("records sso.identity_link alongside SSO_LOGIN when an identity is auto-linked by email", async () => {
+      mockGetSsoConfig.mockReturnValue(makeEnabledConfig());
+
+      const stateCookieValue = await buildStateCookie({ state: "state-link" });
+      mockExchangeCodeForIdentity.mockResolvedValue({
+        provider: PROVIDER_ID,
+        subject: "sub-link",
+        email: "link@example.com",
+        emailVerified: true,
+        username: "linkuser",
+        displayName: "Link User",
+        claims: {},
+      });
+      mockProvisionSsoUser.mockResolvedValue({
+        user: { id: "user-link", username: "linkuser" },
+        tokens: { accessToken: "at-link", refreshToken: "rt-link" },
+        outcome: "linked",
+      });
+
+      const res = await app.request(`/sso/callback`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Cookie: `${SSO_STATE_COOKIE}=${stateCookieValue}`,
+        },
+        body: JSON.stringify({ params: "code=code-link&state=state-link" }),
+      });
+
+      expect(res.status).toBe(200);
+      expect(mockCreateAuditLogWithContext).toHaveBeenCalledWith(
+        expect.anything(),
+        "sso.identity_link",
+        "user-link",
         expect.objectContaining({ status: "success" })
       );
     });

--- a/packages/server/src/rbac/sso/routes.ts
+++ b/packages/server/src/rbac/sso/routes.ts
@@ -10,7 +10,7 @@ import { getSsoConfig } from "./config";
 import { buildAuthorizationRedirect, exchangeCodeForIdentity } from "./client";
 import { buildSamlAuthnRequest, validateSamlResponse, resolveSamlProviderByIssuer, extractSamlIssuer, summarizeSamlResponse } from "./saml/client";
 import { stashTokens, claimTokens, markAssertionSeen } from "./saml/handoff";
-import { provisionSsoUser } from "./service";
+import { provisionSsoUser, type SsoProvisionOutcome } from "./service";
 import { describeSsoError } from "./errors";
 import {
   signStatePayload,
@@ -64,6 +64,39 @@ function safeRedirect(target: string | undefined): string {
 
 const isProduction = (): boolean =>
   (process.env.NODE_ENV || "development") === "production";
+
+/**
+ * Record the security-relevant outcome of an SSO sign-in (a JIT-provisioned
+ * account, or an identity auto-linked to an existing user) in the audit log,
+ * alongside the SSO_LOGIN entry. A plain successful login on an existing link
+ * adds nothing here. Audit failures must never block sign-in.
+ */
+async function auditProvisionOutcome(
+  c: Context,
+  outcome: SsoProvisionOutcome,
+  userId: string,
+  details: Record<string, unknown>,
+  ipAddress?: string,
+): Promise<void> {
+  let action: typeof AUDIT_ACTIONS.SSO_USER_PROVISION | typeof AUDIT_ACTIONS.SSO_IDENTITY_LINK;
+  if (outcome === "created") action = AUDIT_ACTIONS.SSO_USER_PROVISION;
+  else if (outcome === "linked") action = AUDIT_ACTIONS.SSO_IDENTITY_LINK;
+  else return;
+  try {
+    await createAuditLogWithContext(c, action, userId, {
+      resourceType: "user",
+      resourceId: userId,
+      details,
+      ipAddress,
+      status: "success",
+    });
+  } catch (error) {
+    requestLogger(c.get("requestId")).warn(
+      { module: "SSO", action, userId, err: error instanceof Error ? error.message : String(error) },
+      "Failed to write SSO provisioning audit entry",
+    );
+  }
+}
 
 /**
  * GET /rbac/auth/sso/providers — public list for the login page.
@@ -264,6 +297,7 @@ ssoRoutes.post("/callback", zValidator("json", CallbackSchema), async (c) => {
       ipAddress,
       status: "success",
     });
+    await auditProvisionOutcome(c, result.outcome, result.user.id, { provider: providerId }, ipAddress);
 
     return c.json({
       success: true,
@@ -416,6 +450,13 @@ export const samlAcsHandler = async (c: Context): Promise<Response> => {
       ipAddress,
       status: "success",
     });
+    await auditProvisionOutcome(
+      c,
+      result.outcome,
+      result.user.id,
+      { provider: providerId, binding: "saml" },
+      ipAddress,
+    );
 
     const code = stashTokens(
       { user: result.user, tokens: result.tokens, redirect },

--- a/packages/server/src/rbac/sso/service.test.ts
+++ b/packages/server/src/rbac/sso/service.test.ts
@@ -253,7 +253,7 @@ describe("provisionSsoUser", () => {
     expect(mockFns.createUser).not.toHaveBeenCalled();
     expect(mockFns.createUserIdentity).not.toHaveBeenCalled();
     expect(mockFns.createSessionAndTokens).toHaveBeenCalled();
-    expect(result).toEqual(mockCreateSessionResult);
+    expect(result).toEqual({ ...mockCreateSessionResult, outcome: "authenticated" });
   });
 
   // ----------------------------------------------------------------
@@ -264,7 +264,7 @@ describe("provisionSsoUser", () => {
     mockGetUserByEmailResult = existingUserRow;
 
     const identity = makeIdentity({ emailVerified: true });
-    await provisionSsoUser(makeProvider(), identity);
+    const result = await provisionSsoUser(makeProvider(), identity);
 
     expect(mockFns.createUserIdentity).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -276,6 +276,8 @@ describe("provisionSsoUser", () => {
     );
     expect(mockFns.createUser).not.toHaveBeenCalled();
     expect(mockFns.createSessionAndTokens).toHaveBeenCalled();
+    // Auto-link by email is a distinct, auditable outcome.
+    expect(result.outcome).toBe("linked");
   });
 
   // ----------------------------------------------------------------
@@ -292,7 +294,7 @@ describe("provisionSsoUser", () => {
     mockDbUserRow = newUser;
 
     const identity = makeIdentity({ emailVerified: false });
-    await provisionSsoUser(makeProvider(), identity);
+    const result = await provisionSsoUser(makeProvider(), identity);
 
     // Should NOT link to existing user by email
     // Should call createUser instead (JIT)
@@ -301,6 +303,8 @@ describe("provisionSsoUser", () => {
     expect(mockFns.createUserIdentity).toHaveBeenCalledWith(
       expect.objectContaining({ userId: "new-jit-id" })
     );
+    // A JIT-provisioned account is a distinct, auditable outcome.
+    expect(result.outcome).toBe("created");
   });
 
   // ----------------------------------------------------------------
@@ -519,7 +523,7 @@ describe("provisionSsoUser", () => {
 
     // Session should be created — using the winner's row
     expect(mockFns.createSessionAndTokens).toHaveBeenCalled();
-    expect(result).toEqual(mockCreateSessionResult);
+    expect(result).toEqual({ ...mockCreateSessionResult, outcome: "authenticated" });
     // getUserIdentity was called twice: once initial, once to re-resolve
     expect(getUserIdentityCallCount).toBe(2);
   });
@@ -556,7 +560,7 @@ describe("provisionSsoUser", () => {
     const result = await provisionSsoUser(makeProvider(), makeIdentity());
 
     expect(mockFns.createSessionAndTokens).toHaveBeenCalled();
-    expect(result).toEqual(mockCreateSessionResult);
+    expect(result).toEqual({ ...mockCreateSessionResult, outcome: "authenticated" });
     expect(getUserIdentityCallCount).toBe(2);
   });
 

--- a/packages/server/src/rbac/sso/service.ts
+++ b/packages/server/src/rbac/sso/service.ts
@@ -31,12 +31,19 @@ import type { TokenPair } from '../services/jwt';
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type AnyDb = any;
 
+/**
+ * How an SSO sign-in resolved to a local user. Surfaced so the route layer can
+ * record the security-relevant outcomes (JIT provisioning, identity linking) in
+ * the audit log, not just the generic SSO_LOGIN.
+ */
+export type SsoProvisionOutcome = 'authenticated' | 'linked' | 'created';
+
 export async function provisionSsoUser(
   provider: SsoProviderConfig,
   identity: SsoIdentity,
   ipAddress?: string,
   userAgent?: string
-): Promise<{ user: UserResponse; tokens: TokenPair }> {
+): Promise<{ user: UserResponse; tokens: TokenPair; outcome: SsoProvisionOutcome }> {
   const config = getSsoConfig();
   const db = getDatabase() as AnyDb;
   const schema = getSchema();
@@ -52,6 +59,7 @@ export async function provisionSsoUser(
   );
 
   let user: User | null = null;
+  let outcome: SsoProvisionOutcome = 'authenticated';
 
   // 1. Existing identity link
   const existing = await getUserIdentity(provider.id, identity.subject);
@@ -84,6 +92,7 @@ export async function provisionSsoUser(
         email: identity.email,
       });
       user = byEmail;
+      outcome = 'linked';
       logger.info(
         { module: 'SSO', provider: provider.id, userId: byEmail.id },
         'Linked SSO identity to existing user by email'
@@ -125,6 +134,7 @@ export async function provisionSsoUser(
         .where(eq(schema.users.id, created.id))
         .limit(1);
       user = rows[0] || null;
+      outcome = 'created';
       logger.info(
         { module: 'SSO', provider: provider.id, userId: created.id },
         'JIT-provisioned user from SSO login'
@@ -168,7 +178,8 @@ export async function provisionSsoUser(
     );
   }
 
-  return createSessionAndTokens(user, ipAddress, userAgent);
+  const session = await createSessionAndTokens(user, ipAddress, userAgent);
+  return { ...session, outcome };
 }
 
 /** Lowercase, strip disallowed chars, suffix 2,3,... on collision; cap at 50, then UUID fallback. */

--- a/src/features/admin/components/EditUser/index.tsx
+++ b/src/features/admin/components/EditUser/index.tsx
@@ -25,7 +25,6 @@ import {
   UserX,
   UserCheck,
   Database,
-  Link2,
   Unlink,
 } from "lucide-react";
 import { useNavigate, useParams } from "react-router-dom";
@@ -58,6 +57,7 @@ import {
 } from "@/components/ui/dialog";
 import { rbacUsersApi, rbacRolesApi, type RbacUser, type RbacRole, type UpdateUserInput, type SsoIdentityInfo } from "@/api/rbac";
 import { useRbacStore, RBAC_PERMISSIONS } from "@/stores";
+import { SsoProviderIcon } from "@/features/auth/SsoProviderIcon";
 import { formatDistanceToNow, format } from "date-fns";
 
 // Editorial: uniform hairline chrome for every role; identity is conveyed by
@@ -789,8 +789,11 @@ const EditUser: React.FC = () => {
                         className="flex items-center justify-between gap-3 rounded-xs border border-ink-500 bg-ink-100 px-3 py-2.5"
                       >
                         <div className="flex min-w-0 items-center gap-3">
-                          <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-xs border border-emerald-800 bg-emerald-950/30">
-                            <Link2 className="h-3.5 w-3.5 text-emerald-300" aria-hidden />
+                          <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-xs border border-ink-500 bg-ink-200">
+                            <SsoProviderIcon
+                              provider={{ id: identity.provider, displayName: identity.displayName }}
+                              className="h-4 w-4"
+                            />
                           </div>
                           <div className="min-w-0">
                             <div className="flex items-center gap-2">

--- a/src/features/admin/components/SsoSettings/index.tsx
+++ b/src/features/admin/components/SsoSettings/index.tsx
@@ -18,6 +18,8 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import {
   KeyRound,
+  SlidersHorizontal,
+  Boxes,
   Plus,
   Pencil,
   Trash2,
@@ -103,6 +105,7 @@ import {
   type SsoTestResult,
 } from "@/api/rbac";
 import { useRbacStore, RBAC_PERMISSIONS } from "@/stores";
+import { SsoProviderIcon } from "@/features/auth/SsoProviderIcon";
 
 // Shared editorial chrome classes (match ConnectionManagement / DataAccessPolicies).
 const LABEL_CLASS = "font-mono text-[10px] uppercase tracking-[0.14em] text-paper-dim";
@@ -571,7 +574,7 @@ function SettingsPanel({ canEdit }: { canEdit: boolean }) {
   return (
     <div className="rounded-xs border border-ink-500 bg-ink-100">
       <div className="flex items-center gap-2 border-b border-ink-500 px-4 py-3">
-        <KeyRound className="h-3.5 w-3.5 text-paper-dim" aria-hidden />
+        <SlidersHorizontal className="h-3.5 w-3.5 text-paper-dim" aria-hidden />
         <h3 className="font-mono text-[11px] uppercase tracking-[0.14em] text-paper">Global settings</h3>
         {settings && (
           <span
@@ -1048,7 +1051,10 @@ function ProviderWizard({ open, onClose, editing }: ProviderWizardProps) {
       <DialogContent className="flex max-h-[90vh] max-w-2xl flex-col overflow-hidden rounded-xs border-ink-500 bg-ink-100">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2 text-paper">
-            <KeyRound className="h-4 w-4 text-paper-dim" />
+            <SsoProviderIcon
+              provider={{ id: draft.id, displayName: draft.displayName, type: draft.type }}
+              className="h-4 w-4"
+            />
             {isEditing ? `Edit provider — ${editing?.displayName}` : "Add SSO provider"}
           </DialogTitle>
           <DialogDescription className="text-paper-muted">
@@ -1797,7 +1803,7 @@ function ProvidersPanel({ canEdit, canDelete }: { canEdit: boolean; canDelete: b
   return (
     <div className="rounded-xs border border-ink-500 bg-ink-100">
       <div className="flex items-center gap-2 border-b border-ink-500 px-4 py-3">
-        <KeyRound className="h-3.5 w-3.5 text-paper-dim" aria-hidden />
+        <Boxes className="h-3.5 w-3.5 text-paper-dim" aria-hidden />
         <h3 className="font-mono text-[11px] uppercase tracking-[0.14em] text-paper">Providers</h3>
         {canEdit && (
           <Button
@@ -1818,7 +1824,7 @@ function ProvidersPanel({ canEdit, canDelete }: { canEdit: boolean; canDelete: b
           </div>
         ) : !providers || providers.length === 0 ? (
           <div className="px-6 py-10 text-center">
-            <KeyRound className="mx-auto mb-3 h-7 w-7 text-paper-faint" aria-hidden />
+            <Boxes className="mx-auto mb-3 h-7 w-7 text-paper-faint" aria-hidden />
             <p className="font-mono text-[11px] uppercase tracking-[0.18em] text-paper-dim">No SSO providers</p>
             <p className="mt-2 text-[12px] text-paper-muted">
               Add an OIDC, OAuth2, or SAML provider, or configure one via environment variables.
@@ -1835,7 +1841,7 @@ function ProvidersPanel({ canEdit, canDelete }: { canEdit: boolean; canDelete: b
                 >
                   <div className="flex min-w-0 items-center gap-3">
                     <span className="grid h-8 w-8 shrink-0 place-items-center rounded-xs border border-ink-500 bg-ink-100 text-paper-muted">
-                      <KeyRound className="h-3.5 w-3.5" aria-hidden />
+                      <SsoProviderIcon provider={provider} className="h-4 w-4" />
                     </span>
                     <div className="min-w-0">
                       <div className="flex flex-wrap items-center gap-2">
@@ -2046,14 +2052,16 @@ const SsoSettings: React.FC = () => {
 
   return (
     <div className="space-y-4 p-4">
-      <div className="flex flex-col gap-1">
-        <span className="inline-flex items-center gap-2 font-mono text-[10px] uppercase tracking-[0.18em] text-paper-dim">
-          <span className="h-px w-6 bg-ink-700" />
-          <span>Single sign-on</span>
+      <div className="flex items-center gap-3">
+        <span className="grid h-9 w-9 place-items-center rounded-xs border border-ink-500 bg-ink-200 text-paper-muted">
+          <KeyRound className="h-4 w-4" aria-hidden />
         </span>
-        <p className="text-[12px] text-paper-muted">
-          Global SSO settings and OIDC / OAuth2 / SAML providers. Providers from environment config are read-only.
-        </p>
+        <div className="flex flex-col gap-0.5">
+          <h2 className="text-[18px] font-semibold tracking-tight text-paper">Single sign-on</h2>
+          <p className="font-mono text-[10px] uppercase tracking-[0.14em] text-paper-faint">
+            Global SSO settings & OIDC / OAuth2 / SAML providers
+          </p>
+        </div>
       </div>
 
       <SettingsPanel canEdit={canEdit} />

--- a/src/features/auth/SsoProviderIcon.tsx
+++ b/src/features/auth/SsoProviderIcon.tsx
@@ -1,0 +1,119 @@
+/**
+ * SSO provider brand icons.
+ *
+ * Renders a recognisable logo for the inferred brand (see {@link resolveSsoBrand}).
+ * Multi-colour marks (Google, Microsoft, …) carry their own brand colours, so
+ * they read correctly on both light and dark backgrounds. Monochrome marks
+ * (GitHub, Apple) and the generic protocol fallbacks use `currentColor`, so they
+ * adapt to the surrounding theme.
+ */
+
+import type { ReactElement } from "react";
+import { KeyRound, ShieldCheck } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { resolveSsoBrand, type SsoBrand, type SsoBrandInput } from "./ssoBrand";
+
+interface SsoProviderIconProps {
+  provider: SsoBrandInput;
+  className?: string;
+}
+
+type BrandSvg = (props: { className?: string }) => ReactElement;
+
+const SVG_PROPS = {
+  viewBox: "0 0 24 24",
+  xmlns: "http://www.w3.org/2000/svg",
+  "aria-hidden": true,
+} as const;
+
+const BRAND_RENDERERS: Partial<Record<SsoBrand, BrandSvg>> = {
+  google: ({ className }) => (
+    <svg {...SVG_PROPS} className={className}>
+      <path fill="#4285F4" d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 0 1-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z" />
+      <path fill="#34A853" d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84A11 11 0 0 0 12 23z" />
+      <path fill="#FBBC05" d="M5.84 14.1a6.6 6.6 0 0 1 0-4.2V7.06H2.18a11 11 0 0 0 0 9.88l3.66-2.84z" />
+      <path fill="#EA4335" d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.06l3.66 2.84C6.71 7.31 9.14 5.38 12 5.38z" />
+    </svg>
+  ),
+  microsoft: ({ className }) => (
+    <svg {...SVG_PROPS} className={className}>
+      <path fill="#F25022" d="M11.4 11.4H2V2h9.4z" />
+      <path fill="#7FBA00" d="M22 11.4h-9.4V2H22z" />
+      <path fill="#00A4EF" d="M11.4 22H2v-9.4h9.4z" />
+      <path fill="#FFB900" d="M22 22h-9.4v-9.4H22z" />
+    </svg>
+  ),
+  okta: ({ className }) => (
+    <svg {...SVG_PROPS} className={className}>
+      <path
+        fill="#007DC1"
+        fillRule="evenodd"
+        d="M12 2a10 10 0 1 0 0 20 10 10 0 0 0 0-20zm0 5a5 5 0 1 1 0 10 5 5 0 0 1 0-10z"
+      />
+    </svg>
+  ),
+  github: ({ className }) => (
+    <svg {...SVG_PROPS} className={className}>
+      <path
+        fill="currentColor"
+        d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"
+      />
+    </svg>
+  ),
+  gitlab: ({ className }) => (
+    <svg {...SVG_PROPS} className={className}>
+      <path
+        fill="#FC6D26"
+        d="m23.6 9.6-.03-.09-3.26-8.5a.85.85 0 0 0-1.62.08l-2.2 6.73H7.51l-2.2-6.73a.85.85 0 0 0-1.62-.08L.43 9.51l-.03.1a6.05 6.05 0 0 0 2.01 7l.04.03 4.96 3.72 2.46 1.86 1.5 1.13a1 1 0 0 0 1.2 0l1.5-1.13 2.46-1.86 5-3.74.01-.01a6.05 6.05 0 0 0 2.06-6.91z"
+      />
+    </svg>
+  ),
+  auth0: ({ className }) => (
+    <svg {...SVG_PROPS} className={className}>
+      <path
+        fill="#EB5424"
+        d="M21.98 7.45 19.62 0H4.35L2.02 7.45c-1.35 4.3.03 9.2 3.82 12.01L12.01 24l6.15-4.55c3.76-2.81 5.18-7.69 3.82-12.01l-6.16 4.58 2.34 7.44-6.15-4.59-6.16 4.58 2.36-7.43L2.02 7.43l7.63-.02L12.01 0l2.36 7.41 7.61.04z"
+      />
+    </svg>
+  ),
+  apple: ({ className }) => (
+    <svg {...SVG_PROPS} className={className}>
+      <path
+        fill="currentColor"
+        d="M17.05 12.04c-.03-2.6 2.13-3.85 2.22-3.91-1.21-1.77-3.1-2.01-3.77-2.04-1.6-.16-3.13.94-3.94.94-.81 0-2.07-.92-3.4-.9-1.75.03-3.36 1.02-4.26 2.58-1.82 3.16-.47 7.83 1.3 10.39.86 1.25 1.89 2.66 3.24 2.61 1.3-.05 1.79-.84 3.36-.84 1.57 0 2.01.84 3.39.81 1.4-.03 2.28-1.28 3.14-2.54.99-1.45 1.4-2.86 1.42-2.93-.03-.01-2.72-1.04-2.75-4.13zM14.6 4.5c.72-.87 1.2-2.08 1.07-3.28-1.03.04-2.28.69-3.02 1.56-.66.77-1.24 2-1.08 3.18 1.15.09 2.32-.58 3.03-1.46z"
+      />
+    </svg>
+  ),
+  slack: ({ className }) => (
+    <svg {...SVG_PROPS} className={className}>
+      <path fill="#36C5F0" d="M9.04 2.5a2.27 2.27 0 1 0 0 4.54h2.27V4.77A2.27 2.27 0 0 0 9.04 2.5m0 6.04H3a2.27 2.27 0 1 0 0 4.54h6.04a2.27 2.27 0 1 0 0-4.54" />
+      <path fill="#2EB67D" d="M21.5 10.81a2.27 2.27 0 1 0-4.54 0v2.27h2.27a2.27 2.27 0 0 0 2.27-2.27m-6.04 0V4.77a2.27 2.27 0 1 0-4.54 0v6.04a2.27 2.27 0 1 0 4.54 0" />
+      <path fill="#ECB22E" d="M12.96 21.5a2.27 2.27 0 1 0 0-4.54h-2.27v2.27c0 1.25 1.02 2.27 2.27 2.27m0-6.04H19a2.27 2.27 0 1 0 0-4.54h-6.04a2.27 2.27 0 1 0 0 4.54" />
+      <path fill="#E01E5A" d="M2.5 13.19a2.27 2.27 0 1 0 4.54 0v-2.27H4.77A2.27 2.27 0 0 0 2.5 13.19m6.04 0v6.04a2.27 2.27 0 1 0 4.54 0v-6.04a2.27 2.27 0 1 0-4.54 0" />
+    </svg>
+  ),
+  amazon: ({ className }) => (
+    <svg {...SVG_PROPS} className={className}>
+      <path
+        fill="#FF9900"
+        d="M15.93 17.09c-1.94 1.43-4.76 2.2-7.18 2.2-3.4 0-6.46-1.26-8.77-3.35-.18-.16-.02-.39.2-.26 2.5 1.45 5.58 2.33 8.77 2.33 2.15 0 4.5-.45 6.68-1.37.33-.14.6.22.28.45m.81-.93c-.25-.32-1.64-.15-2.27-.08-.19.02-.22-.14-.05-.27 1.11-.78 2.93-.55 3.14-.29.21.26-.06 2.09-1.1 2.96-.16.14-.31.06-.24-.11.23-.58.74-1.87.52-2.14"
+      />
+      <path
+        fill="#FF9900"
+        d="M13.78 9.3v-1.1c0-.17.13-.28.28-.28h4.93c.16 0 .29.12.29.28v.95c0 .16-.14.37-.38.7l-2.55 3.64c.95-.02 1.95.12 2.81.6.19.11.24.27.26.43v1.18c0 .17-.18.36-.37.26-1.51-.79-3.51-.88-5.18.01-.18.09-.36-.09-.36-.26v-1.12c0-.18 0-.49.19-.77l2.96-4.24h-2.57c-.16 0-.29-.11-.31-.28M5.4 16.18H3.9a.28.28 0 0 1-.27-.25V8.22c0-.15.13-.27.29-.27h1.4c.15.01.27.13.28.26v1.01h.03c.36-.97 1.05-1.43 1.98-1.43.94 0 1.53.46 1.95 1.43.37-.97 1.2-1.43 2.08-1.43.63 0 1.32.26 1.74.84.47.65.37 1.59.37 2.42v4.88c0 .15-.13.27-.29.27h-1.5a.28.28 0 0 1-.27-.27v-4.1c0-.32.03-1.14-.04-1.45-.11-.52-.45-.66-.89-.66-.37 0-.75.25-.91.64-.16.4-.14 1.05-.14 1.47v4.1c0 .15-.13.27-.29.27H8.62a.28.28 0 0 1-.27-.27l-.01-4.1c0-.86.14-2.13-.93-2.13-1.08 0-1.04 1.24-1.04 2.13v4.1c0 .15-.13.27-.29.27"
+      />
+    </svg>
+  ),
+};
+
+/** Brand mark for a provider, with a generic protocol glyph as the fallback. */
+export function SsoProviderIcon({ provider, className }: SsoProviderIconProps) {
+  const brand = resolveSsoBrand(provider);
+  const Renderer = BRAND_RENDERERS[brand];
+  if (Renderer) {
+    return <Renderer className={cn("h-5 w-5 shrink-0", className)} />;
+  }
+  // generic-saml → shield, generic-oidc / keycloak / anything else → key.
+  const GenericIcon = brand === "generic-saml" ? ShieldCheck : KeyRound;
+  return <GenericIcon className={cn("h-5 w-5 shrink-0 text-paper-dim", className)} aria-hidden />;
+}

--- a/src/features/auth/ssoBrand.test.ts
+++ b/src/features/auth/ssoBrand.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from "vitest";
+import { resolveSsoBrand } from "./ssoBrand";
+
+const provider = (
+  id: string,
+  displayName: string,
+  type: "oidc" | "oauth2" | "saml" = "oidc",
+) => ({ id, displayName, type });
+
+describe("resolveSsoBrand", () => {
+  it("matches well-known brands by id", () => {
+    expect(resolveSsoBrand(provider("google-workspace", "Sign in"))).toBe("google");
+    expect(resolveSsoBrand(provider("okta-prod", "Corp"))).toBe("okta");
+    expect(resolveSsoBrand(provider("gh", "GitHub"))).toBe("github");
+    expect(resolveSsoBrand(provider("gitlab", "GitLab"))).toBe("gitlab");
+  });
+
+  it("matches by display name when the id is opaque", () => {
+    expect(resolveSsoBrand(provider("idp1", "Continue with Google"))).toBe("google");
+    expect(resolveSsoBrand(provider("idp2", "Apple"))).toBe("apple");
+  });
+
+  it("maps Microsoft aliases (azure / entra) to microsoft", () => {
+    expect(resolveSsoBrand(provider("azure-ad", "AzureAD"))).toBe("microsoft");
+    expect(resolveSsoBrand(provider("entra", "Entra ID"))).toBe("microsoft");
+    expect(resolveSsoBrand(provider("o365", "Office 365"))).toBe("microsoft");
+  });
+
+  it("maps AWS / Cognito to amazon", () => {
+    expect(resolveSsoBrand(provider("cognito", "AWS"))).toBe("amazon");
+  });
+
+  it("is case-insensitive", () => {
+    expect(resolveSsoBrand(provider("OKTA", "OKTA"))).toBe("okta");
+  });
+
+  it("falls back to a generic glyph keyed on protocol type", () => {
+    expect(resolveSsoBrand(provider("acme", "ACME Corp", "oidc"))).toBe("generic-oidc");
+    expect(resolveSsoBrand(provider("acme", "ACME Corp", "oauth2"))).toBe("generic-oidc");
+    expect(resolveSsoBrand(provider("acme", "ACME Corp", "saml"))).toBe("generic-saml");
+  });
+});

--- a/src/features/auth/ssoBrand.ts
+++ b/src/features/auth/ssoBrand.ts
@@ -1,0 +1,60 @@
+/**
+ * SSO brand inference.
+ *
+ * The public provider payload only gives us an id, a display name, and the
+ * protocol type (oidc/oauth2/saml). To show a recognisable logo on the login
+ * page we infer a *brand* from the id + display name (e.g. "okta-prod" →
+ * `okta`), falling back to a generic protocol glyph when nothing matches.
+ */
+
+/**
+ * Minimal shape needed to infer a brand: a stable id/slug, a human label, and
+ * (optionally) the protocol type used only for the generic fallback glyph.
+ */
+export interface SsoBrandInput {
+  id: string;
+  displayName: string;
+  type?: "oidc" | "oauth2" | "saml";
+}
+
+/** Known brands we ship a logo for, plus generic protocol fallbacks. */
+export type SsoBrand =
+  | "google"
+  | "microsoft"
+  | "okta"
+  | "github"
+  | "gitlab"
+  | "auth0"
+  | "keycloak"
+  | "apple"
+  | "slack"
+  | "amazon"
+  | "generic-oidc"
+  | "generic-saml";
+
+// Keyword → brand. Order matters: more specific tokens come first so e.g.
+// "azure"/"entra" resolve to Microsoft before anything broader.
+const BRAND_KEYWORDS: ReadonlyArray<readonly [RegExp, SsoBrand]> = [
+  [/google|gsuite|gws|workspace/, "google"],
+  [/microsoft|azure|entra|aad|office365|o365|msft/, "microsoft"],
+  [/okta/, "okta"],
+  [/github/, "github"],
+  [/gitlab/, "gitlab"],
+  [/auth0/, "auth0"],
+  [/keycloak/, "keycloak"],
+  [/apple/, "apple"],
+  [/slack/, "slack"],
+  [/amazon|cognito|aws/, "amazon"],
+];
+
+/**
+ * Resolve the brand for a provider from its id and display name, falling back
+ * to a generic glyph keyed on the protocol type.
+ */
+export function resolveSsoBrand(provider: SsoBrandInput): SsoBrand {
+  const haystack = `${provider.id} ${provider.displayName}`.toLowerCase();
+  for (const [pattern, brand] of BRAND_KEYWORDS) {
+    if (pattern.test(haystack)) return brand;
+  }
+  return provider.type === "saml" ? "generic-saml" : "generic-oidc";
+}

--- a/src/features/explorer/components/CreateDatabase.tsx
+++ b/src/features/explorer/components/CreateDatabase.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
 import { toast } from "sonner";
 import { log } from "@/lib/log";
-import { Loader2, Server } from "lucide-react";
+import { Loader2, Server, Database, Sparkles } from "lucide-react";
 import { motion, AnimatePresence } from "framer-motion";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -72,8 +72,18 @@ const CreateDatabase: React.FC = () => {
   };
 
   const dialogTitle = (
-    <DialogHeader className="pb-0 border-0">
-      <DialogTitle>Create Database</DialogTitle>
+    <DialogHeader className="pb-0 border-0 flex-none">
+      <DialogTitle className="flex items-center gap-3 text-paper">
+        <span className="grid h-9 w-9 shrink-0 place-items-center rounded-xs border border-ink-500 bg-ink-200 text-paper-muted">
+          <Database className="h-4 w-4" aria-hidden />
+        </span>
+        <span className="flex flex-col gap-0.5 text-left">
+          <span className="text-[16px] font-semibold tracking-tight">Create new database</span>
+          <span className="font-mono text-[10px] uppercase tracking-[0.14em] text-paper-faint">
+            Name it and choose an optional cluster
+          </span>
+        </span>
+      </DialogTitle>
     </DialogHeader>
   );
 
@@ -83,46 +93,68 @@ const CreateDatabase: React.FC = () => {
       onOpenChange={(open) => { if (!open) handleClose(); }}
       dialogId="createDatabase"
       title={dialogTitle}
-      windowClassName="rounded-xl shadow-xl bg-card border border-border"
-      headerClassName="border-b"
-      footerClassName="border-t"
+      windowClassName="rounded-xs border border-ink-500 bg-ink-100 text-paper shadow-lg"
+      headerClassName="px-6 pb-4 border-b border-ink-500"
+      footerClassName="pt-4 border-t border-ink-500 px-6"
+      closeButtonClassName="rounded-xs text-paper-dim hover:bg-ink-200 hover:text-paper"
+      contentClassName="bg-ink-100 text-paper"
       footer={
-        <DialogFooter className="px-0">
-          <Button type="button" variant="outline" onClick={handleClose}>
+        <DialogFooter className="pt-4 border-t border-ink-500 px-0">
+          <Button
+            type="button"
+            variant="outline"
+            onClick={handleClose}
+            className="h-9 gap-2 rounded-xs border-ink-500 bg-ink-100 px-3 font-mono text-[11px] uppercase tracking-[0.14em] text-paper hover:border-ink-700 hover:bg-ink-200"
+          >
             Cancel
           </Button>
-          <Button type="submit" form="create-database-form" disabled={createDatabase.isPending}>
+          <Button
+            type="submit"
+            form="create-database-form"
+            disabled={createDatabase.isPending}
+            className="h-9 gap-2 rounded-xs bg-brand px-3 font-mono text-[11px] font-semibold uppercase tracking-[0.14em] text-ink-50 hover:bg-brand-soft disabled:opacity-50"
+          >
             {createDatabase.isPending ? (
               <>
-                <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                <Loader2 className="h-3.5 w-3.5 animate-spin" />
                 Creating...
               </>
             ) : (
-              "Create Database"
+              <>
+                <Sparkles className="h-3.5 w-3.5" />
+                Create Database
+              </>
             )}
           </Button>
         </DialogFooter>
       }
     >
       <form id="create-database-form" onSubmit={handleSubmit}>
-        <div className="space-y-4 py-4">
+        <div className="space-y-6 px-6 py-4">
           <div className="space-y-2">
-            <Label htmlFor="database-name">Database Name</Label>
+            <Label
+              htmlFor="database-name"
+              className="flex items-center gap-2 font-mono text-[10px] uppercase tracking-[0.14em] text-paper-dim"
+            >
+              <Database className="h-3.5 w-3.5 text-paper-dim" aria-hidden />
+              Database Name
+            </Label>
             <Input
               id="database-name"
               value={databaseName}
               onChange={(e) => setDatabaseName(e.target.value)}
               placeholder="my_database"
+              className="rounded-xs border-ink-500 bg-ink-200 text-paper"
               autoFocus
             />
           </div>
 
           {clusters.length > 0 && (
-            <div className="p-4 rounded-xs bg-ink-200 border border-ink-500 space-y-3">
+            <div className="rounded-xs border border-ink-500 bg-ink-200 p-4 space-y-3">
               <div className="flex items-center justify-between">
                 <div className="flex items-center gap-2">
-                  <Server className="h-4 w-4 text-amber-600 dark:text-orange-400" />
-                  <Label className="text-paper-muted">Create on Cluster</Label>
+                  <Server className="h-3.5 w-3.5 text-paper-dim" aria-hidden />
+                  <Label className="font-mono text-[10px] uppercase tracking-[0.14em] text-paper-dim">Create on Cluster</Label>
                 </div>
                 <Switch checked={useCluster} onCheckedChange={setUseCluster} />
               </div>
@@ -134,7 +166,7 @@ const CreateDatabase: React.FC = () => {
                     exit={{ opacity: 0, height: 0 }}
                   >
                     <Select value={selectedCluster} onValueChange={setSelectedCluster}>
-                      <SelectTrigger className="bg-ink-100 border-ink-500 text-paper">
+                      <SelectTrigger className="rounded-xs border-ink-500 bg-ink-100 text-paper">
                         <SelectValue placeholder="Select cluster" />
                       </SelectTrigger>
                       <SelectContent>

--- a/src/features/explorer/components/ImportWizard/ImportWizard.tsx
+++ b/src/features/explorer/components/ImportWizard/ImportWizard.tsx
@@ -333,7 +333,7 @@ export function ImportWizard({ isOpen, onClose, database }: ImportWizardProps) {
         <DialogHeader className="p-0 border-0 flex-none min-w-0" aria-label="Import wizard">
             <div className="flex items-center gap-4 min-w-0">
                 <div className="flex items-center gap-2 min-w-0 shrink">
-                    <div className="flex h-8 w-8 items-center justify-center rounded-xs bg-emerald-500/15 text-emerald-600 dark:text-emerald-400" aria-hidden>
+                    <div className="flex h-8 w-8 items-center justify-center rounded-xs bg-brand/15 text-brand-dim dark:text-brand" aria-hidden>
                         <FileUp className="h-4 w-4" />
                     </div>
                     <DialogTitle className="text-base font-semibold text-paper truncate">Import data</DialogTitle>
@@ -344,7 +344,7 @@ export function ImportWizard({ isOpen, onClose, database }: ImportWizardProps) {
                             key={s.id}
                             className={cn(
                                 "h-1.5 w-1.5 rounded-full transition-colors",
-                                i + 1 === currentStepIndex ? "bg-emerald-500" : i + 1 < currentStepIndex ? "bg-emerald-500/60" : "bg-ink-500"
+                                i + 1 === currentStepIndex ? "bg-brand" : i + 1 < currentStepIndex ? "bg-brand/60" : "bg-ink-500"
                             )}
                             aria-hidden
                         />
@@ -352,13 +352,13 @@ export function ImportWizard({ isOpen, onClose, database }: ImportWizardProps) {
                 </div>
                 <div className="flex-1 min-w-0 flex justify-end">
                     <Select value={selectedDb} onValueChange={setSelectedDb}>
-                        <SelectTrigger className="h-8 w-[130px] text-xs bg-ink-200 border-ink-500 text-paper-muted focus:ring-1 focus:ring-emerald-500/50 rounded-xs">
+                        <SelectTrigger className="h-8 w-[130px] text-xs bg-ink-200 border-ink-500 text-paper-muted focus:ring-1 focus:ring-brand/50 rounded-xs">
                             <DatabaseIcon className="h-3.5 w-3.5 text-paper-faint mr-1.5 shrink-0" />
                             <SelectValue placeholder="Database" />
                         </SelectTrigger>
                         <SelectContent className="z-[100] border-ink-500 bg-ink-100 text-paper">
                             {databases.map(db => (
-                                <SelectItem key={db.name} value={db.name} className="focus:bg-emerald-500/15 focus:text-emerald-600 dark:focus:text-emerald-400 text-sm">
+                                <SelectItem key={db.name} value={db.name} className="focus:bg-brand/15 focus:text-brand-dim dark:focus:text-brand text-sm">
                                     {db.name}
                                 </SelectItem>
                             ))}
@@ -395,7 +395,7 @@ export function ImportWizard({ isOpen, onClose, database }: ImportWizardProps) {
                             <Button
                                 onClick={handleImport}
                                 disabled={!tableName || !selectedDb || columns.length === 0 || (tableName.length > 0 && !TABLE_NAME_REGEX.test(tableName))}
-                                className="bg-emerald-600 hover:bg-emerald-500 text-white gap-2 order-1 sm:order-2 flex-1 sm:flex-initial min-w-[120px]"
+                                className="bg-brand hover:bg-brand-soft text-ink-50 gap-2 order-1 sm:order-2 flex-1 sm:flex-initial min-w-[120px]"
                                 aria-label="Import data"
                             >
                                 Import <ChevronRight className="h-4 w-4" />
@@ -429,7 +429,7 @@ export function ImportWizard({ isOpen, onClose, database }: ImportWizardProps) {
                             {isAnalyzing && (
                                 <div className="absolute inset-0 bg-ink-100/80 backdrop-blur-sm flex items-center justify-center z-10" aria-live="polite" aria-busy="true">
                                     <div className="flex flex-col items-center gap-4 rounded-xs bg-ink-200 border border-ink-500 px-8 py-6">
-                                        <div className="h-10 w-10 rounded-full border-2 border-emerald-500/40 border-t-emerald-500 animate-spin" />
+                                        <div className="h-10 w-10 rounded-full border-2 border-brand/40 border-t-brand animate-spin" />
                                         <p className="text-sm text-paper-muted">Analyzing file…</p>
                                     </div>
                                 </div>

--- a/src/features/explorer/components/ImportWizard/StepProgress.tsx
+++ b/src/features/explorer/components/ImportWizard/StepProgress.tsx
@@ -33,7 +33,7 @@ export function StepProgress({ status, error, database, tableName, onClose, onVi
                 <div className="relative">
                     {(status === 'uploading' || status === 'creating_table') && (
                         <motion.div
-                            className="absolute -inset-3 rounded-full border-2 border-emerald-500/20 border-t-emerald-400"
+                            className="absolute -inset-3 rounded-full border-2 border-brand/20 border-t-brand"
                             animate={{ rotate: 360 }}
                             transition={{ duration: 2, repeat: Infinity, ease: 'linear' }}
                         />
@@ -41,9 +41,9 @@ export function StepProgress({ status, error, database, tableName, onClose, onVi
                     <div
                         className={cn(
                             'flex h-16 w-16 items-center justify-center rounded-xs',
-                            status === 'creating_table' && 'bg-emerald-500/10 text-emerald-600 dark:text-emerald-400',
-                            status === 'uploading' && 'bg-emerald-500/10 text-emerald-600 dark:text-emerald-400',
-                            status === 'success' && 'bg-emerald-500/15 text-emerald-600 dark:text-emerald-400',
+                            status === 'creating_table' && 'bg-brand/10 text-brand-dim dark:text-brand',
+                            status === 'uploading' && 'bg-brand/10 text-brand-dim dark:text-brand',
+                            status === 'success' && 'bg-brand/15 text-brand-dim dark:text-brand',
                             status === 'error' && 'bg-red-500/10 text-red-600 dark:text-red-400'
                         )}
                     >
@@ -74,7 +74,7 @@ export function StepProgress({ status, error, database, tableName, onClose, onVi
                 {(status === 'uploading' || status === 'creating_table') && (
                     <div className="w-full h-1 rounded-full bg-ink-300 overflow-hidden">
                         <motion.div
-                            className="h-full bg-emerald-500"
+                            className="h-full bg-brand"
                             initial={{ x: '-100%' }}
                             animate={{ x: '100%' }}
                             transition={{ duration: 1.2, repeat: Infinity, ease: 'easeInOut' }}
@@ -94,7 +94,7 @@ export function StepProgress({ status, error, database, tableName, onClose, onVi
                         {canViewTable && (
                             <Button
                                 onClick={() => onViewTable(database, tableName)}
-                                className="flex-1 h-11 bg-emerald-600 hover:bg-emerald-500 text-white gap-2"
+                                className="flex-1 h-11 bg-brand hover:bg-brand-soft text-ink-50 gap-2"
                             >
                                 <Table2 className="h-4 w-4" />
                                 View table
@@ -138,7 +138,7 @@ export function StepProgress({ status, error, database, tableName, onClose, onVi
                                 Copy
                             </Button>
                             {onTryAgain && (
-                                <Button onClick={onTryAgain} size="sm" className="bg-emerald-600 hover:bg-emerald-500 text-white h-9">
+                                <Button onClick={onTryAgain} size="sm" className="bg-brand hover:bg-brand-soft text-ink-50 h-9">
                                     Try again
                                 </Button>
                             )}

--- a/src/features/explorer/components/ImportWizard/StepUpload.tsx
+++ b/src/features/explorer/components/ImportWizard/StepUpload.tsx
@@ -64,8 +64,8 @@ export function StepUpload({
                 <div
                     {...getRootProps()}
                     className={cn(
-                        'relative flex flex-col items-center justify-center min-h-[220px] w-full rounded-xs border-2 border-dashed cursor-pointer transition-colors outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/50',
-                        'border-ink-500 hover:border-emerald-500/40 hover:bg-ink-200'
+                        'relative flex flex-col items-center justify-center min-h-[220px] w-full rounded-xs border-2 border-dashed cursor-pointer transition-colors outline-none focus-visible:ring-2 focus-visible:ring-brand/50',
+                        'border-ink-500 hover:border-brand/40 hover:bg-ink-200'
                     )}
                     role="button"
                     tabIndex={0}
@@ -73,7 +73,7 @@ export function StepUpload({
                 >
                     <input {...getInputProps()} aria-hidden />
                     <div className="flex flex-col items-center gap-3 text-center px-4">
-                        <div className="flex h-12 w-12 items-center justify-center rounded-xs bg-emerald-500/10 text-emerald-600 dark:text-emerald-400">
+                        <div className="flex h-12 w-12 items-center justify-center rounded-xs bg-brand/10 text-brand-dim dark:text-brand">
                             <Upload className="h-6 w-6" />
                         </div>
                         <div>
@@ -86,7 +86,7 @@ export function StepUpload({
                 <div className="flex flex-col gap-4">
                     <div className="rounded-xs border border-ink-500 bg-ink-200 p-4 shrink-0">
                         <div className="flex items-start gap-3">
-                            <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xs bg-emerald-500/10 text-emerald-600 dark:text-emerald-400">
+                            <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xs bg-brand/10 text-brand-dim dark:text-brand">
                                 <FileUp className="h-5 w-5" />
                             </div>
                             <div className="min-w-0 flex-1">
@@ -115,7 +115,7 @@ export function StepUpload({
                                     id="hasHeader"
                                     checked={hasHeader}
                                     onCheckedChange={(c) => onHasHeaderChange(c === true)}
-                                    className="border-ink-500 data-[state=checked]:bg-emerald-600 data-[state=checked]:border-emerald-600"
+                                    className="border-ink-500 data-[state=checked]:bg-brand data-[state=checked]:border-brand data-[state=checked]:text-ink-50"
                                 />
                                 <Label htmlFor="hasHeader" className="text-sm text-paper-muted cursor-pointer">
                                     First row is header
@@ -127,7 +127,7 @@ export function StepUpload({
                         <Button
                             onClick={onContinue}
                             disabled={isAnalyzing}
-                            className="w-full h-11 bg-emerald-600 hover:bg-emerald-500 text-white font-medium"
+                            className="w-full h-11 bg-brand hover:bg-brand-soft text-ink-50 font-medium"
                             aria-label="Continue to preview"
                         >
                             Review schema

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -10,10 +10,11 @@ import { useQuery } from "@tanstack/react-query";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import * as z from "zod";
-import { ArrowUpRight, Eye, EyeOff, Loader2, Lock, ShieldCheck, User } from "lucide-react";
+import { ArrowUpRight, ChevronDown, Eye, EyeOff, Loader2, Lock, ShieldCheck, User } from "lucide-react";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import { useRbacStore } from "@/stores";
 import { ssoApi } from "@/api/rbac";
+import { SsoProviderIcon } from "@/features/auth/SsoProviderIcon";
 
 import { Button } from "@/components/ui/button";
 import {
@@ -26,6 +27,7 @@ import {
 } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
 import { withBasePath } from "@/lib/basePath";
+import { cn } from "@/lib/utils";
 import { log } from "@/lib/log";
 
 const loginSchema = z.object({
@@ -45,6 +47,11 @@ export default function Login() {
 
   const { login, isLoading, error, isAuthenticated, clearError } = useRbacStore();
   const [showPassword, setShowPassword] = useState(false);
+  const [ssoExpanded, setSsoExpanded] = useState(false);
+
+  // Show a few providers up front; collapse the rest behind a toggle so a long
+  // provider list doesn't push the password form off the card.
+  const SSO_COLLAPSED_COUNT = 3;
 
   const { data: ssoProviders = [] } = useQuery({
     queryKey: ["sso-providers"],
@@ -55,6 +62,10 @@ export default function Login() {
     refetchOnWindowFocus: true,
     retry: false,
   });
+
+  const ssoHasMore = ssoProviders.length > SSO_COLLAPSED_COUNT;
+  const visibleSsoProviders =
+    ssoExpanded || !ssoHasMore ? ssoProviders : ssoProviders.slice(0, SSO_COLLAPSED_COUNT);
 
   const form = useForm<LoginFormData>({
     resolver: zodResolver(loginSchema),
@@ -128,21 +139,42 @@ export default function Login() {
             {/* Form */}
             <div className="px-7 py-7">
               {ssoProviders.length > 0 && (
-                <div className="mb-5 flex flex-col gap-2.5">
-                  {ssoProviders.map((provider) => (
-                    <Button
-                      key={provider.id}
+                <div className="mb-5 flex flex-col gap-2">
+                  <div className="flex flex-col gap-2">
+                    {visibleSsoProviders.map((provider) => (
+                      <button
+                        key={provider.id}
+                        type="button"
+                        onClick={() => {
+                          window.location.href = ssoApi.startUrl(provider.id, redirectTo);
+                        }}
+                        aria-label={`Continue with ${provider.displayName}`}
+                        className="group relative flex h-10 w-full items-center rounded-xs border border-ink-500 bg-ink-200 px-3 text-[13px] font-medium tracking-tight text-paper-muted transition-colors hover:border-ink-700 hover:bg-ink-300 hover:text-paper focus:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2 focus-visible:ring-offset-ink-100"
+                      >
+                        <SsoProviderIcon provider={provider} className="absolute left-3 h-[18px] w-[18px]" />
+                        <span className="w-full text-center">Continue with {provider.displayName}</span>
+                      </button>
+                    ))}
+                  </div>
+
+                  {ssoHasMore && (
+                    <button
                       type="button"
-                      variant="outline"
-                      onClick={() => {
-                        window.location.href = ssoApi.startUrl(provider.id, redirectTo);
-                      }}
-                      className="h-11 w-full rounded-xs border-ink-500 bg-ink-200 font-semibold tracking-tight text-paper hover:bg-ink-300 hover:text-paper"
+                      onClick={() => setSsoExpanded((v) => !v)}
+                      aria-expanded={ssoExpanded}
+                      className="flex items-center justify-center gap-1.5 py-1 font-mono text-[10px] uppercase tracking-[0.16em] text-paper-faint transition-colors hover:text-paper-muted focus:outline-none focus-visible:text-paper"
                     >
-                      Continue with {provider.displayName}
-                    </Button>
-                  ))}
-                  <div className="my-2 flex items-center gap-3" aria-hidden>
+                      {ssoExpanded
+                        ? "Show fewer options"
+                        : `Show ${ssoProviders.length - SSO_COLLAPSED_COUNT} more`}
+                      <ChevronDown
+                        className={cn("h-3 w-3 transition-transform", ssoExpanded && "rotate-180")}
+                        aria-hidden
+                      />
+                    </button>
+                  )}
+
+                  <div className="my-1 flex items-center gap-3" aria-hidden>
                     <span className="h-px flex-1 bg-ink-500" />
                     <span className="font-mono text-[10px] uppercase tracking-[0.18em] text-paper-faint">
                       or sign in with password


### PR DESCRIPTION
## Description

Adds recognisable **brand logos** for SSO providers across the UI, reworks the login-page provider list, and closes two gaps in **SSO audit-log coverage**. Also folds in some Explorer theme-consistency tweaks that were in the working tree.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Code refactoring

## Related Issue

Closes #

## Changes Made

### SSO brand icons
- New `src/features/auth/ssoBrand.ts` infers a brand (Google, Microsoft, Okta, GitHub, GitLab, Apple, Slack, AWS, Auth0, …) from each provider's `id` + `displayName`, with a generic key/shield fallback keyed on protocol type.
- New `src/features/auth/SsoProviderIcon.tsx` renders inline brand SVGs. Multicolour marks keep their brand colours; monochrome marks (GitHub, Apple) and fallbacks use `currentColor`, so everything adapts to light/dark themes.
- Icons now appear on: the **login page**, the **admin SSO providers list**, the **provider wizard dialog title** (updates live as you type), and each user's **linked SSO identities** (Security tab).
- **Login page**: providers render as quiet, theme-aligned labelled buttons (icon pinned left, centered label); when more than three are enabled the extras collapse behind a "Show more / Show fewer" toggle so the password form stays in view.
- **Admin → SSO**: the section now has a proper titled header consistent with other admin tabs, and the "Global settings" / "Providers" sub-sections use distinct, meaningful icons instead of all reusing the key glyph.

### SSO sign-in audit coverage
- `provisionSsoUser` now returns an `outcome` discriminator (`authenticated` / `linked` / `created`).
- First-time sign-ins record **`sso.user_provision`** (JIT account created) and **`sso.identity_link`** (identity auto-linked to an existing user by verified email) alongside the existing `auth.sso_login` entry — previously these security-relevant events only hit the app logger.
- Audit writes are **best-effort** (wrapped, failures swallowed + logged) so they can never block sign-in. The auth flow and client response are unchanged; a normal login on an existing link does zero extra DB work. New audit actions flow through the existing server-derived filter automatically.

### Explorer theme consistency
- Create Database dialog and the Import-data upload wizard now use the app's `ink/paper` + `brand` theme tokens instead of off-style/emerald accents, matching the rest of the UI in both themes.

## Testing

- [x] I have tested this locally
- [x] I have added/updated tests
- [x] All existing tests pass

### Test Steps
- `bun run typecheck` ✓
- `bun run lint` ✓
- `bunx vitest run src/features/auth/ssoBrand.test.ts` — 6/6 ✓ (brand inference: id/display-name matching, Microsoft/AWS aliases, case-insensitivity, protocol fallback)
- `bun test packages/server/src/rbac/sso/{service,routes}.test.ts` — 51/51 ✓ (added `outcome` assertions for linked/created/authenticated paths; route tests assert `sso.user_provision` / `sso.identity_link` fire on the right outcomes and that a plain login emits neither)

## Changelog Fragment

- [x] Added `changelogs/unreleased/252-sso-login-brand-icons.md`, `253-sso-audit-provisioning.md`, `253-explorer-modal-theme-consistency.md`

## Checklist

- [x] My code follows the project's code style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have checked for breaking changes and documented them (if applicable)
- [x] I have tested the changes in the relevant environment (development/production)

## Additional Notes

- The public `/sso/providers` payload was intentionally **not** widened — brand inference works off `id` + `displayName`, so no new data is exposed.
- Out of scope (noted for a possible follow-up): IdP-claim **role sync** (`syncMappedRoles`) still isn't audited; it's a privilege change but fires on every login, so it's a separate design call.
- The fragment filenames use placeholder PR numbers; rename if your tooling expects the real PR number.

🤖 Generated with [Claude Code](https://claude.com/claude-code)