### PR TITLE
fix(sso): make GitHub (and other plain OAuth2) SSO work end-to-end

### DIFF
--- a/changelogs/unreleased/github-oauth2-userinfo.md
+++ b/changelogs/unreleased/github-oauth2-userinfo.md
@@ -1,0 +1,5 @@
+type: patch
+
+### Fixed
+- **GitHub SSO (and other plain OAuth2 providers)** — userinfo is now fetched directly instead of through the OIDC-only helper, which rejected GitHub's numeric `id`/missing `sub` (`"sub" property must be a string`). GitHub accounts with a private email also now resolve their primary verified address via `/user/emails`, so just-in-time provisioning no longer fails with "did not supply an email address".
+- **SSO attribute-mapping parsing** — claim/role/auth-param mappings now accept either `=` or `:` as the key/value separator, so values entered as `subject=id,...` are parsed correctly instead of silently producing an empty mapping.

--- a/packages/server/src/rbac/sso/client.test.ts
+++ b/packages/server/src/rbac/sso/client.test.ts
@@ -232,19 +232,15 @@ describe("buildAuthorizationRedirect (oidc, mocked discovery)", () => {
 describe("exchangeCodeForIdentity checks wiring", () => {
   // Captured call args so individual tests can assert on them.
   let capturedGrantArgs: unknown[] = [];
-  let capturedFetchUserInfoArgs: unknown[] = [];
 
   // Switchable mock results, set per test.
   let mockTokenClaims: Record<string, unknown> | null = null;
   let mockAccessToken = "at-mock";
-  let mockUserinfo: Record<string, unknown> = {};
 
   beforeEach(() => {
     capturedGrantArgs = [];
-    capturedFetchUserInfoArgs = [];
     mockTokenClaims = null;
     mockAccessToken = "at-mock";
-    mockUserinfo = {};
     resetProviderConfigurationCache();
   });
 
@@ -277,14 +273,6 @@ describe("exchangeCodeForIdentity checks wiring", () => {
             access_token: mockAccessToken,
             claims: () => mockTokenClaims,
           };
-        },
-        fetchUserInfo: async (
-          _cfg: unknown,
-          accessToken: unknown,
-          subjectCheck: unknown
-        ) => {
-          capturedFetchUserInfoArgs = [_cfg, accessToken, subjectCheck];
-          return mockUserinfo;
         },
       };
     });
@@ -339,60 +327,128 @@ describe("exchangeCodeForIdentity checks wiring", () => {
     expect(identity.provider).toBe("okta");
   });
 
-  it("oauth2: checks have pkceCodeVerifier+expectedState but NOT expectedNonce/idTokenExpected; fetchUserInfo called with access_token+skipSubjectCheck; claimMapping applied", async () => {
+  it("oauth2: checks have pkceCodeVerifier+expectedState but NOT expectedNonce/idTokenExpected; userinfo fetched directly with bearer token; claimMapping applied", async () => {
     mockAccessToken = "gh-access-token";
-    mockUserinfo = {
-      id: 9001,
-      email: "Dev@GitHub.com",
-      login: "DevUser",
-      name: "Dev User",
-    };
 
     setupMock();
-    const { exchangeCodeForIdentity, resetProviderConfigurationCache: reset } =
-      await import("./client");
-    reset();
 
-    const oauth2Provider = {
-      id: "github",
-      type: "oauth2" as const,
-      displayName: "GitHub",
-      clientId: "client-id",
-      clientSecret: "client-secret",
-      scopes: "read:user user:email",
-      authorizationEndpoint: "https://github.com/login/oauth/authorize",
-      tokenEndpoint: "https://github.com/login/oauth/access_token",
-      userinfoEndpoint: "https://api.github.com/user",
-      claimMapping: { subject: "id", email: "email", username: "login" },
-    };
+    // oauth2 fetches the userinfo endpoint directly (not via oidc.fetchUserInfo,
+    // which would reject GitHub's numeric `id`/missing `sub`). Mock global fetch.
+    const realFetch = globalThis.fetch;
+    const fetchCalls: Array<{ url: string; auth: string | null }> = [];
+    globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input instanceof URL ? input.toString() : String(input);
+      const headers = new Headers(init?.headers);
+      fetchCalls.push({ url, auth: headers.get("Authorization") });
+      return new Response(
+        JSON.stringify({ id: 9001, email: "Dev@GitHub.com", login: "DevUser", name: "Dev User" }),
+        { status: 200, headers: { "Content-Type": "application/json" } }
+      );
+    }) as typeof fetch;
 
-    const callbackUrl = new URL(
-      "https://app.example.com/callback?code=c&state=st"
-    );
-    const identity = await exchangeCodeForIdentity(oauth2Provider, callbackUrl, {
-      codeVerifier: "cv",
-      state: "st",
-      nonce: "",
-    });
+    try {
+      const { exchangeCodeForIdentity, resetProviderConfigurationCache: reset } =
+        await import("./client");
+      reset();
 
-    // Verify checks: PKCE and state present, no nonce/idToken fields
-    const checks = capturedGrantArgs[2] as Record<string, unknown>;
-    expect(checks.pkceCodeVerifier).toBe("cv");
-    expect(checks.expectedState).toBe("st");
-    expect("expectedNonce" in checks).toBe(false);
-    expect("idTokenExpected" in checks).toBe(false);
+      const oauth2Provider = {
+        id: "github",
+        type: "oauth2" as const,
+        displayName: "GitHub",
+        clientId: "client-id",
+        clientSecret: "client-secret",
+        scopes: "read:user user:email",
+        authorizationEndpoint: "https://github.com/login/oauth/authorize",
+        tokenEndpoint: "https://github.com/login/oauth/access_token",
+        userinfoEndpoint: "https://api.github.com/user",
+        claimMapping: { subject: "id", email: "email", username: "login" },
+      };
 
-    // fetchUserInfo called with the access_token (skipSubjectCheck is a symbol)
-    expect(capturedFetchUserInfoArgs[1]).toBe("gh-access-token");
-    // third argument is oidc.skipSubjectCheck (a symbol/unique value)
-    expect(capturedFetchUserInfoArgs[2]).toBeDefined();
+      const callbackUrl = new URL(
+        "https://app.example.com/callback?code=c&state=st"
+      );
+      const identity = await exchangeCodeForIdentity(oauth2Provider, callbackUrl, {
+        codeVerifier: "cv",
+        state: "st",
+        nonce: "",
+      });
 
-    // claimMapping applied correctly
-    expect(identity.subject).toBe("9001");
-    expect(identity.email).toBe("dev@github.com");
-    expect(identity.username).toBe("devuser");
-    expect(identity.emailVerified).toBe(false);
-    expect(identity.displayName).toBe("Dev User");
-    expect(identity.provider).toBe("github");
+      // Verify checks: PKCE and state present, no nonce/idToken fields
+      const checks = capturedGrantArgs[2] as Record<string, unknown>;
+      expect(checks.pkceCodeVerifier).toBe("cv");
+      expect(checks.expectedState).toBe("st");
+      expect("expectedNonce" in checks).toBe(false);
+      expect("idTokenExpected" in checks).toBe(false);
+
+      // userinfo endpoint fetched directly with the access token as a bearer
+      expect(fetchCalls[0].url).toBe("https://api.github.com/user");
+      expect(fetchCalls[0].auth).toBe("Bearer gh-access-token");
+
+      // claimMapping applied correctly
+      expect(identity.subject).toBe("9001");
+      expect(identity.email).toBe("dev@github.com");
+      expect(identity.username).toBe("devuser");
+      expect(identity.emailVerified).toBe(false);
+      expect(identity.displayName).toBe("Dev User");
+      expect(identity.provider).toBe("github");
+    } finally {
+      globalThis.fetch = realFetch;
+    }
+  });
+
+  it("oauth2 (github): falls back to /user/emails when /user returns a null email", async () => {
+    mockAccessToken = "gh-access-token";
+
+    setupMock();
+
+    const realFetch = globalThis.fetch;
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      const url = input instanceof URL ? input.toString() : String(input);
+      if (url === "https://api.github.com/user") {
+        return new Response(
+          JSON.stringify({ id: 42, email: null, login: "PrivUser", name: "Priv User" }),
+          { status: 200, headers: { "Content-Type": "application/json" } }
+        );
+      }
+      if (url === "https://api.github.com/user/emails") {
+        return new Response(
+          JSON.stringify([
+            { email: "old@github.com", primary: false, verified: true },
+            { email: "primary@github.com", primary: true, verified: true },
+          ]),
+          { status: 200, headers: { "Content-Type": "application/json" } }
+        );
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    }) as typeof fetch;
+
+    try {
+      const { exchangeCodeForIdentity, resetProviderConfigurationCache: reset } =
+        await import("./client");
+      reset();
+
+      const identity = await exchangeCodeForIdentity(
+        {
+          id: "github",
+          type: "oauth2" as const,
+          displayName: "GitHub",
+          clientId: "client-id",
+          clientSecret: "client-secret",
+          scopes: "read:user user:email",
+          authorizationEndpoint: "https://github.com/login/oauth/authorize",
+          tokenEndpoint: "https://github.com/login/oauth/access_token",
+          userinfoEndpoint: "https://api.github.com/user",
+          claimMapping: { subject: "id", email: "email", username: "login" },
+        },
+        new URL("https://app.example.com/callback?code=c&state=st"),
+        { codeVerifier: "cv", state: "st", nonce: "" }
+      );
+
+      expect(identity.subject).toBe("42");
+      expect(identity.email).toBe("primary@github.com");
+      expect(identity.username).toBe("privuser");
+    } finally {
+      globalThis.fetch = realFetch;
+    }
   });
 });

--- a/packages/server/src/rbac/sso/client.ts
+++ b/packages/server/src/rbac/sso/client.ts
@@ -155,19 +155,93 @@ export async function exchangeCodeForIdentity(
     return normalizeOidcClaims(p.id, claims as Record<string, unknown>, p.claimMapping);
   }
 
-  // skipSubjectCheck is required: plain OAuth2 userinfo has no ID-token sub to
-  // compare against. The mapped-subject throw in applyClaimMapping is the
-  // compensating control.
-  const userinfo = await oidc.fetchUserInfo(
-    cfg,
-    tokens.access_token,
-    oidc.skipSubjectCheck
-  );
-  return applyClaimMapping(
+  // Fetch the userinfo endpoint directly rather than via oidc.fetchUserInfo:
+  // openid-client enforces OIDC userinfo semantics and rejects any response
+  // whose `sub` is not a string. Non-OIDC providers (e.g. GitHub, whose /user
+  // returns a numeric `id` and no `sub`) fail that check before claim_mapping
+  // can run. The mapped-subject throw in applyClaimMapping is the compensating
+  // control for the skipped sub check.
+  const userinfo = await fetchOauth2UserInfo(
     p.id,
-    p.claimMapping,
-    userinfo as Record<string, unknown>
+    p.userinfoEndpoint,
+    tokens.access_token
   );
+  return applyClaimMapping(p.id, p.claimMapping, userinfo);
+}
+
+/**
+ * Fetch a plain-OAuth2 provider's userinfo endpoint and return the raw JSON
+ * object. Sends a User-Agent because some providers (notably GitHub's API)
+ * reject requests without one.
+ */
+async function fetchOauth2UserInfo(
+  providerId: string,
+  userinfoEndpoint: string,
+  accessToken: string
+): Promise<Record<string, unknown>> {
+  const res = await fetch(userinfoEndpoint, {
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      Accept: "application/json",
+      "User-Agent": "chouse-ui-sso",
+    },
+  });
+  if (!res.ok) {
+    throw new Error(
+      `[SSO] Provider ${providerId} userinfo request failed (${res.status} ${res.statusText})`
+    );
+  }
+  const body: unknown = await res.json();
+  if (typeof body !== "object" || body === null || Array.isArray(body)) {
+    throw new Error(`[SSO] Provider ${providerId} userinfo response was not a JSON object`);
+  }
+  const userinfo = body as Record<string, unknown>;
+
+  // GitHub keeps a user's email private by default, so /user returns
+  // email:null. Fall back to /user/emails (granted by the user:email scope)
+  // and use the primary verified address so JIT provisioning still has an email.
+  const url = new URL(userinfoEndpoint);
+  if (url.hostname === "api.github.com" && userinfo.email == null) {
+    const email = await fetchGithubPrimaryEmail(url.origin, accessToken);
+    if (email) userinfo.email = email;
+  }
+  return userinfo;
+}
+
+interface GithubEmail {
+  email: string;
+  primary: boolean;
+  verified: boolean;
+}
+
+/** Resolve a GitHub account's primary verified email via /user/emails. */
+async function fetchGithubPrimaryEmail(
+  apiOrigin: string,
+  accessToken: string
+): Promise<string | null> {
+  const res = await fetch(new URL("/user/emails", apiOrigin), {
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      Accept: "application/json",
+      "User-Agent": "chouse-ui-sso",
+    },
+  });
+  if (!res.ok) {
+    logger.warn(
+      { module: "SSO", status: res.status },
+      "GitHub /user/emails request failed; proceeding without email"
+    );
+    return null;
+  }
+  const body: unknown = await res.json();
+  if (!Array.isArray(body)) return null;
+  const emails = body.filter(
+    (e): e is GithubEmail =>
+      typeof e === "object" && e !== null && typeof (e as GithubEmail).email === "string"
+  );
+  const chosen =
+    emails.find((e) => e.primary && e.verified) ?? emails.find((e) => e.verified);
+  return chosen ? chosen.email : null;
 }
 
 export function normalizeOidcClaims(

--- a/packages/server/src/rbac/sso/config.test.ts
+++ b/packages/server/src/rbac/sso/config.test.ts
@@ -124,6 +124,25 @@ describe('loadSsoConfig', () => {
     }
   });
 
+  it('accepts "=" as the claim-mapping separator (alongside ":")', () => {
+    const env = {
+      ...baseEnv(),
+      AUTH_SSO_PROVIDERS_GITHUB_TYPE: 'oauth2',
+      AUTH_SSO_PROVIDERS_GITHUB_DISPLAY_NAME: 'GitHub',
+      AUTH_SSO_PROVIDERS_GITHUB_AUTHORIZATION_ENDPOINT: 'https://github.com/login/oauth/authorize',
+      AUTH_SSO_PROVIDERS_GITHUB_TOKEN_ENDPOINT: 'https://github.com/login/oauth/access_token',
+      AUTH_SSO_PROVIDERS_GITHUB_USERINFO_ENDPOINT: 'https://api.github.com/user',
+      AUTH_SSO_PROVIDERS_GITHUB_CLIENT_ID: 'gid',
+      AUTH_SSO_PROVIDERS_GITHUB_CLIENT_SECRET: 'gsecret',
+      AUTH_SSO_PROVIDERS_GITHUB_SCOPES: 'read:user user:email',
+      AUTH_SSO_PROVIDERS_GITHUB_CLAIM_MAPPING: 'subject=id,email=email,username=login',
+    };
+    const gh = loadSsoConfig(env).providers.get('github')!;
+    if (gh.type === 'oauth2') {
+      expect(gh.claimMapping).toEqual({ subject: 'id', email: 'email', username: 'login' });
+    }
+  });
+
   it('parses auth_params into a record', () => {
     const env = {
       ...baseEnv(),

--- a/packages/server/src/rbac/sso/config.ts
+++ b/packages/server/src/rbac/sso/config.ts
@@ -40,13 +40,20 @@ const FIELD_SUFFIXES = [
   'TYPE',
 ] as const;
 
-/** Parse "a:b,c:d" into { a: 'b', c: 'd' }. Whitespace-tolerant. */
+/**
+ * Parse "a:b,c:d" into { a: 'b', c: 'd' }. Whitespace-tolerant. Accepts either
+ * ':' or '=' as the key/value separator (whichever appears first in the pair,
+ * so a value may itself contain the other character).
+ */
 function parsePairs(value: string): Record<string, string> {
   const out: Record<string, string> = {};
   for (const pair of value.split(',')) {
     const trimmed = pair.trim();
     if (!trimmed) continue;
-    const idx = trimmed.indexOf(':');
+    const colon = trimmed.indexOf(':');
+    const equals = trimmed.indexOf('=');
+    const idx =
+      colon === -1 ? equals : equals === -1 ? colon : Math.min(colon, equals);
     if (idx <= 0 || idx === trimmed.length - 1) continue;
     out[trimmed.slice(0, idx).trim()] = trimmed.slice(idx + 1).trim();
   }

--- a/src/features/admin/components/SsoSettings/index.tsx
+++ b/src/features/admin/components/SsoSettings/index.tsx
@@ -1380,11 +1380,12 @@ function ProviderWizard({ open, onClose, editing }: ProviderWizardProps) {
                       <Input
                         value={draft.claimMapping}
                         onChange={(e) => update({ claimMapping: e.target.value })}
-                        placeholder="email=email,name=displayName"
+                        placeholder="email=mail,username=uid"
                         className={INPUT_CLASS}
                       />
                       <p className={HELP_CLASS}>
-                        Map SAML attribute names to user fields (subject / email / username).
+                        Map user fields to SAML attributes (field=attribute pairs, e.g.
+                        subject / email / username).
                       </p>
                     </div>
                   </section>
@@ -1458,10 +1459,13 @@ function ProviderWizard({ open, onClose, editing }: ProviderWizardProps) {
                     <Input
                       value={draft.claimMapping}
                       onChange={(e) => update({ claimMapping: e.target.value })}
-                      placeholder="email=email,name=displayName"
+                      placeholder="subject=id,email=email,username=login"
                       className={INPUT_CLASS}
                     />
-                    <p className={HELP_CLASS}>Map provider claims to user fields (key=value pairs).</p>
+                    <p className={HELP_CLASS}>
+                      Map user fields to provider claims (field=claim pairs). Required for OAuth2 —
+                      e.g. GitHub: <code>subject=id,email=email,username=login</code>.
+                    </p>
                   </div>
                 )}
               </section>
@@ -1508,7 +1512,7 @@ function ProviderWizard({ open, onClose, editing }: ProviderWizardProps) {
                             <Input
                               value={draft.claimMapping}
                               onChange={(e) => update({ claimMapping: e.target.value })}
-                              placeholder="username:preferred_username,email:email"
+                              placeholder="username=preferred_username,email=email"
                               className={INPUT_CLASS}
                             />
                             <p className={HELP_CLASS}>


### PR DESCRIPTION
## Description

Fixes GitHub OAuth2 SSO, which failed through three sequential bugs. The fixes also benefit other non-OIDC OAuth2 providers and leave OIDC (e.g. Google) untouched.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issue

Closes #

## Changes Made

1. **`"sub" property must be a string`** — the oauth2 path used `openid-client`'s `fetchUserInfo`, which enforces OIDC userinfo semantics and rejects GitHub's numeric `id`/missing `sub`. We now fetch the userinfo endpoint directly and apply `claim_mapping` ourselves. The mapped-subject throw in `applyClaimMapping` is the compensating control for the skipped sub check. *(Affects all oauth2 providers, but strictly more permissive — it only removes the sub-must-be-string check.)*
2. **`did not supply an email address`** — GitHub returns `email: null` for accounts with a private email, but JIT provisioning requires one. We fall back to `/user/emails` (granted by the `user:email` scope) for the primary verified address. **Hostname-gated to `api.github.com`**, so other providers are unaffected.
3. **`missing mapped subject field "undefined"`** — `claim_mapping` stored with `=` separators parsed to an empty object because `parsePairs` only split on `:`. The admin UI placeholders also wrongly advertised `=`. `parsePairs` now accepts either `=` or `:`, and the placeholders are made consistent.

## Testing

- [x] I have tested this locally
- [x] I have added/updated tests
- [x] All existing tests pass

### Test Steps
- `bun test src/rbac/sso/client.test.ts` (12 pass) and `config.test.ts` (14 pass)
- Frontend `bun run typecheck` clean
- Manually verified GitHub login completes end-to-end

> Note: the full `src/rbac/sso/` suite shows 10 pre-existing failures in `identity.test.ts` caused by `mock.module` leakage across files when run together (they pass in isolation). These exist on `main` before this PR and are unrelated to these changes.

## Changelog Fragment

- [x] Added `changelogs/unreleased/github-oauth2-userinfo.md`

## Additional Notes

- **OIDC providers (e.g. Google) are unaffected** — the OIDC branch reads identity from ID-token claims and never calls the userinfo endpoint; none of the changed oauth2 code is reachable for `type: oidc`.
- **One narrowing for oauth2:** a userinfo endpoint returning a signed JWT (`application/jwt`) instead of JSON is no longer supported on the oauth2 path. This is an OIDC feature; no plain-oauth2 brand does it, and such a provider should be configured as `type: oidc`.
- After deploying, the SSO config cache rebuilds on restart or on the next provider save, so existing `=`-separated values start parsing correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)