### PR TITLE
feat: fleet observability suite and SSO single-role fix

### DIFF
--- a/changelogs/unreleased/261-sso-single-role.md
+++ b/changelogs/unreleased/261-sso-single-role.md
@@ -1,0 +1,4 @@
+type: patch
+
+### Fixed
+- **SSO role mapping now respects the one-role-per-user model** ([#261](https://github.com/daun-gatal/chouse-ui/issues/261)) — when an IdP claim matched multiple mapped groups, SSO tried to assign several roles at once, which violated the `user_id` unique constraint and made the login fail (leaving the user with no role at all). Role sync now collapses multiple matches to the single highest-privilege role (using the same `ROLE_HIERARCHY` precedence as the rest of RBAC) and writes it via an atomic upsert, so a sync can never strip a user's role mid-update. Affected users self-heal on their next login.

--- a/changelogs/unreleased/264-fleet-memory-fallback.md
+++ b/changelogs/unreleased/264-fleet-memory-fallback.md
@@ -1,0 +1,4 @@
+type: patch
+
+### Fixed
+- **Fleet memory tile no longer shows `0%` / `0 Bytes` on cgroup-limited nodes** ([#264](https://github.com/daun-gatal/chouse-ui/issues/264)) — containerised ClickHouse nodes that don't expose `OSMemoryTotal` were rendering a phantom `~2 GB / 0 Bytes → 0%`. The fleet `summary` metric now falls back through `OSMemoryTotal` → `CGroupMemoryTotal` (excluding the `~2^63` "no limit" sentinel) → `max_server_memory_usage` for the memory ceiling. When none is available the card shows `X used / —` and `—%` honestly instead of a misleading `0%`. `formatBytes()` was also extended to `PB`/`EB` and clamped so an out-of-range value can never render as `"8 undefined"`.

--- a/changelogs/unreleased/fleet-config-in-db.md
+++ b/changelogs/unreleased/fleet-config-in-db.md
@@ -1,0 +1,7 @@
+type: patch
+
+### Changed
+- **Fleet alert config & Doctor schedule now persist in the shared database** — alert rules/thresholds, Slack/Google Chat/email delivery settings, and the scheduled-scan config + run-state moved off local pod disk into the shared RBAC DB. This makes settings consistent across replicas, survive restarts, and immune to concurrent-write races. Existing `alert-config.json` / `doctor-schedule.json` files are imported automatically on first upgrade.
+
+### Fixed
+- **Scheduled health scans no longer double-fire under multiple replicas** — the scheduled Chouse AI scan is now gated by an atomic per-slot claim in the DB, so exactly one instance runs (and delivers) a given scheduled slot instead of every replica firing it.

--- a/changelogs/unreleased/mutation-progress-and-ddl-simulator.md
+++ b/changelogs/unreleased/mutation-progress-and-ddl-simulator.md
@@ -1,0 +1,7 @@
+type: minor
+
+### Added
+- **DDL impact simulator** — a read-only "what would this `ALTER` cost" estimator in the Cluster tab. Paste an `ALTER … UPDATE/DELETE` and it estimates rows matched, parts and bytes rewritten, projected duration (from mutation/merge history), and whether free disk can hold the transient rewrite — without executing anything.
+
+### Changed
+- **Mutation progress** — the Cluster → Mutations view now shows an approximate progress bar (parts done / total) and a Killed status, alongside the existing parts-remaining and failure-reason columns.

--- a/changelogs/unreleased/parts-pressure-alert.md
+++ b/changelogs/unreleased/parts-pressure-alert.md
@@ -1,0 +1,4 @@
+type: minor
+
+### Added
+- **Predictive "too many parts" alert** — a new fleet alert rule fires when a table is projected to hit its `parts_to_throw_insert` limit within a configurable number of minutes, turning the parts-pressure trend into an early warning before inserts start failing. Configurable in the fleet alert delivery dialog (server-side, delivered to Slack/Google Chat/email) and the in-app alerts bell, and surfaced as a "Parts limit ETA" tile on each fleet card.

--- a/changelogs/unreleased/parts-pressure-observatory.md
+++ b/changelogs/unreleased/parts-pressure-observatory.md
@@ -1,0 +1,4 @@
+type: minor
+
+### Added
+- **Parts pressure monitoring** — a new Parts tab in Metrics surfaces the insert-vs-merge race behind ClickHouse's "too many parts" failure mode. For each table it shows the worst partition against `parts_to_throw_insert`, live insert/merge rates, and a projected ETA until the threshold is crossed. Also collected fleet-wide as the `parts_pressure` metric for historical trends.

--- a/packages/server/src/rbac/db/migrations.test.ts
+++ b/packages/server/src/rbac/db/migrations.test.ts
@@ -143,6 +143,20 @@ const VERSION_CHECKS: Record<string, () => Promise<void>> = {
   "1.35.0": async () => {
     expect(await h.columnExists("rbac_sso_providers", "saml_trust_email_verified")).toBe(true);
   },
+  "1.36.0": async () => {
+    expect(await h.tableExists("fleet_alert_config")).toBe(true);
+    expect(await h.columnExists("fleet_alert_config", "config")).toBe(true);
+    // The single config row (id=1) is seeded by the migration.
+    const rows = await h.rawAll(sql`SELECT id FROM fleet_alert_config WHERE id = 1`);
+    expect(rows.length).toBe(1);
+  },
+  "1.37.0": async () => {
+    expect(await h.tableExists("doctor_schedule")).toBe(true);
+    expect(await h.columnExists("doctor_schedule", "last_run_at")).toBe(true);
+    expect(await h.columnExists("doctor_schedule", "last_run_by")).toBe(true);
+    const rows = await h.rawAll(sql`SELECT id FROM doctor_schedule WHERE id = 1`);
+    expect(rows.length).toBe(1);
+  },
 };
 
 // ---------------------------------------------------------------------------

--- a/packages/server/src/rbac/db/migrations.ts
+++ b/packages/server/src/rbac/db/migrations.ts
@@ -7,6 +7,7 @@
  * - Version upgrades (runs only new migrations)
  */
 
+import { readFileSync } from 'node:fs';
 import { sql } from 'drizzle-orm';
 import { randomUUID } from 'crypto';
 import { eq } from 'drizzle-orm';
@@ -44,7 +45,7 @@ export interface MigrationResult {
 // Current App Version
 // ============================================
 
-export const APP_VERSION = '1.35.0';
+export const APP_VERSION = '1.37.0';
 
 // ============================================
 // Error Helpers
@@ -101,6 +102,22 @@ async function rebuildSsoProvidersNullable(db: SqliteDb): Promise<void> {
   db.run(sql`DROP TABLE rbac_sso_providers`);
   db.run(sql`ALTER TABLE rbac_sso_providers__new RENAME TO rbac_sso_providers`);
   db.run(sql`PRAGMA foreign_keys=ON`);
+}
+
+/**
+ * Read a legacy on-disk JSON config file for one-time import into the DB during
+ * a migration. Returns the raw file contents, or "{}" if the file is missing or
+ * unreadable (fresh installs, test runs, containers without the old volume).
+ * Never throws — a missing legacy file is the normal case, not an error.
+ */
+function readLegacyJsonFile(path: string): string {
+  try {
+    const raw = readFileSync(path, 'utf8');
+    JSON.parse(raw); // validate — store "{}" rather than a corrupt blob
+    return raw;
+  } catch {
+    return '{}';
+  }
 }
 
 // ============================================
@@ -3359,6 +3376,132 @@ export const MIGRATIONS: Migration[] = [
       logger.info({ module: 'RBAC', phase: 'migration' }, '[Migration 1.35.0] Added saml_trust_email_verified');
     },
     down: async () => { /* forward-only */ },
+  },
+  {
+    version: '1.36.0',
+    name: 'fleet_alert_config',
+    description: 'HA — move fleet alert config (rules/thresholds + Slack/email/Google Chat webhooks) off local pod disk into a single-row DB table so all replicas share one source of truth. Imports an existing alert-config.json file on first run.',
+    up: async (db) => {
+      const dbType = getDatabaseType();
+
+      if (dbType === 'sqlite') {
+        (db as SqliteDb).run(sql`
+          CREATE TABLE IF NOT EXISTS fleet_alert_config (
+            id         INTEGER PRIMARY KEY,
+            config     TEXT    NOT NULL DEFAULT '{}',
+            updated_at INTEGER NOT NULL DEFAULT 0
+          )
+        `);
+      } else {
+        await (db as PostgresDb).execute(sql`
+          CREATE TABLE IF NOT EXISTS fleet_alert_config (
+            id         INTEGER PRIMARY KEY,
+            config     TEXT    NOT NULL DEFAULT '{}',
+            updated_at BIGINT  NOT NULL DEFAULT 0
+          )
+        `);
+      }
+
+      // Seed the single config row (id=1), importing the legacy on-disk file if
+      // present so existing deployments don't lose their alert settings. The
+      // INSERT is idempotent (IGNORE / ON CONFLICT DO NOTHING), so the import
+      // only happens the first time this migration runs.
+      const seed = readLegacyJsonFile(
+        process.env.ALERT_CONFIG_FILE || '/app/data/alert-config.json',
+      );
+      const now = Date.now();
+      if (dbType === 'sqlite') {
+        (db as SqliteDb).run(sql`
+          INSERT OR IGNORE INTO fleet_alert_config (id, config, updated_at)
+          VALUES (1, ${seed}, ${now})
+        `);
+      } else {
+        await (db as PostgresDb).execute(sql`
+          INSERT INTO fleet_alert_config (id, config, updated_at)
+          VALUES (1, ${seed}, ${now})
+          ON CONFLICT (id) DO NOTHING
+        `);
+      }
+      logger.info({ module: 'RBAC', phase: 'migration' }, `[Migration 1.36.0] Created fleet_alert_config (${dbType})`);
+    },
+    down: async (db) => {
+      const dbType = getDatabaseType();
+      if (dbType === 'sqlite') {
+        (db as SqliteDb).run(sql`DROP TABLE IF EXISTS fleet_alert_config`);
+      } else {
+        await (db as PostgresDb).execute(sql`DROP TABLE IF EXISTS fleet_alert_config`);
+      }
+      logger.info({ module: 'RBAC', phase: 'migration' }, '[Migration 1.36.0] Dropped fleet_alert_config');
+    },
+  },
+  {
+    version: '1.37.0',
+    name: 'doctor_schedule',
+    description: 'HA — move the Chouse AI scheduled-scan config + run-state off local pod disk into a single-row DB table. last_run_at/last_run_by double as a per-slot claim so that with multiple replicas only one fires a given scheduled scan. Imports an existing doctor-schedule.json file on first run.',
+    up: async (db) => {
+      const dbType = getDatabaseType();
+
+      if (dbType === 'sqlite') {
+        (db as SqliteDb).run(sql`
+          CREATE TABLE IF NOT EXISTS doctor_schedule (
+            id          INTEGER PRIMARY KEY,
+            config      TEXT    NOT NULL DEFAULT '{}',
+            last_run_at INTEGER NOT NULL DEFAULT 0,
+            last_run_by TEXT    NOT NULL DEFAULT ''
+          )
+        `);
+      } else {
+        await (db as PostgresDb).execute(sql`
+          CREATE TABLE IF NOT EXISTS doctor_schedule (
+            id          INTEGER PRIMARY KEY,
+            config      TEXT    NOT NULL DEFAULT '{}',
+            last_run_at BIGINT  NOT NULL DEFAULT 0,
+            last_run_by TEXT    NOT NULL DEFAULT ''
+          )
+        `);
+      }
+
+      // Seed the single row (id=1), importing the legacy file if present. The
+      // file's lastRunAt is split out into the last_run_at column so the
+      // de-dupe guard carries over; the rest of the schedule stays in `config`.
+      const raw = readLegacyJsonFile(
+        process.env.DOCTOR_SCHEDULE_FILE || '/app/data/doctor-schedule.json',
+      );
+      let lastRunAt = 0;
+      let configJson = '{}';
+      try {
+        const parsed = JSON.parse(raw) as Record<string, unknown>;
+        const lr = Number(parsed.lastRunAt);
+        lastRunAt = Number.isFinite(lr) && lr > 0 ? Math.floor(lr) : 0;
+        delete parsed.lastRunAt;
+        configJson = JSON.stringify(parsed);
+      } catch {
+        // No/invalid file — defaults are fine (loadSchedule fills DEFAULTS).
+      }
+
+      if (dbType === 'sqlite') {
+        (db as SqliteDb).run(sql`
+          INSERT OR IGNORE INTO doctor_schedule (id, config, last_run_at, last_run_by)
+          VALUES (1, ${configJson}, ${lastRunAt}, '')
+        `);
+      } else {
+        await (db as PostgresDb).execute(sql`
+          INSERT INTO doctor_schedule (id, config, last_run_at, last_run_by)
+          VALUES (1, ${configJson}, ${lastRunAt}, '')
+          ON CONFLICT (id) DO NOTHING
+        `);
+      }
+      logger.info({ module: 'RBAC', phase: 'migration' }, `[Migration 1.37.0] Created doctor_schedule (${dbType})`);
+    },
+    down: async (db) => {
+      const dbType = getDatabaseType();
+      if (dbType === 'sqlite') {
+        (db as SqliteDb).run(sql`DROP TABLE IF EXISTS doctor_schedule`);
+      } else {
+        await (db as PostgresDb).execute(sql`DROP TABLE IF EXISTS doctor_schedule`);
+      }
+      logger.info({ module: 'RBAC', phase: 'migration' }, '[Migration 1.37.0] Dropped doctor_schedule');
+    },
   },
 ];
 

--- a/packages/server/src/rbac/sso/service.test.ts
+++ b/packages/server/src/rbac/sso/service.test.ts
@@ -15,7 +15,11 @@ import { describe, it, expect, mock, beforeEach } from "bun:test";
 let mockGetUserIdentityResult: Record<string, unknown> | null = null;
 let mockGetUserByEmailResult: Record<string, unknown> | null = null;
 let mockGetUserByUsernameResults: Map<string, Record<string, unknown> | null> = new Map();
-let mockGetRoleByNameResult: Record<string, unknown> | null = null;
+// Either a fixed role (returned for any name) or a name-aware resolver — the
+// latter lets a test map several group→role names to distinct roles. Reset in
+// beforeEach so it never leaks across tests.
+type RoleResolver = (name: string) => Record<string, unknown> | null;
+let mockGetRoleByNameResult: Record<string, unknown> | null | RoleResolver = null;
 let mockGetUserRolesResult: string[] = [];
 let mockCreateUserResult: Record<string, unknown> = {
   id: "new-user-id",
@@ -61,7 +65,8 @@ const mockFns = {
   touchUserIdentity: mock(async (_id: string) => undefined),
   getUserByEmail: mock(async (_e: string) => mockGetUserByEmailResult),
   getUserByUsername: mock(async (u: string) => mockGetUserByUsernameResults.get(u) ?? null),
-  getRoleByName: mock(async (_n: string) => mockGetRoleByNameResult),
+  getRoleByName: mock(async (n: string) =>
+    typeof mockGetRoleByNameResult === "function" ? mockGetRoleByNameResult(n) : mockGetRoleByNameResult),
   getUserRoles: mock(async (_id: string) => mockGetUserRolesResult),
   createUser: mock(async (_input: unknown) => mockCreateUserResult),
   createSessionAndTokens: mock(async (_u: unknown, _ip?: string, _ua?: string) => mockCreateSessionResult),
@@ -92,6 +97,9 @@ function makeInsertBuilder(): Record<string, unknown> {
     mockDbInsertValues.push(v);
     return b;
   });
+  // Role sync upserts (insert ... on conflict (user_id) do update) so it never
+  // leaves the user role-less mid-sync.
+  b.onConflictDoUpdate = mock(() => b);
   b.then = mock((resolve: (v: unknown) => void) => resolve(undefined));
   return b;
 }
@@ -402,7 +410,7 @@ describe("provisionSsoUser", () => {
   // ----------------------------------------------------------------
   // Test 8: role re-sync via roleMapping (Fix 7 hygiene)
   // ----------------------------------------------------------------
-  it("8. role re-sync: roleMappingClaim 'groups', mapping ch-admins→admin, claims {groups:['ch-admins']} → db delete+insert with admin role id and assignedBy='sso:okta'", async () => {
+  it("8. role re-sync: roleMappingClaim 'groups', mapping ch-admins→admin, claims {groups:['ch-admins']} → atomic upsert with admin role id and assignedBy='sso:okta' (no delete)", async () => {
     mockGetUserIdentityResult = existingIdentityRow;
     mockDbUserRow = { ...existingUserRow };
     mockGetUserRolesResult = ["viewer"]; // current roles differ from mapped
@@ -416,15 +424,46 @@ describe("provisionSsoUser", () => {
 
     await provisionSsoUser(provider, identity);
 
-    // Verify role sync happened: delete was called then insert with admin roleId
-    expect(mockDb.delete).toHaveBeenCalled();
+    // Role sync is an atomic upsert — no delete-then-insert lockout window.
+    expect(mockDb.delete).not.toHaveBeenCalled();
     expect(mockDb.insert).toHaveBeenCalled();
 
-    // assert inserted rows have correct roleId and assignedBy
+    // assert upserted row has the correct roleId and assignedBy
     const inserted = mockDbInsertValues[0];
     const insertedArr = Array.isArray(inserted) ? inserted : [inserted];
     expect(insertedArr.some((r: unknown) => (r as Record<string, unknown>).roleId === "role-admin")).toBe(true);
     expect(insertedArr.some((r: unknown) => (r as Record<string, unknown>).assignedBy === "sso:okta")).toBe(true);
+  });
+
+  // ----------------------------------------------------------------
+  // Test 8b: multi-group claim → collapse to highest-privilege role (#261)
+  // ----------------------------------------------------------------
+  it("8b. multi-role mapping: claims {groups:['devs','admins']} mapping to developer+admin → upserts ONE role (admin, highest privilege)", async () => {
+    mockGetUserIdentityResult = existingIdentityRow;
+    mockDbUserRow = { ...existingUserRow };
+    mockGetUserRolesResult = ["viewer"];
+    // Resolve each mapped name to its own role (data-driven, reset in beforeEach).
+    mockGetRoleByNameResult = (name: string) => {
+      if (name === "admin") return { id: "role-admin", name: "admin", displayName: "Admin" };
+      if (name === "developer") return { id: "role-developer", name: "developer", displayName: "Developer" };
+      return null;
+    };
+
+    const provider = makeProvider({
+      roleMappingClaim: "groups",
+      roleMapping: { devs: "developer", admins: "admin" },
+    });
+    const identity = makeIdentity({ claims: { groups: ["devs", "admins"] } });
+
+    await provisionSsoUser(provider, identity);
+
+    // Exactly one role upserted, and it's the highest-privilege one (admin).
+    expect(mockDb.delete).not.toHaveBeenCalled();
+    expect(mockDbInsertValues.length).toBe(1);
+    const inserted = mockDbInsertValues[0];
+    const insertedArr = Array.isArray(inserted) ? inserted : [inserted];
+    expect(insertedArr.length).toBe(1);
+    expect((insertedArr[0] as Record<string, unknown>).roleId).toBe("role-admin");
   });
 
   // ----------------------------------------------------------------

--- a/packages/server/src/rbac/sso/service.ts
+++ b/packages/server/src/rbac/sso/service.ts
@@ -24,7 +24,7 @@ import { getSsoConfig, type SsoProviderConfig } from './config';
 import type { SsoIdentity } from './client';
 import { logger } from '../../utils/logger';
 import { AppError } from '../../types';
-import { SYSTEM_ROLES } from '../schema/base';
+import { SYSTEM_ROLES, ROLE_HIERARCHY, type SystemRole } from '../schema/base';
 import type { User, UserResponse } from '../schema';
 import type { TokenPair } from '../services/jwt';
 
@@ -202,11 +202,20 @@ async function pickAvailableUsername(base: string): Promise<string> {
 }
 
 /**
- * Replace the user's roles with those mapped from the IdP claim.
- * If no mapped role resolves to a known role, keep existing roles (avoid lockout).
- * If the user currently holds super_admin, skip sync entirely to avoid demotion.
+ * Set the user's role from the IdP claim. This system is single-role-per-user
+ * (a UNIQUE index on rbac_user_roles.user_id), so when an IdP claim matches
+ * several mapped groups we MUST collapse to exactly one role — otherwise the
+ * multi-row insert violates that index and the login fails, leaving the user
+ * role-less. We pick the highest-privilege resolved role (ROLE_HIERARCHY), the
+ * same precedence migration 1.27.0 used to collapse legacy multi-role users.
  *
- * accepts explicit claimName + mapping so no `as` casts are needed.
+ * Behaviour preserved:
+ *   - If no mapped role resolves to a known role, keep the existing role (avoid lockout).
+ *   - If the user currently holds super_admin, skip sync entirely (avoid demotion).
+ *
+ * The write is a single atomic upsert keyed on user_id, so the user is never
+ * left without a role mid-sync. accepts explicit claimName + mapping so no
+ * `as` casts are needed.
  */
 async function syncMappedRoles(
   userId: string,
@@ -269,25 +278,58 @@ async function syncMappedRoles(
     return;
   }
 
-  const targetNames = targetRoles.map((r) => r.name).sort();
-  if (JSON.stringify([...currentNames].sort()) === JSON.stringify(targetNames)) return;
+  // Single-role-per-user: collapse multiple matched roles to the highest
+  // privilege one. Logged so admins can see when a user's group membership
+  // resolved to more than one mapping.
+  const chosen = pickHighestPrivilegeRole(targetRoles);
+  if (targetRoles.length > 1) {
+    logger.warn(
+      {
+        module: 'SSO',
+        provider: provider.id,
+        userId,
+        resolvedRoles: targetRoles.map((r) => r.name),
+        chosenRole: chosen.name,
+      },
+      'IdP claim mapped to multiple roles; collapsed to highest-privilege role (single-role-per-user)'
+    );
+  }
 
+  // No change needed when the user already holds exactly the chosen role.
+  if (currentNames.length === 1 && currentNames[0] === chosen.name) return;
+
+  // Atomic upsert keyed on the user_id unique index — replaces whatever role
+  // the user has (or inserts one) in a single statement, so a failure can never
+  // leave them role-less the way a delete-then-insert could.
   const db = getDatabase() as AnyDb;
   const schema = getSchema();
-  await db.delete(schema.userRoles).where(eq(schema.userRoles.userId, userId));
-  await db.insert(schema.userRoles).values(
-    targetRoles.map((role) => ({
-      id: randomUUID(),
-      userId,
-      roleId: role.id,
-      assignedAt: new Date(),
-      assignedBy: `sso:${provider.id}`,
-    }))
-  );
+  const assignedAt = new Date();
+  const assignedBy = `sso:${provider.id}`;
+  await db
+    .insert(schema.userRoles)
+    .values({ id: randomUUID(), userId, roleId: chosen.id, assignedAt, assignedBy })
+    .onConflictDoUpdate({
+      target: schema.userRoles.userId,
+      set: { roleId: chosen.id, assignedAt, assignedBy },
+    });
   logger.info(
-    { module: 'SSO', provider: provider.id, userId, roles: targetNames },
-    'Synced roles from IdP claim'
+    { module: 'SSO', provider: provider.id, userId, role: chosen.name },
+    'Synced role from IdP claim'
   );
+}
+
+/**
+ * Pick the highest-privilege role from a resolved set, using the canonical
+ * ROLE_HIERARCHY. Custom (non-system) roles rank lowest (0); ties break
+ * alphabetically so the choice is deterministic. Callers must pass a non-empty
+ * array.
+ */
+function pickHighestPrivilegeRole<T extends { id: string; name: string }>(roles: T[]): T {
+  const rank = (name: string): number => ROLE_HIERARCHY[name as SystemRole] ?? 0;
+  return [...roles].sort((a, b) => {
+    const diff = rank(b.name) - rank(a.name);
+    return diff !== 0 ? diff : a.name.localeCompare(b.name);
+  })[0];
 }
 
 /** Returns true if the error is a unique-constraint violation (SQLite or PostgreSQL). */

--- a/packages/server/src/routes/fleet.ts
+++ b/packages/server/src/routes/fleet.ts
@@ -40,8 +40,12 @@ import {
 } from "../services/fleetMetrics";
 import { AppError } from "../types";
 import { logger } from "../utils/logger";
-import { readFileSync, writeFileSync } from "node:fs";
 import { sendTestAlert } from "../services/fleetAlerter";
+import {
+  loadRawAlertConfig,
+  saveRawAlertConfig,
+  type RawAlertConfig,
+} from "../services/fleetAlertConfig";
 import { runStructuredCapability } from "../services/ai/engine";
 import { fleetScanCapability } from "../services/ai/capabilities/fleetScan";
 import { isAIEnabled } from "../services/aiConfig";
@@ -56,29 +60,6 @@ import {
 import { listAiConfigs } from "../rbac/services/aiModels";
 
 const fleet = new Hono();
-
-const ALERT_CONFIG_PATH =
-  process.env.ALERT_CONFIG_FILE || "/app/data/alert-config.json";
-
-type RawAlertConfig = {
-  enabled?: boolean;
-  rules?: { memoryPercent?: number; queryMemoryGb?: number; longQueryMin?: number };
-  slack?: { webhookUrl?: string; enabled?: boolean };
-  googleChat?: { webhookUrl?: string; enabled?: boolean };
-  email?: { user?: string; password?: string; to?: string; enabled?: boolean; host?: string; port?: number; secure?: boolean };
-  /** When true, a new breach also fires a Chouse AI RCA to the channels. */
-  aiRcaOnBreach?: boolean;
-  /** AI config id for the auto-RCA scan (blank = default model). */
-  aiRcaModelId?: string;
-};
-
-function loadRawAlertConfig(): RawAlertConfig {
-  try {
-    return JSON.parse(readFileSync(ALERT_CONFIG_PATH, "utf8")) as RawAlertConfig;
-  } catch {
-    return {};
-  }
-}
 
 // Apply RBAC + per-surface permissions to every route in this module.
 //   - Coarse gate: you need at least one fleet/doctor capability to touch the router.
@@ -462,7 +443,7 @@ fleet.get("/alert-config", async (c) => {
   if (!requireSuperAdmin(c)) {
     return c.json({ success: false, error: "Super admin required" }, 403);
   }
-  const cfg = loadRawAlertConfig();
+  const cfg = await loadRawAlertConfig();
   return c.json({
     success: true,
     data: {
@@ -473,6 +454,7 @@ fleet.get("/alert-config", async (c) => {
         memoryPercent: Number(cfg.rules?.memoryPercent ?? 85),
         queryMemoryGb: Number(cfg.rules?.queryMemoryGb ?? 0),
         longQueryMin: Number(cfg.rules?.longQueryMin ?? 0),
+        partsEtaMin: Number(cfg.rules?.partsEtaMin ?? 0),
       },
       slack: {
         configured: Boolean(cfg.slack?.webhookUrl),
@@ -500,6 +482,7 @@ const alertConfigSchema = z.object({
     memoryPercent: z.number().min(0).max(100),
     queryMemoryGb: z.number().min(0),
     longQueryMin: z.number().min(0),
+    partsEtaMin: z.number().min(0).max(1440).optional().default(0),
   }),
   // Blank/omitted secret = keep existing; `remove*` clears the channel.
   slackWebhookUrl: z.string().optional(),
@@ -520,7 +503,7 @@ fleet.put("/alert-config", zValidator("json", alertConfigSchema), async (c) => {
     return c.json({ success: false, error: "Super admin required" }, 403);
   }
   const body = c.req.valid("json");
-  const existing = loadRawAlertConfig();
+  const existing = await loadRawAlertConfig();
 
   const next: RawAlertConfig = {
     enabled: body.enabled,
@@ -530,6 +513,7 @@ fleet.put("/alert-config", zValidator("json", alertConfigSchema), async (c) => {
       memoryPercent: body.rules.memoryPercent,
       queryMemoryGb: body.rules.queryMemoryGb,
       longQueryMin: body.rules.longQueryMin,
+      partsEtaMin: body.rules.partsEtaMin,
     },
   };
 
@@ -579,7 +563,7 @@ fleet.put("/alert-config", zValidator("json", alertConfigSchema), async (c) => {
   }
 
   try {
-    writeFileSync(ALERT_CONFIG_PATH, JSON.stringify(next, null, 2));
+    await saveRawAlertConfig(next);
   } catch (e) {
     logger.error(
       { module: "FleetAlerter", err: e instanceof Error ? e.message : String(e) },
@@ -740,7 +724,7 @@ fleet.post("/doctor/reports/delete", zValidator("json", doctorDeleteSchema), asy
 
 // Scheduled scans (daily / weekly / monthly).
 fleet.get("/doctor/schedule", async (c) => {
-  return c.json({ success: true, data: loadSchedule() });
+  return c.json({ success: true, data: await loadSchedule() });
 });
 
 const doctorScheduleSchema = z.object({
@@ -759,7 +743,7 @@ fleet.put("/doctor/schedule", requirePermission(PERMISSIONS.DOCTOR_RUN), zValida
   const body = c.req.valid("json");
   // Stamp lastRunAt = now so enabling/editing fires at the NEXT occurrence,
   // not a backfill of a slot that already passed today.
-  saveSchedule({ ...body, lastRunAt: Date.now() } as DoctorSchedule);
+  await saveSchedule({ ...body, lastRunAt: Date.now() } as DoctorSchedule);
   await createAuditLogWithContext(c, AUDIT_ACTIONS.DOCTOR_SCHEDULE_UPDATE, getRbacUser(c).sub, {
     resourceType: "doctor_schedule",
     details: {

--- a/packages/server/src/routes/metrics.ts
+++ b/packages/server/src/routes/metrics.ts
@@ -481,6 +481,65 @@ metrics.get("/insert-throughput", async (c) => {
 });
 
 /**
+ * GET /metrics/parts-pressure
+ * Per-table parts pressure: live part counts, worst-partition vs threshold, and
+ * the insert-vs-merge race with a projected eta until "too many parts".
+ * @param interval - Rate window in minutes (default: 10)
+ */
+metrics.get("/parts-pressure", async (c) => {
+  const rbacUserId = c.get("rbacUserId");
+  const rbacPermissions = c.get("rbacPermissions");
+  const isRbacAdmin = c.get("isRbacAdmin");
+
+  // Advanced metrics: parts pressure exposes per-table operational internals.
+  await checkMetricsPermission(rbacUserId, rbacPermissions, isRbacAdmin, true);
+
+  const interval = parseInt(c.req.query("interval") || "10", 10);
+  const service = c.get("service");
+
+  const partsPressure = await service.getPartsPressure(Math.min(interval, 1440));
+
+  return c.json({
+    success: true,
+    data: partsPressure,
+  });
+});
+
+/**
+ * POST /metrics/ddl/simulate
+ * Read-only impact estimate for an ALTER … UPDATE/DELETE mutation. Parses the
+ * statement (strict allowlist — only UPDATE/DELETE) and runs SELECT/metadata
+ * queries to estimate affected rows, parts/bytes rewritten, duration, and disk.
+ * NEVER executes the mutation.
+ * Body: { statement: string }
+ */
+metrics.post("/ddl/simulate", async (c) => {
+  const rbacUserId = c.get("rbacUserId");
+  const rbacPermissions = c.get("rbacPermissions");
+  const isRbacAdmin = c.get("isRbacAdmin");
+
+  // Advanced metrics: estimating mutation cost is an operational concern.
+  await checkMetricsPermission(rbacUserId, rbacPermissions, isRbacAdmin, true);
+
+  const body = await c.req.json().catch(() => ({}));
+  const statement = typeof body?.statement === "string" ? body.statement : "";
+
+  const { parseMutationStatement } = await import("../services/ddlSimulator");
+  const parsed = parseMutationStatement(statement);
+  if (!parsed.ok) {
+    throw AppError.badRequest(parsed.error);
+  }
+
+  const service = c.get("service");
+  const estimate = await service.getDdlImpact(parsed.value, service.defaultDatabase);
+
+  return c.json({
+    success: true,
+    data: estimate,
+  });
+});
+
+/**
  * GET /metrics/top-tables
  * Get top tables by size
  * @param limit - Number of tables to return (default: 10)

--- a/packages/server/src/services/clickhouse.test.ts
+++ b/packages/server/src/services/clickhouse.test.ts
@@ -140,6 +140,136 @@ describe("ClickHouse Service", () => {
         });
     });
 
+    describe("getPartsPressure", () => {
+        it("should map per-table parts pressure rows and coerce numbers", async () => {
+            mockJsonFn.mockResolvedValue({
+                data: [
+                    {
+                        database: "default",
+                        table: "events",
+                        active_parts: "250",
+                        max_parts_in_partition: "240",
+                        rows: "1000000",
+                        bytes: "5000000",
+                        merges_running: "1",
+                        insert_parts_per_min: 12,
+                        merge_parts_per_min: 4,
+                        parts_threshold: 300,
+                        net_parts_per_min: 8,
+                        eta_minutes: 7.5,
+                    },
+                ],
+            });
+
+            const result = await service.getPartsPressure(10);
+
+            expect(result).toHaveLength(1);
+            expect(result[0]).toEqual({
+                database: "default",
+                table: "events",
+                active_parts: 250,
+                max_parts_in_partition: 240,
+                rows: 1000000,
+                bytes: 5000000,
+                merges_running: 1,
+                insert_parts_per_min: 12,
+                merge_parts_per_min: 4,
+                parts_threshold: 300,
+                net_parts_per_min: 8,
+                eta_minutes: 7.5,
+            });
+
+            const call = (mockQueryFn as any).mock.calls[0];
+            const queryParams = call[0] as any;
+            expect(queryParams.query).toContain("system.parts");
+            expect(queryParams.query).toContain("parts_to_throw_insert");
+            expect(queryParams.query).toContain("system.part_log");
+            expect(queryParams.format).toBe("JSON");
+        });
+
+        it("should preserve a negative eta (-1 = converging) rather than zeroing it", async () => {
+            mockJsonFn.mockResolvedValue({
+                data: [
+                    {
+                        database: "default",
+                        table: "calm",
+                        active_parts: 10,
+                        max_parts_in_partition: 5,
+                        rows: 100,
+                        bytes: 200,
+                        merges_running: 0,
+                        insert_parts_per_min: 1,
+                        merge_parts_per_min: 3,
+                        parts_threshold: 300,
+                        net_parts_per_min: -2,
+                        eta_minutes: -1,
+                    },
+                ],
+            });
+
+            const result = await service.getPartsPressure();
+
+            expect(result[0].eta_minutes).toBe(-1);
+            expect(result[0].net_parts_per_min).toBe(-2);
+        });
+
+        it("should return empty array when no parts", async () => {
+            mockJsonFn.mockResolvedValue({ data: [] });
+
+            const result = await service.getPartsPressure(10);
+
+            expect(result).toEqual([]);
+        });
+    });
+
+    describe("getDdlImpact", () => {
+        const parsed = { database: "demo", table: "events", kind: "update" as const, where: "id < 5" };
+
+        it("estimates rows, parts, duration, and disk sufficiency (read-only)", async () => {
+            // Consumed in order: affected-rows, parts agg, throughput, disk free.
+            mockJsonFn
+                .mockResolvedValueOnce({ data: [{ c: 159 }] })
+                .mockResolvedValueOnce({ data: [{ parts: 300, rows: 1000, bytes: 5_000_000 }] })
+                .mockResolvedValueOnce({ data: [{ bytes: 10_000_000, ms: 2000 }] })
+                .mockResolvedValueOnce({ data: [{ free: 9_000_000_000 }] });
+
+            const r = await service.getDdlImpact(parsed, "demo");
+
+            expect(r.affected_rows).toBe(159);
+            expect(r.total_rows).toBe(1000);
+            expect(r.parts_to_rewrite).toBe(300);
+            expect(r.bytes_to_rewrite).toBe(5_000_000);
+            // throughput = 10MB / 2s = 5MB/s; duration = 5MB / 5MB/s = 1s
+            expect(r.est_duration_seconds).toBeCloseTo(1, 5);
+            expect(r.disk_sufficient).toBe(true);
+
+            // First query must be the read-only count against the table — never an ALTER.
+            const firstQuery = (mockQueryFn as any).mock.calls[0][0].query as string;
+            expect(firstQuery).toContain("count()");
+            expect(firstQuery).toContain("`demo`.`events`");
+            expect(firstQuery.toUpperCase()).not.toContain("ALTER");
+        });
+
+        it("reports unknown duration (-1) when there is no mutation/merge history", async () => {
+            mockJsonFn
+                .mockResolvedValueOnce({ data: [{ c: 10 }] })
+                .mockResolvedValueOnce({ data: [{ parts: 5, rows: 100, bytes: 1000 }] })
+                .mockResolvedValueOnce({ data: [{ bytes: 0, ms: 0 }] })
+                .mockResolvedValueOnce({ data: [{ free: 500 }] });
+
+            const r = await service.getDdlImpact(parsed, "demo");
+
+            expect(r.est_duration_seconds).toBe(-1);
+            expect(r.disk_sufficient).toBe(false); // free 500 < 1000 bytes to rewrite
+        });
+
+        it("rejects an invalid table reference", async () => {
+            await expect(
+                service.getDdlImpact({ database: "demo", table: "bad table", kind: "delete", where: "1" }, "demo"),
+            ).rejects.toThrow();
+        });
+    });
+
     describe("ping", () => {
         it("should return true on success", async () => {
             const result = await service.ping();

--- a/packages/server/src/services/clickhouse.ts
+++ b/packages/server/src/services/clickhouse.ts
@@ -46,6 +46,11 @@ export class ClickHouseService {
     return ClientManager.getInstance().getClient(this.config);
   }
 
+  /** The connection's default database (used to resolve unqualified table refs). */
+  get defaultDatabase(): string | undefined {
+    return this.config.database;
+  }
+
   async close(): Promise<void> {
     // No-op: Client is managed by ClientManager
     // We don't close the shared client here
@@ -1243,6 +1248,200 @@ export class ClickHouseService {
       }));
     } catch (error) {
       throw this.handleError(error, "Failed to fetch insert throughput metrics");
+    }
+  }
+
+  /**
+   * Per-table parts pressure for the live (single-connection) view. Surfaces the
+   * insert-vs-merge race behind the "too many parts" failure: live part counts,
+   * the worst partition (compared against parts_to_throw_insert), and a projected
+   * eta_minutes until that partition crosses the threshold (-1 = converging).
+   *
+   * Rates are approximate (NewPart/MergeParts events per minute from
+   * system.part_log). The threshold is the table's effective parts_to_throw_insert
+   * — a per-table SETTINGS override (parsed from create_table_query) when present,
+   * else the server-global default from system.merge_tree_settings, defaulting to
+   * 300 when neither is available. Uses system.parts/merges/part_log/tables
+   * (present on CH 24+); returns [] gracefully if part_log is absent.
+   */
+  async getPartsPressure(intervalMinutes: number = 10): Promise<import("../types").PartsPressureRow[]> {
+    try {
+      const window = Math.max(1, Math.min(intervalMinutes, 1440));
+      const result = await this.client.query({
+        query: `
+          WITH
+            (SELECT toFloat64OrZero(value) FROM system.merge_tree_settings WHERE name = 'parts_to_throw_insert') AS global_threshold_raw,
+            if(global_threshold_raw > 0, global_threshold_raw, 300) AS global_threshold,
+            parts_agg AS (
+              SELECT
+                database,
+                table,
+                sum(part_count) AS active_parts,
+                max(part_count) AS max_parts_in_partition,
+                sum(part_rows) AS rows,
+                sum(part_bytes) AS bytes
+              FROM (
+                SELECT
+                  database,
+                  table,
+                  partition_id,
+                  count() AS part_count,
+                  sum(rows) AS part_rows,
+                  sum(bytes_on_disk) AS part_bytes
+                FROM system.parts
+                WHERE active
+                  AND database NOT IN ('system', 'information_schema', 'INFORMATION_SCHEMA')
+                GROUP BY database, table, partition_id
+              )
+              GROUP BY database, table
+            ),
+            merges_agg AS (
+              SELECT database, table, count() AS merges_running
+              FROM system.merges
+              GROUP BY database, table
+            ),
+            log_agg AS (
+              SELECT
+                database,
+                table,
+                countIf(event_type = 'NewPart') / ${window}.0 AS insert_parts_per_min,
+                countIf(event_type = 'MergeParts') / ${window}.0 AS merge_parts_per_min
+              FROM system.part_log
+              WHERE event_time >= now() - INTERVAL ${window} MINUTE
+              GROUP BY database, table
+            ),
+            settings_agg AS (
+              SELECT
+                database,
+                name AS table,
+                toFloat64OrZero(extract(create_table_query, 'parts_to_throw_insert\\\\s*=\\\\s*(\\\\d+)')) AS table_threshold
+              FROM system.tables
+              WHERE database NOT IN ('system', 'information_schema', 'INFORMATION_SCHEMA')
+            )
+          SELECT
+            p.database AS database,
+            p.table AS table,
+            p.active_parts AS active_parts,
+            p.max_parts_in_partition AS max_parts_in_partition,
+            p.rows AS rows,
+            p.bytes AS bytes,
+            coalesce(m.merges_running, 0) AS merges_running,
+            coalesce(l.insert_parts_per_min, 0) AS insert_parts_per_min,
+            coalesce(l.merge_parts_per_min, 0) AS merge_parts_per_min,
+            if(s.table_threshold > 0, s.table_threshold, global_threshold) AS parts_threshold,
+            (coalesce(l.insert_parts_per_min, 0) - coalesce(l.merge_parts_per_min, 0)) AS net_parts_per_min,
+            if(
+              net_parts_per_min > 0,
+              (parts_threshold - p.max_parts_in_partition) / net_parts_per_min,
+              -1
+            ) AS eta_minutes
+          FROM parts_agg p
+          LEFT JOIN merges_agg m ON p.database = m.database AND p.table = m.table
+          LEFT JOIN log_agg l ON p.database = l.database AND p.table = l.table
+          LEFT JOIN settings_agg s ON p.database = s.database AND p.table = s.table
+          ORDER BY max_parts_in_partition DESC
+          LIMIT 50
+        `,
+        format: "JSON",
+      });
+      const response = await result.json() as JsonResponse<Record<string, string | number>>;
+
+      return response.data.map((d) => ({
+        database: String(d.database ?? ""),
+        table: String(d.table ?? ""),
+        active_parts: Number(d.active_parts) || 0,
+        max_parts_in_partition: Number(d.max_parts_in_partition) || 0,
+        rows: Number(d.rows) || 0,
+        bytes: Number(d.bytes) || 0,
+        merges_running: Number(d.merges_running) || 0,
+        insert_parts_per_min: Number(d.insert_parts_per_min) || 0,
+        merge_parts_per_min: Number(d.merge_parts_per_min) || 0,
+        parts_threshold: Number(d.parts_threshold) || 300,
+        net_parts_per_min: Number(d.net_parts_per_min) || 0,
+        eta_minutes: Number(d.eta_minutes),
+      }));
+    } catch (error) {
+      throw this.handleError(error, "Failed to fetch parts pressure metrics");
+    }
+  }
+
+  /**
+   * Read-only impact estimate for an ALTER … UPDATE/DELETE mutation. Runs only
+   * SELECT/metadata queries — it NEVER executes the mutation. Estimates rows
+   * matched by the predicate, the (worst-case) set of active parts a mutation
+   * rewrites, projected duration from historical mutation/merge throughput, and
+   * whether free disk can hold the transient rewrite. The predicate is bounded
+   * to a read-only count (single statement, capped execution time).
+   */
+  async getDdlImpact(
+    parsed: import("./ddlSimulator").ParsedMutation,
+    defaultDatabase?: string,
+  ): Promise<import("../types").DdlImpactEstimate> {
+    const ident = /^[A-Za-z_][A-Za-z0-9_]*$/;
+    const db = parsed.database ?? defaultDatabase ?? "default";
+    if (!ident.test(db) || !ident.test(parsed.table)) {
+      throw AppError.badRequest("Invalid table reference.");
+    }
+    const ref = `\`${db}\`.\`${parsed.table}\``;
+    const predicate = parsed.where && parsed.where.trim() ? parsed.where : "1";
+
+    const scalar = async <T extends Record<string, unknown>>(query: string): Promise<T | undefined> => {
+      const res = await this.client.query({ query, format: "JSON" });
+      const json = await res.json() as JsonResponse<T>;
+      return json.data[0];
+    };
+
+    try {
+      // Rows matched by the predicate (read-only, time-capped). Runs first so an
+      // invalid table/predicate surfaces a clear error before the rest.
+      const matched = await scalar<{ c: string | number }>(
+        `SELECT count() AS c FROM ${ref} WHERE ${predicate} SETTINGS max_execution_time = 15`,
+      );
+
+      // Worst-case rewrite set: all active parts of the table (a mutation
+      // rewrites whole parts). Also the table's total rows.
+      const partsAgg = await scalar<{ parts: string | number; rows: string | number; bytes: string | number }>(
+        `SELECT count() AS parts, sum(rows) AS rows, sum(bytes_on_disk) AS bytes
+         FROM system.parts
+         WHERE active AND database = '${db}' AND table = '${parsed.table}'`,
+      );
+
+      // Throughput from mutation history, falling back to merge history (similar
+      // part-rewrite speed) — bytes per second over the last 30 days.
+      const rate = await scalar<{ bytes: string | number; ms: string | number }>(
+        `SELECT sum(size_in_bytes) AS bytes, sum(duration_ms) AS ms
+         FROM system.part_log
+         WHERE event_type IN ('MutatePart', 'MergeParts')
+           AND database = '${db}' AND table = '${parsed.table}'
+           AND event_time >= now() - INTERVAL 30 DAY`,
+      );
+
+      const disk = await scalar<{ free: string | number }>(
+        `SELECT min(free_space) AS free FROM system.disks`,
+      );
+
+      const bytesToRewrite = Number(partsAgg?.bytes) || 0;
+      const rateBytes = Number(rate?.bytes) || 0;
+      const rateMs = Number(rate?.ms) || 0;
+      const bytesPerSec = rateMs > 0 ? rateBytes / (rateMs / 1000) : 0;
+      const estDuration = bytesPerSec > 0 ? bytesToRewrite / bytesPerSec : -1;
+      const diskFree = Number(disk?.free) || 0;
+
+      return {
+        database: db,
+        table: parsed.table,
+        kind: parsed.kind,
+        where: parsed.where,
+        affected_rows: Number(matched?.c) || 0,
+        total_rows: Number(partsAgg?.rows) || 0,
+        parts_to_rewrite: Number(partsAgg?.parts) || 0,
+        bytes_to_rewrite: bytesToRewrite,
+        est_duration_seconds: estDuration,
+        disk_free_bytes: diskFree,
+        disk_sufficient: diskFree > bytesToRewrite,
+      };
+    } catch (error) {
+      throw this.handleError(error, "Failed to simulate mutation impact");
     }
   }
 

--- a/packages/server/src/services/ddlSimulator.test.ts
+++ b/packages/server/src/services/ddlSimulator.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from "bun:test";
+import { parseMutationStatement } from "./ddlSimulator";
+
+describe("ddlSimulator parseMutationStatement", () => {
+  it("parses a qualified UPDATE with a predicate", () => {
+    const r = parseMutationStatement("ALTER TABLE demo.events UPDATE col = 1 WHERE id < 5");
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.value).toEqual({ database: "demo", table: "events", kind: "update", where: "id < 5" });
+  });
+
+  it("parses a DELETE and an unqualified table (null database)", () => {
+    const r = parseMutationStatement("ALTER TABLE events DELETE WHERE ts < now()");
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.value.database).toBeNull();
+    expect(r.value.table).toBe("events");
+    expect(r.value.kind).toBe("delete");
+    expect(r.value.where).toBe("ts < now()");
+  });
+
+  it("strips backticks and tolerates ON CLUSTER", () => {
+    const r = parseMutationStatement("ALTER TABLE `db`.`t` ON CLUSTER my_cluster DELETE WHERE 1");
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.value.database).toBe("db");
+    expect(r.value.table).toBe("t");
+  });
+
+  it("treats a missing WHERE as an empty predicate", () => {
+    const r = parseMutationStatement("ALTER TABLE db.t DELETE");
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.value.where).toBe("");
+  });
+
+  it("strips comments before parsing", () => {
+    const r = parseMutationStatement("/* cleanup */ ALTER TABLE db.t DELETE WHERE id = 1 -- trailing");
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.value.kind).toBe("delete");
+  });
+
+  it.each([
+    ["a SELECT", "SELECT 1"],
+    ["a DROP", "DROP TABLE db.t"],
+    ["a non-mutating ALTER", "ALTER TABLE db.t ADD COLUMN x Int32"],
+    ["a TRUNCATE", "TRUNCATE TABLE db.t"],
+    ["an empty string", "   "],
+  ])("rejects %s", (_label, sql) => {
+    expect(parseMutationStatement(sql).ok).toBe(false);
+  });
+
+  it("rejects multiple statements", () => {
+    const r = parseMutationStatement("ALTER TABLE db.t DELETE WHERE 1; DROP TABLE db.t");
+    expect(r.ok).toBe(false);
+  });
+
+  it("rejects a predicate that smuggles a second statement", () => {
+    const r = parseMutationStatement("ALTER TABLE db.t DELETE WHERE id = 1; DROP TABLE x");
+    expect(r.ok).toBe(false);
+  });
+});

--- a/packages/server/src/services/ddlSimulator.ts
+++ b/packages/server/src/services/ddlSimulator.ts
@@ -1,0 +1,88 @@
+/**
+ * ddlSimulator — parse a ClickHouse mutation (ALTER TABLE … UPDATE/DELETE) for
+ * the read-only DDL impact simulator. ClickHouse's mutation syntax isn't
+ * standard SQL (node-sql-parser can't parse it), so this is a deliberately
+ * strict allowlist parser: it accepts ONLY ALTER TABLE … UPDATE/DELETE and
+ * rejects everything else. The parsed pieces are used solely to build read-only
+ * estimate queries — the simulator never executes the ALTER.
+ */
+
+export interface ParsedMutation {
+  /** Null means "use the connection's default database". */
+  database: string | null;
+  table: string;
+  kind: "update" | "delete";
+  /** Predicate after WHERE; empty string means the statement had no WHERE. */
+  where: string;
+}
+
+export type ParseResult =
+  | { ok: true; value: ParsedMutation }
+  | { ok: false; error: string };
+
+const IDENT = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+/** Strip ClickHouse line (`--`) and block (`/* *​/`) comments. */
+function stripComments(sql: string): string {
+  return sql
+    .replace(/\/\*[\s\S]*?\*\//g, " ")
+    .replace(/--[^\n]*/g, " ");
+}
+
+export function parseMutationStatement(input: string): ParseResult {
+  if (!input || !input.trim()) {
+    return { ok: false, error: "Empty statement." };
+  }
+
+  let sql = stripComments(input).trim();
+  // Allow a single trailing semicolon; reject anything that looks like more
+  // than one statement (defence-in-depth, even though we never execute it).
+  sql = sql.replace(/;\s*$/, "");
+  if (sql.includes(";")) {
+    return { ok: false, error: "Only a single statement is supported." };
+  }
+
+  // ALTER TABLE [db.]table [ON CLUSTER name] <UPDATE…|DELETE…>
+  const head = sql.match(
+    /^ALTER\s+TABLE\s+(?:(`?[A-Za-z_][A-Za-z0-9_]*`?)\.)?(`?[A-Za-z_][A-Za-z0-9_]*`?)\s+(?:ON\s+CLUSTER\s+\S+\s+)?(.*)$/is,
+  );
+  if (!head) {
+    return {
+      ok: false,
+      error: "Only ALTER TABLE … UPDATE/DELETE statements can be simulated.",
+    };
+  }
+
+  const database = head[1] ? head[1].replace(/`/g, "") : null;
+  const table = head[2].replace(/`/g, "");
+  const rest = head[3].trim();
+
+  if (database !== null && !IDENT.test(database)) {
+    return { ok: false, error: `Invalid database name: ${database}` };
+  }
+  if (!IDENT.test(table)) {
+    return { ok: false, error: `Invalid table name: ${table}` };
+  }
+
+  const kindMatch = rest.match(/^(UPDATE|DELETE)\b/i);
+  if (!kindMatch) {
+    return {
+      ok: false,
+      error:
+        "Only UPDATE and DELETE mutations are supported (ADD/DROP/MODIFY and other ALTERs are not part-rewriting mutations).",
+    };
+  }
+  const kind = kindMatch[1].toLowerCase() as "update" | "delete";
+
+  // The mutation predicate is everything after the first WHERE. UPDATE without
+  // WHERE / DELETE without WHERE → empty predicate (affects the whole table).
+  const whereMatch = rest.match(/\bWHERE\b(.+)$/is);
+  const where = whereMatch ? whereMatch[1].trim() : "";
+
+  // A predicate must not smuggle a second statement.
+  if (where.includes(";")) {
+    return { ok: false, error: "Invalid predicate." };
+  }
+
+  return { ok: true, value: { database, table, kind, where } };
+}

--- a/packages/server/src/services/doctorScheduler.test.ts
+++ b/packages/server/src/services/doctorScheduler.test.ts
@@ -1,0 +1,164 @@
+/**
+ * DoctorScheduler persistence + per-slot claim tests (SQLite in-memory).
+ *
+ * Covers the DB-backed schedule (replacing the old local JSON file) and the
+ * atomic slot claim that makes scheduled scans safe under multiple replicas:
+ * for one slot, exactly one holder wins claimScheduledSlot(); the rest stand by.
+ */
+import { describe, it, expect, beforeEach, afterAll } from "bun:test";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { closeDatabase } from "../rbac/db";
+import { runMigrations } from "../rbac/db/migrations";
+import { freshDatabase } from "../rbac/db/migrationTestHarness";
+import {
+  loadSchedule,
+  saveSchedule,
+  claimScheduledSlot,
+  type DoctorSchedule,
+} from "./doctorScheduler";
+
+async function setupDb(): Promise<void> {
+  delete process.env.DOCTOR_SCHEDULE_FILE;
+  await freshDatabase("sqlite");
+  await runMigrations({ skipSeed: true });
+}
+
+afterAll(async () => {
+  await closeDatabase();
+});
+
+describe("doctorScheduler persistence", () => {
+  beforeEach(async () => {
+    await setupDb();
+  });
+
+  it("returns defaults from the migration-seeded row (disabled, no backfill)", async () => {
+    const cfg = await loadSchedule();
+    expect(cfg.enabled).toBe(false);
+    expect(cfg.frequency).toBe("daily");
+    expect(cfg.lastRunAt).toBe(0);
+  });
+
+  it("round-trips a saved schedule, splitting lastRunAt into its own column", async () => {
+    const next: DoctorSchedule = {
+      enabled: true,
+      frequency: "weekly",
+      hour: 9,
+      dayOfWeek: 3,
+      dayOfMonth: 1,
+      modelId: "cfg-123",
+      hours: 12,
+      connectionIds: ["a", "b"],
+      deliver: false,
+      lastRunAt: 1_700_000_000_000,
+    };
+    await saveSchedule(next);
+
+    const loaded = await loadSchedule();
+    expect(loaded.enabled).toBe(true);
+    expect(loaded.frequency).toBe("weekly");
+    expect(loaded.hour).toBe(9);
+    expect(loaded.dayOfWeek).toBe(3);
+    expect(loaded.modelId).toBe("cfg-123");
+    expect(loaded.hours).toBe(12);
+    expect(loaded.connectionIds).toEqual(["a", "b"]);
+    expect(loaded.deliver).toBe(false);
+    expect(loaded.lastRunAt).toBe(1_700_000_000_000);
+  });
+
+  it("clamps out-of-range values on load", async () => {
+    await saveSchedule({
+      enabled: true,
+      frequency: "daily",
+      hour: 99,
+      dayOfWeek: 9,
+      dayOfMonth: 99,
+      hours: 9999,
+      deliver: true,
+      lastRunAt: 0,
+    } as DoctorSchedule);
+    const loaded = await loadSchedule();
+    expect(loaded.hour).toBe(23); // clamped to max
+    expect(loaded.dayOfWeek).toBe(6); // clamped to max
+    expect(loaded.dayOfMonth).toBe(28); // clamped to max
+    expect(loaded.hours).toBe(72); // clamped to max
+  });
+});
+
+describe("doctorScheduler per-slot claim (multi-instance dedup)", () => {
+  beforeEach(async () => {
+    await setupDb();
+  });
+
+  it("lets exactly one holder win a slot; others stand by", async () => {
+    const fireAt = 1_000_000;
+    const now = 1_000_500;
+
+    // Two replicas contend for the same slot back-to-back (writes are
+    // serialized, so this models the race deterministically).
+    const first = await claimScheduledSlot("pod-A", fireAt, now);
+    const second = await claimScheduledSlot("pod-B", fireAt, now + 1);
+
+    expect(first).toBe(true);
+    expect(second).toBe(false);
+
+    // The winner's stamp is what persisted.
+    const loaded = await loadSchedule();
+    expect(loaded.lastRunAt).toBe(now);
+  });
+
+  it("does not re-fire a slot already claimed in a previous tick", async () => {
+    const fireAt = 2_000_000;
+    expect(await claimScheduledSlot("pod-A", fireAt, 2_000_100)).toBe(true);
+    // Same slot, later tick — already stamped at/after fireAt, so no win.
+    expect(await claimScheduledSlot("pod-A", fireAt, 2_000_200)).toBe(false);
+  });
+
+  it("allows the next slot to be claimed once fireAt advances", async () => {
+    expect(await claimScheduledSlot("pod-A", 3_000_000, 3_000_100)).toBe(true);
+    // A later slot (fireAt past the stored lastRunAt) is claimable again.
+    expect(await claimScheduledSlot("pod-A", 4_000_000, 4_000_100)).toBe(true);
+  });
+});
+
+describe("doctorScheduler legacy-file import (migration 1.37.0)", () => {
+  let dir = "";
+
+  afterAll(() => {
+    delete process.env.DOCTOR_SCHEDULE_FILE;
+    if (dir) rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("imports an existing doctor-schedule.json (config + lastRunAt) on first migration", async () => {
+    dir = mkdtempSync(join(tmpdir(), "doctor-sched-"));
+    const file = join(dir, "doctor-schedule.json");
+    writeFileSync(
+      file,
+      JSON.stringify({
+        enabled: true,
+        frequency: "weekly",
+        hour: 7,
+        dayOfWeek: 2,
+        hours: 24,
+        deliver: false,
+        lastRunAt: 1_650_000_000_000,
+      }),
+    );
+    process.env.DOCTOR_SCHEDULE_FILE = file;
+
+    await freshDatabase("sqlite");
+    await runMigrations({ skipSeed: true });
+
+    const loaded = await loadSchedule();
+    expect(loaded.enabled).toBe(true);
+    expect(loaded.frequency).toBe("weekly");
+    expect(loaded.hour).toBe(7);
+    expect(loaded.dayOfWeek).toBe(2);
+    expect(loaded.hours).toBe(24);
+    expect(loaded.deliver).toBe(false);
+    // lastRunAt is split out of the blob into its own column and preserved.
+    expect(loaded.lastRunAt).toBe(1_650_000_000_000);
+  });
+});

--- a/packages/server/src/services/doctorScheduler.ts
+++ b/packages/server/src/services/doctorScheduler.ts
@@ -3,20 +3,29 @@
  * (daily / weekly / monthly) and saves the report (trigger="scheduled"),
  * optionally delivering it to the configured Slack/email channels.
  *
- * Config is a JSON file (default <data>/doctor-schedule.json, override with
- * DOCTOR_SCHEDULE_FILE), re-read every tick so it's live-editable. `lastRunAt`
- * is written back after each run so a missed/late tick still fires once.
+ * Config + run-state live in the shared RBAC DB (single-row doctor_schedule,
+ * id=1), re-read every tick so it's live-editable. `last_run_at` is written
+ * back after each run so a missed/late tick still fires once.
  *
- * Multi-instance: best-effort (it stamps lastRunAt before running). If several
- * replicas share a DB they could double-fire a scheduled scan; single-container
- * is the happy path. Deferred, like the early fleet poller.
+ * Multi-instance: safe. The per-slot claim (claimSlot) is one atomic
+ * conditional UPDATE on last_run_at — the row itself is the lease, mirroring
+ * the fleet-poller pattern. With N replicas only the one whose UPDATE flips the
+ * row for a given slot runs the scan; the rest see the slot already taken.
+ *
+ * Backward compat: migration 1.37.0 imports an existing doctor-schedule.json
+ * (including its lastRunAt) into the seed row on first run.
  */
 
-import { readFileSync, writeFileSync } from "node:fs";
+import { randomUUID } from "crypto";
+import { sql } from "drizzle-orm";
 
+import {
+  getDatabase,
+  getDatabaseType,
+  type SqliteDb,
+  type PostgresDb,
+} from "../rbac/db";
 import { logger } from "../utils/logger";
-
-const SCHEDULE_PATH = process.env.DOCTOR_SCHEDULE_FILE || "/app/data/doctor-schedule.json";
 
 export type ScheduleFrequency = "daily" | "weekly" | "monthly";
 
@@ -49,11 +58,45 @@ function clampInt(v: unknown, lo: number, hi: number, d: number): number {
   return Number.isFinite(n) ? Math.min(hi, Math.max(lo, n)) : d;
 }
 
-export function loadSchedule(): DoctorSchedule {
+function num(v: unknown): number {
+  const n = Number(v);
+  return Number.isFinite(n) ? n : 0;
+}
+
+/** Read the single config row (id=1) — config blob + last_run_at column. */
+async function selectScheduleRow(): Promise<Record<string, unknown> | undefined> {
+  const db = getDatabase();
+  const stmt = sql`SELECT config, last_run_at FROM doctor_schedule WHERE id = 1 LIMIT 1`;
+  if (getDatabaseType() === "sqlite") {
+    return (db as SqliteDb).all(stmt)[0] as Record<string, unknown> | undefined;
+  }
+  const res = await (db as PostgresDb).execute(stmt);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const anyRes = res as any;
+  const rows = (Array.isArray(anyRes) ? anyRes : anyRes.rows ?? []) as Record<string, unknown>[];
+  return rows[0];
+}
+
+/**
+ * Load the schedule from the DB. The schedule fields live in the `config` JSON
+ * blob; `lastRunAt` is the dedicated last_run_at column (it's the atomic claim
+ * guard). Falls back to DEFAULTS when no row exists or the blob is unparseable.
+ */
+export async function loadSchedule(): Promise<DoctorSchedule> {
   let raw: Partial<DoctorSchedule> = {};
+  let lastRunAt = 0;
   try {
-    raw = JSON.parse(readFileSync(SCHEDULE_PATH, "utf8")) as Partial<DoctorSchedule>;
-  } catch {
+    const row = await selectScheduleRow();
+    lastRunAt = num(row?.last_run_at);
+    const cfg = row?.config;
+    if (typeof cfg === "string" && cfg.length > 0) {
+      raw = JSON.parse(cfg) as Partial<DoctorSchedule>;
+    }
+  } catch (err) {
+    logger.error(
+      { module: "DoctorScheduler", err: err instanceof Error ? err.message : String(err) },
+      "Failed to load schedule",
+    );
     return { ...DEFAULTS };
   }
   const frequency: ScheduleFrequency =
@@ -68,12 +111,61 @@ export function loadSchedule(): DoctorSchedule {
     hours: clampInt(raw.hours, 1, 72, DEFAULTS.hours),
     connectionIds: Array.isArray(raw.connectionIds) ? raw.connectionIds.map(String) : undefined,
     deliver: raw.deliver !== false,
-    lastRunAt: clampInt(raw.lastRunAt, 0, Number.MAX_SAFE_INTEGER, 0),
+    lastRunAt: clampInt(lastRunAt, 0, Number.MAX_SAFE_INTEGER, 0),
   };
 }
 
-export function saveSchedule(next: DoctorSchedule): void {
-  writeFileSync(SCHEDULE_PATH, JSON.stringify(next, null, 2));
+/**
+ * Persist the schedule. The schedule fields go into the `config` blob and
+ * `lastRunAt` into its own column. The row (id=1) is seeded by migration
+ * 1.37.0; the INSERT fallback covers a missing row so a save never no-ops.
+ */
+export async function saveSchedule(next: DoctorSchedule): Promise<void> {
+  const db = getDatabase();
+  const dbType = getDatabaseType();
+  const { lastRunAt, ...config } = next;
+  const json = JSON.stringify(config);
+  if (dbType === "sqlite") {
+    (db as SqliteDb).run(sql`
+      INSERT INTO doctor_schedule (id, config, last_run_at)
+      VALUES (1, ${json}, ${lastRunAt})
+      ON CONFLICT (id) DO UPDATE SET config = excluded.config, last_run_at = excluded.last_run_at
+    `);
+  } else {
+    await (db as PostgresDb).execute(sql`
+      INSERT INTO doctor_schedule (id, config, last_run_at)
+      VALUES (1, ${json}, ${lastRunAt})
+      ON CONFLICT (id) DO UPDATE SET config = EXCLUDED.config, last_run_at = EXCLUDED.last_run_at
+    `);
+  }
+}
+
+/**
+ * Atomically claim the scheduled slot for `fireAt`. Returns true if THIS call
+ * performed the claim (and the caller should run the scan), false if the slot
+ * was already taken. One conditional UPDATE flips last_run_at→now and stamps
+ * last_run_by; the WHERE (last_run_at < fireAt) means only the first writer
+ * across all replicas matches a row. We key off the affected-row count (1 = we
+ * won, 0 = someone else already had it) rather than reading the holder back, so
+ * the result is correct even when the same holder retries. Race-safe like the
+ * fleet-poller lease: SQLite serializes writes; Postgres row-locks and
+ * re-evaluates the WHERE under READ COMMITTED.
+ */
+export async function claimScheduledSlot(holderId: string, fireAt: number, now: number): Promise<boolean> {
+  const db = getDatabase();
+  const dbType = getDatabaseType();
+  const claim = sql`
+    UPDATE doctor_schedule
+    SET last_run_at = ${now}, last_run_by = ${holderId}
+    WHERE id = 1 AND last_run_at < ${fireAt}
+  `;
+  if (dbType === "sqlite") {
+    const res = (db as SqliteDb).run(claim) as unknown as { changes?: number };
+    return (res?.changes ?? 0) > 0;
+  }
+  // postgres-js exposes affected rows as `.count` on the result.
+  const res = (await (db as PostgresDb).execute(claim)) as unknown as { count?: number };
+  return (res?.count ?? 0) > 0;
 }
 
 /** Unix ms of the most recent moment the schedule should have fired, <= now. */
@@ -103,6 +195,7 @@ class DoctorScheduler {
   private static instance: DoctorScheduler | null = null;
   private timer: NodeJS.Timeout | null = null;
   private running = false;
+  private readonly runId = randomUUID();
 
   static getInstance(): DoctorScheduler {
     if (!DoctorScheduler.instance) DoctorScheduler.instance = new DoctorScheduler();
@@ -127,15 +220,23 @@ class DoctorScheduler {
     if (this.running) return;
     this.running = true;
     try {
-      const cfg = loadSchedule();
+      const cfg = await loadSchedule();
       if (!cfg.enabled) return;
 
       const now = Date.now();
       const fireAt = lastScheduledFireMs(cfg, new Date(now));
-      if (cfg.lastRunAt >= fireAt) return; // already ran for this slot
+      if (cfg.lastRunAt >= fireAt) return; // already ran for this slot (fast path)
 
-      // Stamp BEFORE the (slow) scan so a re-entry / next tick can't double-fire.
-      saveSchedule({ ...cfg, lastRunAt: now });
+      // Atomically claim the slot BEFORE the (slow) scan: this both prevents a
+      // re-entry / next tick from double-firing AND ensures only one replica
+      // fires when several share the DB. Lost the race → another pod has it.
+      if (!(await claimScheduledSlot(this.runId, fireAt, now))) {
+        logger.debug(
+          { module: "DoctorScheduler", runId: this.runId },
+          "Scheduled slot already claimed by another instance; standing by",
+        );
+        return;
+      }
       logger.info(
         { module: "DoctorScheduler", frequency: cfg.frequency, hours: cfg.hours, model: cfg.modelId ?? "default" },
         "Scheduled scan starting",

--- a/packages/server/src/services/fleetAlertConfig.test.ts
+++ b/packages/server/src/services/fleetAlertConfig.test.ts
@@ -1,0 +1,82 @@
+/**
+ * fleetAlertConfig persistence tests (SQLite in-memory).
+ *
+ * Covers the DB-backed alert config (replacing alert-config.json) and the
+ * one-time backward-compat import of an existing on-disk file by migration
+ * 1.36.0.
+ */
+import { describe, it, expect, beforeEach, afterAll } from "bun:test";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { closeDatabase } from "../rbac/db";
+import { runMigrations } from "../rbac/db/migrations";
+import { freshDatabase } from "../rbac/db/migrationTestHarness";
+import {
+  loadRawAlertConfig,
+  saveRawAlertConfig,
+  type RawAlertConfig,
+} from "./fleetAlertConfig";
+
+afterAll(async () => {
+  await closeDatabase();
+});
+
+describe("fleetAlertConfig persistence", () => {
+  beforeEach(async () => {
+    delete process.env.ALERT_CONFIG_FILE;
+    await freshDatabase("sqlite");
+    await runMigrations({ skipSeed: true });
+  });
+
+  it("starts empty when no legacy file exists", async () => {
+    expect(await loadRawAlertConfig()).toEqual({});
+  });
+
+  it("round-trips a saved config including secrets and channel flags", async () => {
+    const cfg: RawAlertConfig = {
+      enabled: true,
+      aiRcaOnBreach: true,
+      aiRcaModelId: "cfg-9",
+      rules: { memoryPercent: 90, queryMemoryGb: 20, longQueryMin: 5, partsEtaMin: 30 },
+      slack: { webhookUrl: "https://hooks.slack.com/services/X", enabled: false },
+      email: { user: "ops@x.com", password: "secret", to: "team@x.com", enabled: true },
+    };
+    await saveRawAlertConfig(cfg);
+    expect(await loadRawAlertConfig()).toEqual(cfg);
+  });
+
+  it("overwrites on subsequent saves (single source of truth)", async () => {
+    await saveRawAlertConfig({ enabled: true, rules: { memoryPercent: 50 } });
+    await saveRawAlertConfig({ enabled: false, rules: { memoryPercent: 99 } });
+    const loaded = await loadRawAlertConfig();
+    expect(loaded.enabled).toBe(false);
+    expect(loaded.rules?.memoryPercent).toBe(99);
+  });
+});
+
+describe("fleetAlertConfig legacy-file import (migration 1.36.0)", () => {
+  let dir = "";
+
+  afterAll(() => {
+    delete process.env.ALERT_CONFIG_FILE;
+    if (dir) rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("imports an existing alert-config.json into the DB on first migration", async () => {
+    dir = mkdtempSync(join(tmpdir(), "alert-cfg-"));
+    const file = join(dir, "alert-config.json");
+    const legacy: RawAlertConfig = {
+      enabled: true,
+      rules: { memoryPercent: 85 },
+      slack: { webhookUrl: "https://hooks.slack.com/services/LEGACY", enabled: true },
+    };
+    writeFileSync(file, JSON.stringify(legacy));
+    process.env.ALERT_CONFIG_FILE = file;
+
+    await freshDatabase("sqlite");
+    await runMigrations({ skipSeed: true });
+
+    expect(await loadRawAlertConfig()).toEqual(legacy);
+  });
+});

--- a/packages/server/src/services/fleetAlertConfig.ts
+++ b/packages/server/src/services/fleetAlertConfig.ts
@@ -1,0 +1,111 @@
+/**
+ * fleetAlertConfig — persistence for the fleet alert delivery config.
+ *
+ * Previously this config (rules/thresholds + Slack/email/Google Chat webhooks)
+ * lived in a JSON file on local pod disk (alert-config.json). That broke under
+ * multiple replicas: a UI update only changed one pod's file, the poller pod
+ * read its own stale copy, settings were lost on restart, and concurrent writes
+ * raced. It now lives in a single-row table (fleet_alert_config, id=1) in the
+ * shared RBAC DB so every replica reads/writes one source of truth.
+ *
+ * Backward compat: migration 1.36.0 imports an existing alert-config.json into
+ * the seed row on first run, so upgrades keep their settings.
+ *
+ * The blob keeps the original file's shape (RawAlertConfig) verbatim, so the
+ * route + alerter parsing code is unchanged apart from awaiting the load.
+ */
+
+import { sql } from "drizzle-orm";
+import {
+  getDatabase,
+  getDatabaseType,
+  type SqliteDb,
+  type PostgresDb,
+} from "../rbac/db";
+import { logger } from "../utils/logger";
+
+/** On-disk/in-DB shape — mirrors the legacy alert-config.json verbatim. */
+export interface RawAlertConfig {
+  enabled?: boolean;
+  rules?: {
+    memoryPercent?: number;
+    queryMemoryGb?: number;
+    longQueryMin?: number;
+    partsEtaMin?: number;
+  };
+  slack?: { webhookUrl?: string; enabled?: boolean };
+  googleChat?: { webhookUrl?: string; enabled?: boolean };
+  email?: {
+    user?: string;
+    password?: string;
+    to?: string;
+    enabled?: boolean;
+    host?: string;
+    port?: number;
+    secure?: boolean;
+    from?: string;
+  };
+  /** When true, a new breach also fires a Chouse AI RCA to the channels. */
+  aiRcaOnBreach?: boolean;
+  /** AI config id for the auto-RCA scan (blank = default model). */
+  aiRcaModelId?: string;
+}
+
+async function selectConfigRow(): Promise<Record<string, unknown> | undefined> {
+  const db = getDatabase();
+  const stmt = sql`SELECT config FROM fleet_alert_config WHERE id = 1 LIMIT 1`;
+  if (getDatabaseType() === "sqlite") {
+    return (db as SqliteDb).all(stmt)[0] as Record<string, unknown> | undefined;
+  }
+  const res = await (db as PostgresDb).execute(stmt);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const anyRes = res as any;
+  const rows = (Array.isArray(anyRes) ? anyRes : anyRes.rows ?? []) as Record<string, unknown>[];
+  return rows[0];
+}
+
+/**
+ * Load the raw alert config from the DB. Returns {} when no row exists yet
+ * (pre-migration) or the stored blob is unparseable — callers already treat an
+ * empty config as "delivery off / defaults", matching the old missing-file path.
+ */
+export async function loadRawAlertConfig(): Promise<RawAlertConfig> {
+  try {
+    const row = await selectConfigRow();
+    const raw = row?.config;
+    if (typeof raw !== "string" || raw.length === 0) return {};
+    return JSON.parse(raw) as RawAlertConfig;
+  } catch (err) {
+    logger.error(
+      { module: "FleetAlertConfig", err: err instanceof Error ? err.message : String(err) },
+      "Failed to load alert config",
+    );
+    return {};
+  }
+}
+
+/**
+ * Persist the raw alert config. The single row (id=1) is seeded by migration
+ * 1.36.0; we UPDATE it. The INSERT fallback covers the unlikely case the row is
+ * missing (e.g. manual DB surgery) so a save never silently no-ops.
+ */
+export async function saveRawAlertConfig(cfg: RawAlertConfig): Promise<void> {
+  const db = getDatabase();
+  const dbType = getDatabaseType();
+  const json = JSON.stringify(cfg);
+  const now = Date.now();
+
+  if (dbType === "sqlite") {
+    (db as SqliteDb).run(sql`
+      INSERT INTO fleet_alert_config (id, config, updated_at)
+      VALUES (1, ${json}, ${now})
+      ON CONFLICT (id) DO UPDATE SET config = excluded.config, updated_at = excluded.updated_at
+    `);
+  } else {
+    await (db as PostgresDb).execute(sql`
+      INSERT INTO fleet_alert_config (id, config, updated_at)
+      VALUES (1, ${json}, ${now})
+      ON CONFLICT (id) DO UPDATE SET config = EXCLUDED.config, updated_at = EXCLUDED.updated_at
+    `);
+  }
+}

--- a/packages/server/src/services/fleetAlerter.test.ts
+++ b/packages/server/src/services/fleetAlerter.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from "bun:test";
+import { evaluateNode } from "./fleetAlerter";
+
+// Minimal rules object; only partsEtaMin matters for these cases (others off).
+const rules = (partsEtaMin: number) => ({
+  memoryPercent: 0,
+  queryMemoryGb: 0,
+  longQueryMin: 0,
+  partsEtaMin,
+});
+
+const partsRow = (over: Partial<Record<string, number | string>> = {}) => ({
+  database: "default",
+  table: "events",
+  active_parts: 240,
+  max_parts_in_partition: 240,
+  rows: 1_000_000,
+  bytes: 5_000_000,
+  merges_running: 0,
+  insert_parts_per_min: 24,
+  merge_parts_per_min: 0,
+  parts_threshold: 300,
+  net_parts_per_min: 24,
+  eta_minutes: 2.5,
+  ...over,
+});
+
+describe("fleetAlerter evaluateNode — parts pressure", () => {
+  it("does not emit a parts rule when partsEtaMin is 0 (off)", () => {
+    const out = evaluateNode({ parts_pressure: [partsRow()] }, rules(0));
+    expect(out.find((r) => r.ruleKey === "partspressure")).toBeUndefined();
+  });
+
+  it("breaches when a diverging table's ETA is under the threshold", () => {
+    const out = evaluateNode({ parts_pressure: [partsRow({ eta_minutes: 2.5 })] }, rules(60));
+    const r = out.find((r) => r.ruleKey === "partspressure");
+    expect(r).toBeDefined();
+    expect(r?.breaching).toBe(true);
+    expect(r?.clearing).toBe(false);
+    expect(r?.instanceId).toBe("default.events");
+    expect(r?.metric).toBe("parts pressure");
+  });
+
+  it("clears when the table is converging (net rate <= 0)", () => {
+    const out = evaluateNode(
+      { parts_pressure: [partsRow({ net_parts_per_min: -5, eta_minutes: -1 })] },
+      rules(60),
+    );
+    const r = out.find((r) => r.ruleKey === "partspressure");
+    expect(r?.breaching).toBe(false);
+    expect(r?.clearing).toBe(true);
+  });
+
+  it("holds the latch inside the hysteresis band (between threshold and 1.25x)", () => {
+    // partsEtaMin=60 → ETA 70 is above threshold but below the 75 clear point.
+    const out = evaluateNode({ parts_pressure: [partsRow({ eta_minutes: 70 })] }, rules(60));
+    const r = out.find((r) => r.ruleKey === "partspressure");
+    expect(r?.breaching).toBe(false);
+    expect(r?.clearing).toBe(false);
+  });
+
+  it("clears once ETA climbs past the 1.25x hysteresis point", () => {
+    const out = evaluateNode({ parts_pressure: [partsRow({ eta_minutes: 90 })] }, rules(60));
+    const r = out.find((r) => r.ruleKey === "partspressure");
+    expect(r?.breaching).toBe(false);
+    expect(r?.clearing).toBe(true);
+  });
+
+  it("latches each table independently via instanceId", () => {
+    const out = evaluateNode(
+      {
+        parts_pressure: [
+          partsRow({ eta_minutes: 2 }),
+          { ...partsRow(), table: "logs", eta_minutes: 1000, net_parts_per_min: 24 },
+        ],
+      },
+      rules(60),
+    );
+    const parts = out.filter((r) => r.ruleKey === "partspressure");
+    expect(parts).toHaveLength(2);
+    expect(parts.map((r) => r.instanceId).sort()).toEqual(["default.events", "default.logs"]);
+    expect(parts.find((r) => r.instanceId === "default.events")?.breaching).toBe(true);
+    expect(parts.find((r) => r.instanceId === "default.logs")?.breaching).toBe(false);
+  });
+});

--- a/packages/server/src/services/fleetAlerter.ts
+++ b/packages/server/src/services/fleetAlerter.ts
@@ -7,12 +7,12 @@
  * to the configured channels — Slack (incoming webhook) and/or email (SMTP,
  * e.g. Gmail). This runs server-side so alerts fire even with no browser open.
  *
- * Config is a JSON file (default <data>/alert-config.json, override with
- * ALERT_CONFIG_FILE). It's re-read every tick so it can be edited live without
- * recreating the container. A missing/invalid file or `enabled: false` simply
- * turns delivery off.
+ * Config lives in the shared RBAC DB (single-row fleet_alert_config), loaded
+ * via fleetAlertConfig. It's re-read every tick so it can be edited live, and
+ * every replica sees the same settings. An empty config or `enabled: false`
+ * simply turns delivery off.
  *
- * Example alert-config.json:
+ * Example stored config (RawAlertConfig):
  * {
  *   "enabled": true,
  *   "rules": { "memoryPercent": 85, "queryMemoryGb": 10, "longQueryMin": 5 },
@@ -22,12 +22,9 @@
  * }
  */
 
-import { readFileSync } from "node:fs";
-
 import { logger } from "../utils/logger";
+import { loadRawAlertConfig } from "./fleetAlertConfig";
 import type { DoctorReport } from "./ai/capabilities/fleetScan";
-
-const CONFIG_PATH = process.env.ALERT_CONFIG_FILE || "/app/data/alert-config.json";
 /** Node-memory re-arms only once it drops this far below threshold (anti-flap). */
 const HYSTERESIS = 5;
 /** Min gap between autonomous RCA scans, so a breach storm can't spawn a scan storm. */
@@ -41,7 +38,10 @@ interface AlertRules {
   memoryPercent: number; // node memory %, 0 = off
   queryMemoryGb: number; // single query GB, 0 = off
   longQueryMin: number; // single query minutes, 0 = off
+  partsEtaMin: number; // projected minutes until a table hits parts_to_throw_insert, 0 = off
 }
+/** A diverging table re-arms only once its projected ETA climbs this far past the limit (anti-flap). */
+const PARTS_ETA_CLEAR_RATIO = 1.25;
 interface SlackConfig {
   webhookUrl: string;
 }
@@ -102,20 +102,18 @@ function num(v: unknown): number {
   return Number.isFinite(n) ? n : 0;
 }
 
-function loadConfig(): AlertConfig | null {
-  let parsed: Record<string, unknown>;
-  try {
-    parsed = JSON.parse(readFileSync(CONFIG_PATH, "utf8"));
-  } catch {
-    return null; // no/invalid file → delivery off
+async function loadConfig(): Promise<AlertConfig | null> {
+  const parsed = (await loadRawAlertConfig()) as Record<string, unknown>;
+  if (!parsed || Object.keys(parsed).length === 0 || parsed.enabled === false) {
+    return null; // no config / disabled → delivery off
   }
-  if (!parsed || parsed.enabled === false) return null;
 
   const rulesRaw = (parsed.rules ?? {}) as Record<string, unknown>;
   const rules: AlertRules = {
     memoryPercent: num(rulesRaw.memoryPercent),
     queryMemoryGb: num(rulesRaw.queryMemoryGb),
     longQueryMin: num(rulesRaw.longQueryMin),
+    partsEtaMin: num(rulesRaw.partsEtaMin),
   };
 
   const slackRaw = parsed.slack as { webhookUrl?: unknown; enabled?: unknown } | undefined;
@@ -164,6 +162,13 @@ function fmtDuration(seconds: number): string {
   return `${(seconds / 3600).toFixed(1)}h`;
 }
 
+function fmtMinutes(minutes: number): string {
+  if (!Number.isFinite(minutes) || minutes < 0) return "—";
+  if (minutes < 1) return "<1m";
+  if (minutes < 60) return `${Math.round(minutes)}m`;
+  return `${(minutes / 60).toFixed(1)}h`;
+}
+
 function querySnippet(q: Record<string, unknown>): string | undefined {
   const user = q.user ? String(q.user) : "";
   const sql = String(q.query_preview ?? "")
@@ -176,8 +181,8 @@ function querySnippet(q: Record<string, unknown>): string | undefined {
   return user || sql || undefined;
 }
 
-/** Pure rule evaluation for one node — mirrors the client's evaluateNode. */
-function evaluateNode(metrics: Record<string, Record<string, unknown>[]>, rules: AlertRules): RuleEval[] {
+/** Pure rule evaluation for one node — mirrors the client's evaluateNode. Exported for tests. */
+export function evaluateNode(metrics: Record<string, Record<string, unknown>[]>, rules: AlertRules): RuleEval[] {
   const out: RuleEval[] = [];
 
   if (rules.memoryPercent > 0) {
@@ -226,6 +231,31 @@ function evaluateNode(metrics: Record<string, Record<string, unknown>[]>, rules:
         detail: querySnippet(q),
         breaching: over,
         clearing: !over,
+      });
+    }
+  }
+
+  if (rules.partsEtaMin > 0) {
+    // Predictive "too many parts": each table in the parts_pressure snapshot
+    // carries a projected eta_minutes until its worst partition crosses
+    // parts_to_throw_insert (negative = converging / not at risk). Latch per
+    // table so independent tables fire and clear on their own.
+    for (const row of metrics.parts_pressure ?? []) {
+      const eta = num(row.eta_minutes);
+      const net = num(row.net_parts_per_min);
+      const db = String(row.database ?? "");
+      const table = String(row.table ?? "");
+      const maxParts = Math.round(num(row.max_parts_in_partition));
+      const threshold = Math.round(num(row.parts_threshold));
+      const diverging = net > 0 && eta >= 0;
+      out.push({
+        ruleKey: "partspressure",
+        instanceId: db && table ? `${db}.${table}` : table || db,
+        metric: "parts pressure",
+        summary: `~${fmtMinutes(eta)} to parts limit`,
+        detail: `${db}.${table} (${maxParts}/${threshold} parts, +${net.toFixed(1)}/min)`,
+        breaching: diverging && eta < rules.partsEtaMin,
+        clearing: !diverging || eta > rules.partsEtaMin * PARTS_ETA_CLEAR_RATIO,
       });
     }
   }
@@ -596,7 +626,7 @@ async function deliverRca(report: DoctorReport, triggers: string[], config: Aler
  * Used by the scheduler for scheduled scans. No-op if no channel is configured.
  */
 export async function deliverDoctorReport(report: DoctorReport, context: string): Promise<void> {
-  const config = loadConfig();
+  const config = await loadConfig();
   if (!config) return;
   await deliverRca(report, [context], config);
 }
@@ -639,9 +669,9 @@ async function runAutoRca(config: AlertConfig, triggers: string[]): Promise<void
  * (a "send test alert" action / one-off check). Throws if no config is loaded.
  */
 export async function sendTestAlert(): Promise<{ slack: boolean; googleChat: boolean; email: boolean }> {
-  const config = loadConfig();
+  const config = await loadConfig();
   if (!config) {
-    throw new Error(`No alert config at ${CONFIG_PATH} (missing, invalid, disabled, or no channel set)`);
+    throw new Error("No alert config (missing, disabled, or no channel set)");
   }
   await deliver(
     {
@@ -666,7 +696,7 @@ export async function processTick(
   rows: SnapshotInput[],
 ): Promise<void> {
   try {
-    const config = loadConfig();
+    const config = await loadConfig();
     if (!config) return;
 
     const nameById = new Map(connections.map((c) => [c.id, c.name]));

--- a/packages/server/src/services/fleetMetrics.ts
+++ b/packages/server/src/services/fleetMetrics.ts
@@ -26,7 +26,25 @@ export const FLEET_METRICS = {
    */
   summary: `
     SELECT
-      (SELECT value FROM system.asynchronous_metrics WHERE metric = 'OSMemoryTotal' LIMIT 1) AS server_memory_total_bytes,
+      -- Memory ceiling with a fallback chain so cgroup-limited / containerised
+      -- nodes (which don't expose OSMemoryTotal) still get a real denominator
+      -- instead of degrading to 0 (a phantom "X / 0 Bytes → 0%"):
+      --   1. OSMemoryTotal       — host RAM (bare-metal / VM).
+      --   2. CGroupMemoryTotal   — the cgroup limit, BUT skip the ~2^63
+      --      "no limit set" sentinel: value < 2^50 (1 PiB) rejects it while
+      --      still admitting any realistic limit.
+      --   3. max_server_memory_usage — the CH process ceiling (same sentinel
+      --      guard; 0 = "auto", which isn't a usable number, so > 0 too).
+      -- 0 only if none is available; the frontend renders that as "X / —".
+      coalesce(
+        (SELECT value FROM system.asynchronous_metrics WHERE metric = 'OSMemoryTotal' LIMIT 1),
+        (SELECT value FROM system.asynchronous_metrics
+           WHERE metric = 'CGroupMemoryTotal' AND value > 0 AND value < pow(2, 50) LIMIT 1),
+        (SELECT toFloat64(toUInt64OrZero(value)) FROM system.server_settings
+           WHERE name = 'max_server_memory_usage'
+             AND toUInt64OrZero(value) > 0 AND toUInt64OrZero(value) < pow(2, 50) LIMIT 1),
+        0
+      ) AS server_memory_total_bytes,
       (SELECT value FROM system.asynchronous_metrics WHERE metric = 'MemoryResident' LIMIT 1) AS server_memory_used_bytes,
       -- System-wide CPU usage %. Built from the *Normalized async metrics
       -- (already divided by core count) so it's 0..100 regardless of node
@@ -125,6 +143,97 @@ export const FLEET_METRICS = {
       AND exception != ''
     ORDER BY event_time DESC
     LIMIT 10
+  `,
+
+  /**
+   * Per-table parts pressure — the data behind the "too many parts" failure
+   * mode. For each table we report the live part count, the worst single
+   * partition's part count (the value ClickHouse actually compares against
+   * parts_to_throw_insert), and the insert-vs-merge race over the last 10
+   * minutes. net_parts_per_min > 0 means parts are accumulating faster than
+   * merges clear them; eta_minutes then projects when the worst partition
+   * crosses the threshold (-1 = converging / not approaching the wall).
+   *
+   * Rates are approximate by design: insert rate = NewPart events/min, merge
+   * rate = MergeParts events/min from system.part_log. The threshold is the
+   * table's effective parts_to_throw_insert: a per-table SETTINGS override
+   * (parsed from create_table_query) when present, otherwise the server-global
+   * default from system.merge_tree_settings, falling back to 300 when neither
+   * is available. LIMIT 20 (worst partitions first) keeps the payload small.
+   */
+  parts_pressure: `
+    WITH
+      (SELECT toFloat64OrZero(value) FROM system.merge_tree_settings WHERE name = 'parts_to_throw_insert') AS global_threshold_raw,
+      if(global_threshold_raw > 0, global_threshold_raw, 300) AS global_threshold,
+      parts_agg AS (
+        SELECT
+          database,
+          table,
+          sum(part_count) AS active_parts,
+          max(part_count) AS max_parts_in_partition,
+          sum(part_rows) AS rows,
+          sum(part_bytes) AS bytes
+        FROM (
+          SELECT
+            database,
+            table,
+            partition_id,
+            count() AS part_count,
+            sum(rows) AS part_rows,
+            sum(bytes_on_disk) AS part_bytes
+          FROM system.parts
+          WHERE active
+            AND database NOT IN ('system', 'information_schema', 'INFORMATION_SCHEMA')
+          GROUP BY database, table, partition_id
+        )
+        GROUP BY database, table
+      ),
+      merges_agg AS (
+        SELECT database, table, count() AS merges_running
+        FROM system.merges
+        GROUP BY database, table
+      ),
+      log_agg AS (
+        SELECT
+          database,
+          table,
+          countIf(event_type = 'NewPart') / 10.0 AS insert_parts_per_min,
+          countIf(event_type = 'MergeParts') / 10.0 AS merge_parts_per_min
+        FROM system.part_log
+        WHERE event_time >= now() - INTERVAL 10 MINUTE
+        GROUP BY database, table
+      ),
+      settings_agg AS (
+        SELECT
+          database,
+          name AS table,
+          toFloat64OrZero(extract(create_table_query, 'parts_to_throw_insert\\\\s*=\\\\s*(\\\\d+)')) AS table_threshold
+        FROM system.tables
+        WHERE database NOT IN ('system', 'information_schema', 'INFORMATION_SCHEMA')
+      )
+    SELECT
+      p.database AS database,
+      p.table AS table,
+      p.active_parts AS active_parts,
+      p.max_parts_in_partition AS max_parts_in_partition,
+      p.rows AS rows,
+      p.bytes AS bytes,
+      coalesce(m.merges_running, 0) AS merges_running,
+      coalesce(l.insert_parts_per_min, 0) AS insert_parts_per_min,
+      coalesce(l.merge_parts_per_min, 0) AS merge_parts_per_min,
+      if(s.table_threshold > 0, s.table_threshold, global_threshold) AS parts_threshold,
+      (coalesce(l.insert_parts_per_min, 0) - coalesce(l.merge_parts_per_min, 0)) AS net_parts_per_min,
+      if(
+        net_parts_per_min > 0,
+        (parts_threshold - p.max_parts_in_partition) / net_parts_per_min,
+        -1
+      ) AS eta_minutes
+    FROM parts_agg p
+    LEFT JOIN merges_agg m ON p.database = m.database AND p.table = m.table
+    LEFT JOIN log_agg l ON p.database = l.database AND p.table = l.table
+    LEFT JOIN settings_agg s ON p.database = s.database AND p.table = s.table
+    ORDER BY max_parts_in_partition DESC
+    LIMIT 20
   `,
 } as const;
 

--- a/packages/server/src/types/index.ts
+++ b/packages/server/src/types/index.ts
@@ -181,6 +181,48 @@ export interface MergeMetrics {
   pending_mutations: number;
 }
 
+/**
+ * Per-table parts-pressure row — the insert-vs-merge race behind the "too many
+ * parts" failure mode. `max_parts_in_partition` is the value ClickHouse compares
+ * against `parts_threshold` (parts_to_throw_insert). `eta_minutes` projects when
+ * the worst partition crosses the threshold; -1 means converging (not at risk).
+ */
+export interface PartsPressureRow {
+  database: string;
+  table: string;
+  active_parts: number;
+  max_parts_in_partition: number;
+  rows: number;
+  bytes: number;
+  merges_running: number;
+  insert_parts_per_min: number;
+  merge_parts_per_min: number;
+  parts_threshold: number;
+  net_parts_per_min: number;
+  eta_minutes: number;
+}
+
+/**
+ * Read-only estimate of what an ALTER … UPDATE/DELETE mutation would cost,
+ * computed without running it. `affected_rows` is the rows matching the
+ * predicate; `parts_to_rewrite`/`bytes_to_rewrite` is the (worst-case) set of
+ * active parts a mutation rewrites. `est_duration_seconds` is projected from
+ * historical mutation/merge throughput (-1 = unknown, no history).
+ */
+export interface DdlImpactEstimate {
+  database: string;
+  table: string;
+  kind: "update" | "delete";
+  where: string;
+  affected_rows: number;
+  total_rows: number;
+  parts_to_rewrite: number;
+  bytes_to_rewrite: number;
+  est_duration_seconds: number;
+  disk_free_bytes: number;
+  disk_sufficient: boolean;
+}
+
 export interface ReplicationMetrics {
   database: string;
   table: string;

--- a/scripts/demo-parts-pressure.sh
+++ b/scripts/demo-parts-pressure.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+#
+# demo-parts-pressure.sh — generate a realistic "too many parts" scenario for the
+# Metrics → Parts Pressure tab (and the 1B predictive alert) against a local
+# ClickHouse dev container.
+#
+# Each INSERT becomes its own part; background merges are stopped on the demo
+# table so parts accumulate faster than they're cleared (divergence). A steady
+# insert loop keeps the insert-rate window populated so the panel stays "live".
+#
+# Usage:
+#   scripts/demo-parts-pressure.sh up        # create table + stop merges
+#   scripts/demo-parts-pressure.sh load [N]  # stream N parts/iteration forever (Ctrl-C to stop)
+#   scripts/demo-parts-pressure.sh burst [N]  # one-shot: create N parts now (default 240)
+#   scripts/demo-parts-pressure.sh status    # show current parts pressure for the demo table
+#   scripts/demo-parts-pressure.sh down       # drop the demo table (resumes merges implicitly)
+#
+# Env: CH_CONTAINER (default: clickhouse-server)
+
+set -euo pipefail
+
+CONTAINER="${CH_CONTAINER:-clickhouse-server}"
+DB="demo"
+TABLE="parts_pressure_demo"
+FQT="${DB}.${TABLE}"
+
+ch() { docker exec -i "$CONTAINER" clickhouse-client "$@"; }
+
+up() {
+  ch --multiquery -q "
+    CREATE DATABASE IF NOT EXISTS ${DB};
+    DROP TABLE IF EXISTS ${FQT};
+    CREATE TABLE ${FQT}
+    (
+        id UInt64,
+        ts DateTime DEFAULT now(),
+        payload String
+    )
+    ENGINE = MergeTree
+    PARTITION BY toYYYYMMDD(ts)
+    ORDER BY id
+    SETTINGS parts_to_throw_insert = 300, parts_to_delay_insert = 250;
+    SYSTEM STOP MERGES ${FQT};
+  "
+  echo "Created ${FQT} with merges stopped (parts will accumulate)."
+}
+
+burst() {
+  local n="${1:-240}"
+  echo "Creating ${n} parts (one INSERT each)..."
+  for i in $(seq 1 "$n"); do
+    echo "INSERT INTO ${FQT} (id, payload) VALUES (${i}, 'p${i}');"
+  done | ch --multiquery
+  status
+}
+
+load() {
+  local per="${1:-20}"
+  echo "Streaming ~${per} parts every 30s into ${FQT}. Ctrl-C to stop."
+  local id=0
+  while true; do
+    for _ in $(seq 1 "$per"); do
+      id=$((id + 1))
+      echo "INSERT INTO ${FQT} (id, payload) VALUES (${id}, 'p${id}');"
+    done | ch --multiquery
+    echo "  +${per} parts (total inserted: ${id})"
+    sleep 30
+  done
+}
+
+status() {
+  ch -q "
+    SELECT
+      sum(part_count)            AS active_parts,
+      max(part_count)            AS max_parts_in_partition,
+      (SELECT countIf(event_type='NewPart')/10.0 FROM system.part_log
+        WHERE database='${DB}' AND table='${TABLE}' AND event_time >= now() - INTERVAL 10 MINUTE) AS insert_parts_per_min,
+      (SELECT countIf(event_type='MergeParts')/10.0 FROM system.part_log
+        WHERE database='${DB}' AND table='${TABLE}' AND event_time >= now() - INTERVAL 10 MINUTE) AS merge_parts_per_min
+    FROM (SELECT partition_id, count() AS part_count FROM system.parts
+          WHERE active AND database='${DB}' AND table='${TABLE}' GROUP BY partition_id)
+    FORMAT Vertical"
+}
+
+down() {
+  ch -q "DROP TABLE IF EXISTS ${FQT}"
+  echo "Dropped ${FQT}."
+}
+
+cmd="${1:-}"
+shift || true
+case "$cmd" in
+  up) up ;;
+  burst) burst "$@" ;;
+  load) load "$@" ;;
+  status) status ;;
+  down) down ;;
+  *) echo "Usage: $0 {up|load [N]|burst [N]|status|down}"; exit 1 ;;
+esac

--- a/src/api/fleet.ts
+++ b/src/api/fleet.ts
@@ -78,6 +78,21 @@ export interface FleetSchemaTotalsRow {
   bytes: number;
 }
 
+export interface FleetPartsPressureRow {
+  database: string;
+  table: string;
+  active_parts: number;
+  max_parts_in_partition: number;
+  rows: number;
+  bytes: number;
+  merges_running: number;
+  insert_parts_per_min: number;
+  merge_parts_per_min: number;
+  parts_threshold: number;
+  net_parts_per_min: number;
+  eta_minutes: number;
+}
+
 // ============================================
 // M2 — Snapshot cache endpoints
 // ============================================
@@ -96,6 +111,7 @@ export interface FleetConnectionSnapshot {
     top_memory_query?: { data: FleetLongestQueryRow[]; error: string | null };
     last_exception?: { data: FleetLastExceptionRow[]; error: string | null };
     schema_totals?: { data: FleetSchemaTotalsRow[]; error: string | null };
+    parts_pressure?: { data: FleetPartsPressureRow[]; error: string | null };
   };
 }
 
@@ -180,7 +196,7 @@ export interface FleetAlertConfig {
   aiRcaOnBreach: boolean;
   /** AI config id used for the auto-RCA scan (null = default model). */
   aiRcaModelId: string | null;
-  rules: { memoryPercent: number; queryMemoryGb: number; longQueryMin: number };
+  rules: { memoryPercent: number; queryMemoryGb: number; longQueryMin: number; partsEtaMin: number };
   slack: { configured: boolean; enabled: boolean };
   googleChat: { configured: boolean; enabled: boolean };
   email: { configured: boolean; enabled: boolean; user: string; to: string };
@@ -190,7 +206,7 @@ export interface FleetAlertConfigUpdate {
   enabled: boolean;
   aiRcaOnBreach?: boolean;
   aiRcaModelId?: string;
-  rules: { memoryPercent: number; queryMemoryGb: number; longQueryMin: number };
+  rules: { memoryPercent: number; queryMemoryGb: number; longQueryMin: number; partsEtaMin: number };
   /** Blank/omitted = keep the existing webhook; use `removeSlack` to clear. */
   slackWebhookUrl?: string;
   /** Per-channel on/off — independent of whether it's configured. */

--- a/src/api/metrics.test.ts
+++ b/src/api/metrics.test.ts
@@ -8,6 +8,8 @@ import {
     getRecentQueries,
     getDiskMetrics,
     getTopTables,
+    getPartsPressure,
+    simulateDdl,
 } from './metrics';
 
 describe('Metrics API', () => {
@@ -72,6 +74,46 @@ describe('Metrics API', () => {
         it('should respect limit parameter', async () => {
             const tables = await getTopTables(3);
             expect(tables.length).toBeLessThanOrEqual(3);
+        });
+    });
+
+    describe('getPartsPressure', () => {
+        it('should fetch per-table parts pressure rows', async () => {
+            const rows = await getPartsPressure(10);
+
+            expect(Array.isArray(rows)).toBe(true);
+            expect(rows.length).toBeGreaterThan(0);
+            const first = rows[0];
+            expect(first).toHaveProperty('database');
+            expect(first).toHaveProperty('table');
+            expect(first).toHaveProperty('max_parts_in_partition');
+            expect(first).toHaveProperty('parts_threshold');
+            expect(first).toHaveProperty('net_parts_per_min');
+            expect(first).toHaveProperty('eta_minutes');
+        });
+
+        it('should preserve a negative eta for converging tables', async () => {
+            const rows = await getPartsPressure();
+            const converging = rows.find((r) => r.table === 'calm');
+
+            expect(converging).toBeDefined();
+            expect(converging?.eta_minutes).toBe(-1);
+            expect(converging?.net_parts_per_min).toBeLessThan(0);
+        });
+    });
+
+    describe('simulateDdl', () => {
+        it('returns an impact estimate for a valid ALTER mutation', async () => {
+            const est = await simulateDdl("ALTER TABLE demo.events UPDATE col = 1 WHERE id < 5");
+
+            expect(est.kind).toBe('update');
+            expect(est.affected_rows).toBe(159);
+            expect(est.parts_to_rewrite).toBe(300);
+            expect(est.disk_sufficient).toBe(true);
+        });
+
+        it('rejects a non-ALTER statement', async () => {
+            await expect(simulateDdl('SELECT 1')).rejects.toThrow();
         });
     });
 });

--- a/src/api/metrics.ts
+++ b/src/api/metrics.ts
@@ -127,6 +127,35 @@ export interface TopTableBySize {
   parts_count: number;
 }
 
+export interface PartsPressureRow {
+  database: string;
+  table: string;
+  active_parts: number;
+  max_parts_in_partition: number;
+  rows: number;
+  bytes: number;
+  merges_running: number;
+  insert_parts_per_min: number;
+  merge_parts_per_min: number;
+  parts_threshold: number;
+  net_parts_per_min: number;
+  eta_minutes: number;
+}
+
+export interface DdlImpactEstimate {
+  database: string;
+  table: string;
+  kind: 'update' | 'delete';
+  where: string;
+  affected_rows: number;
+  total_rows: number;
+  parts_to_rewrite: number;
+  bytes_to_rewrite: number;
+  est_duration_seconds: number;
+  disk_free_bytes: number;
+  disk_sufficient: boolean;
+}
+
 export interface NetworkMetrics {
   tcp_connections: number;
   http_connections: number;
@@ -360,6 +389,24 @@ export async function getTopTables(limit: number = 10): Promise<TopTableBySize[]
   return api.get<TopTableBySize[]>('/metrics/top-tables', {
     params: { limit },
   });
+}
+
+/**
+ * Get per-table parts pressure (insert-vs-merge race + projected "too many parts" eta)
+ * @param interval - Rate window in minutes (default: 10)
+ */
+export async function getPartsPressure(interval: number = 10): Promise<PartsPressureRow[]> {
+  return api.get<PartsPressureRow[]>('/metrics/parts-pressure', {
+    params: { interval },
+  });
+}
+
+/**
+ * Read-only impact estimate for an ALTER … UPDATE/DELETE mutation. The server
+ * parses and estimates only — it never executes the statement.
+ */
+export async function simulateDdl(statement: string): Promise<DdlImpactEstimate> {
+  return api.post<DdlImpactEstimate>('/metrics/ddl/simulate', { statement });
 }
 
 /**

--- a/src/components/monitoring/DdlSimulator.tsx
+++ b/src/components/monitoring/DdlSimulator.tsx
@@ -1,0 +1,164 @@
+import { useState } from "react";
+import { useMutation } from "@tanstack/react-query";
+import { AlertTriangle, CheckCircle2, Play } from "lucide-react";
+
+import { simulateDdl, type DdlImpactEstimate } from "@/api/metrics";
+import { cn, formatBytes, formatNumber } from "@/lib/utils";
+
+const PLACEHOLDER = "ALTER TABLE db.table UPDATE col = 0 WHERE ts < '2024-01-01'";
+
+function formatDuration(seconds: number): string {
+  if (!Number.isFinite(seconds) || seconds < 0) return "unknown";
+  if (seconds < 1) return "<1s";
+  if (seconds < 60) return `${Math.round(seconds)}s`;
+  if (seconds < 3600) return `${Math.floor(seconds / 60)}m ${Math.round(seconds % 60)}s`;
+  return `${(seconds / 3600).toFixed(1)}h`;
+}
+
+/**
+ * DDL impact simulator — a read-only "what would this ALTER cost" estimator.
+ * The server parses and estimates only (rows matched, parts/bytes rewritten,
+ * duration, disk headroom); it NEVER runs the mutation. Existing CH UIs show
+ * what's running — this shows the cost *before* you commit.
+ */
+export function DdlSimulator() {
+  const [statement, setStatement] = useState("");
+
+  const sim = useMutation<DdlImpactEstimate, Error, string>({
+    mutationFn: (sql) => simulateDdl(sql),
+  });
+
+  const run = () => {
+    const sql = statement.trim();
+    if (sql) sim.mutate(sql);
+  };
+
+  const result = sim.data;
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="rounded-md border border-ink-500 bg-ink-100 p-4">
+        <div className="mb-2 flex items-center justify-between">
+          <span className="font-mono text-[10px] uppercase tracking-[0.14em] text-paper-faint">
+            ALTER … UPDATE / DELETE — estimate only, never executed
+          </span>
+        </div>
+        <textarea
+          value={statement}
+          onChange={(e) => setStatement(e.target.value)}
+          onKeyDown={(e) => {
+            if ((e.metaKey || e.ctrlKey) && e.key === "Enter") run();
+          }}
+          placeholder={PLACEHOLDER}
+          spellCheck={false}
+          rows={3}
+          className="w-full resize-y rounded-xs border border-ink-500 bg-ink-200 px-3 py-2 font-mono text-[12px] text-paper placeholder:text-paper-faint focus-visible:border-brand focus-visible:outline-none"
+        />
+        <div className="mt-3 flex items-center gap-3">
+          <button
+            type="button"
+            onClick={run}
+            disabled={!statement.trim() || sim.isPending}
+            className={cn(
+              "inline-flex items-center gap-2 rounded-xs border border-ink-500 bg-ink-200 px-3 py-1.5 font-mono text-[11px] uppercase tracking-[0.14em] text-paper transition-colors",
+              "hover:bg-ink-300 disabled:cursor-not-allowed disabled:opacity-50",
+            )}
+          >
+            <Play className="h-3.5 w-3.5" aria-hidden />
+            {sim.isPending ? "Estimating…" : "Simulate"}
+          </button>
+          <span className="font-mono text-[10px] tracking-[0.14em] text-paper-faint">⌘/Ctrl+Enter</span>
+        </div>
+      </div>
+
+      {sim.isError && (
+        <div className="flex items-start gap-2 rounded-md border border-red-500/40 bg-red-500/5 px-4 py-3">
+          <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-red-400" aria-hidden />
+          <p className="text-[12px] text-red-300">{sim.error.message}</p>
+        </div>
+      )}
+
+      {result && <EstimateCard result={result} />}
+    </div>
+  );
+}
+
+function EstimateCard({ result }: { result: DdlImpactEstimate }) {
+  const affectedPct =
+    result.total_rows > 0 ? (result.affected_rows / result.total_rows) * 100 : 0;
+
+  return (
+    <div className="rounded-md border border-ink-500 bg-ink-100">
+      <div className="flex items-center justify-between border-b border-ink-500 px-4 py-2.5">
+        <span className="font-mono text-[11px] text-paper">
+          <span className="uppercase tracking-[0.14em] text-brand">{result.kind}</span>
+          {" · "}
+          {result.database}.{result.table}
+        </span>
+        {result.disk_sufficient ? (
+          <span className="inline-flex items-center gap-1.5 font-mono text-[10px] uppercase tracking-[0.14em] text-emerald-400">
+            <CheckCircle2 className="h-3.5 w-3.5" aria-hidden />
+            disk ok
+          </span>
+        ) : (
+          <span className="inline-flex items-center gap-1.5 font-mono text-[10px] uppercase tracking-[0.14em] text-red-400">
+            <AlertTriangle className="h-3.5 w-3.5" aria-hidden />
+            insufficient disk
+          </span>
+        )}
+      </div>
+
+      <div className="grid grid-cols-2 gap-px bg-ink-500/40 md:grid-cols-4">
+        <Stat
+          label="Rows affected"
+          value={formatNumber(result.affected_rows)}
+          sub={`${affectedPct.toFixed(1)}% of ${formatNumber(result.total_rows)}`}
+        />
+        <Stat
+          label="Parts rewritten"
+          value={formatNumber(result.parts_to_rewrite)}
+          sub={formatBytes(result.bytes_to_rewrite)}
+        />
+        <Stat
+          label="Est. duration"
+          value={formatDuration(result.est_duration_seconds)}
+          sub={result.est_duration_seconds < 0 ? "no mutation history" : "at recent throughput"}
+        />
+        <Stat
+          label="Disk free"
+          value={formatBytes(result.disk_free_bytes)}
+          sub={result.disk_sufficient ? "headroom ok" : "below rewrite size"}
+          danger={!result.disk_sufficient}
+        />
+      </div>
+
+      <p className="border-t border-ink-500 px-4 py-2.5 text-[11px] leading-[1.6] text-paper-muted">
+        A mutation rewrites whole parts in the background. The estimate assumes all active
+        parts are rewritten (worst case); partition-pruned predicates touch fewer. Nothing
+        was executed.
+      </p>
+    </div>
+  );
+}
+
+function Stat({
+  label,
+  value,
+  sub,
+  danger,
+}: {
+  label: string;
+  value: string;
+  sub: string;
+  danger?: boolean;
+}) {
+  return (
+    <div className="bg-ink-100 px-4 py-3">
+      <div className="font-mono text-[9px] uppercase tracking-[0.18em] text-paper-faint">{label}</div>
+      <div className={cn("mt-1 font-mono text-[16px] font-semibold tabular-nums", danger ? "text-red-400" : "text-paper")}>
+        {value}
+      </div>
+      <div className="mt-0.5 text-[11px] text-paper-muted">{sub}</div>
+    </div>
+  );
+}

--- a/src/components/monitoring/PartsPressurePanel.tsx
+++ b/src/components/monitoring/PartsPressurePanel.tsx
@@ -1,0 +1,295 @@
+import type { ElementType } from "react";
+import { FileStack, Database, TrendingUp, AlertTriangle, Gauge, Timer, Activity } from "lucide-react";
+
+import type { PartsPressureRow } from "@/api/metrics";
+import { cn, formatCompactNumber } from "@/lib/utils";
+
+interface SummaryProps {
+  data: PartsPressureRow[];
+  /** Rate lookback in minutes — chosen via the header range control (short by design). */
+  windowMinutes: number;
+  isLoading?: boolean;
+}
+
+interface TableProps {
+  data: PartsPressureRow[];
+  isLoading?: boolean;
+  error?: Error | null;
+}
+
+/** "≈3h", "12m", "<1m", or "—" when not approaching the threshold. */
+function formatEta(minutes: number): string {
+  if (!Number.isFinite(minutes) || minutes < 0) return "—";
+  if (minutes < 1) return "<1m";
+  if (minutes < 60) return `${Math.round(minutes)}m`;
+  if (minutes < 1440) return `${(minutes / 60).toFixed(1)}h`;
+  return `${(minutes / 1440).toFixed(1)}d`;
+}
+
+function formatRate(perMin: number): string {
+  if (!Number.isFinite(perMin) || perMin === 0) return "0";
+  if (Math.abs(perMin) < 1) return perMin.toFixed(2);
+  return formatCompactNumber(Math.round(perMin * 100) / 100);
+}
+
+/** Tables crossing this fraction of parts_to_throw_insert are flagged amber. */
+const PARTS_WARN_RATIO = 0.7;
+/** A projected eta below this (minutes) is treated as imminent (red). */
+const ETA_DANGER_MIN = 180;
+
+function rowRisk(row: PartsPressureRow): "danger" | "warn" | "ok" {
+  const ratio = row.parts_threshold > 0 ? row.max_parts_in_partition / row.parts_threshold : 0;
+  const diverging = row.net_parts_per_min > 0;
+  if (ratio >= 1 || (diverging && row.eta_minutes >= 0 && row.eta_minutes < ETA_DANGER_MIN)) {
+    return "danger";
+  }
+  if (ratio >= PARTS_WARN_RATIO || diverging) return "warn";
+  return "ok";
+}
+
+/**
+ * Parts pressure summary — section header + KPI cards. Rendered as its own
+ * standalone card in the Parts Pressure tab (the per-table detail lives in a
+ * separate card below, matching the other Metrics sub-tabs' layout).
+ */
+export function PartsPressureSummary({ data, windowMinutes, isLoading }: SummaryProps) {
+  const diverging = data.filter((r) => r.net_parts_per_min > 0).length;
+  const atRisk = data.filter((r) => rowRisk(r) === "danger").length;
+
+  const worst = data.reduce<{ ratio: number; table: string } | null>((acc, r) => {
+    const ratio = r.parts_threshold > 0 ? r.max_parts_in_partition / r.parts_threshold : 0;
+    return !acc || ratio > acc.ratio ? { ratio, table: `${r.database}.${r.table}` } : acc;
+  }, null);
+  const soonest = data
+    .filter((r) => r.net_parts_per_min > 0 && r.eta_minutes >= 0)
+    .reduce<{ eta: number; table: string } | null>(
+      (acc, r) => (!acc || r.eta_minutes < acc.eta ? { eta: r.eta_minutes, table: `${r.database}.${r.table}` } : acc),
+      null,
+    );
+  const netTotal = data.reduce((s, r) => s + r.net_parts_per_min, 0);
+
+  return (
+    <div className="flex flex-col gap-5 p-6">
+      <div className="flex items-center gap-3">
+        <span className="grid h-9 w-9 place-items-center rounded-xs border border-ink-500 bg-ink-200 text-paper-muted">
+          <FileStack className="h-4 w-4" aria-hidden />
+        </span>
+        <div className="flex flex-col gap-0.5">
+          <h3 className="text-[14px] font-semibold tracking-tight text-paper">Parts pressure</h3>
+          <p className="font-mono text-[10px] uppercase tracking-[0.14em] text-paper-faint">
+            Insert vs merge race · rate over last {windowMinutes}m
+          </p>
+        </div>
+      </div>
+
+      {isLoading && data.length === 0 ? (
+        <div className="grid grid-cols-2 gap-px md:grid-cols-3 lg:grid-cols-6">
+          {[...Array(6)].map((_, i) => (
+            <div key={i} className="h-20 animate-pulse rounded-xs bg-ink-300" />
+          ))}
+        </div>
+      ) : data.length === 0 ? (
+        <p className="text-[12px] text-paper-muted">No MergeTree parts to summarize.</p>
+      ) : (
+        <div className="grid grid-cols-2 border-l border-t border-ink-500 md:grid-cols-3 lg:grid-cols-6">
+          <StatCard label="Tables" icon={Database} value={String(data.length)} sub="tracked" tone="ok" />
+          <StatCard
+            label="Diverging"
+            icon={TrendingUp}
+            value={String(diverging)}
+            sub="net parts rising"
+            tone={diverging > 0 ? "warn" : "ok"}
+          />
+          <StatCard
+            label="At risk"
+            icon={AlertTriangle}
+            value={String(atRisk)}
+            sub="ETA under 3h"
+            tone={atRisk > 0 ? "danger" : "ok"}
+          />
+          <StatCard
+            label="Worst fill"
+            icon={Gauge}
+            value={worst ? `${Math.round(worst.ratio * 100)}%` : "—"}
+            sub={worst ? worst.table : "no tables"}
+            tone={worst && worst.ratio >= 1 ? "danger" : worst && worst.ratio >= PARTS_WARN_RATIO ? "warn" : "ok"}
+          />
+          <StatCard
+            label="Soonest ETA"
+            icon={Timer}
+            value={soonest ? formatEta(soonest.eta) : "—"}
+            sub={soonest ? soonest.table : "all converging"}
+            tone={soonest && soonest.eta < ETA_DANGER_MIN ? "danger" : soonest ? "warn" : "ok"}
+          />
+          <StatCard
+            label="Net parts/min"
+            icon={Activity}
+            value={`${netTotal > 0 ? "+" : ""}${formatRate(netTotal)}`}
+            sub={netTotal > 0 ? "accumulating" : netTotal < 0 ? "merges winning" : "steady"}
+            tone={netTotal > 0 ? "warn" : "ok"}
+          />
+        </div>
+      )}
+    </div>
+  );
+}
+
+/**
+ * Per-table parts pressure detail — its own standalone card. Worst partitions
+ * sort to the top; rows turn amber approaching parts_to_throw_insert and red
+ * when a positive net part rate projects an imminent breach.
+ */
+export function PartsPressureTable({ data, isLoading, error }: TableProps) {
+  return (
+    <div className="flex flex-col gap-3 p-4">
+      <div className="flex items-end justify-between gap-3 px-1">
+        <span className="font-mono text-[10px] uppercase tracking-[0.18em] text-paper-faint">
+          Per-table detail
+        </span>
+        <span className="font-mono text-[10px] uppercase tracking-[0.14em] text-paper-faint">
+          {data.length} tables
+        </span>
+      </div>
+
+      {isLoading && data.length === 0 ? (
+        <div className="space-y-1">
+          {[...Array(4)].map((_, i) => (
+            <div key={i} className="h-9 w-full animate-pulse rounded-xs bg-ink-300" />
+          ))}
+        </div>
+      ) : error ? (
+        <p className="text-[12px] text-paper-muted">Couldn't load parts pressure — {error.message}</p>
+      ) : data.length === 0 ? (
+        <p className="text-[12px] text-paper-muted">
+          No MergeTree parts found, or part activity is unavailable on this server.
+        </p>
+      ) : (
+        <div className="overflow-x-auto">
+          <table className="w-full text-[12px]">
+            <thead>
+              <tr className="border-b border-ink-500">
+                <th className="pb-2 pr-3 text-left font-mono text-[10px] uppercase tracking-[0.14em] text-paper-faint">
+                  Table
+                </th>
+                <th className="pb-2 pr-3 text-left font-mono text-[10px] uppercase tracking-[0.14em] text-brand">
+                  Worst partition
+                </th>
+                <th className="pb-2 pr-3 text-right font-mono text-[10px] uppercase tracking-[0.14em] text-paper-faint">
+                  Active parts
+                </th>
+                <th className="pb-2 pr-3 text-right font-mono text-[10px] uppercase tracking-[0.14em] text-paper-faint">
+                  Insert/min
+                </th>
+                <th className="pb-2 pr-3 text-right font-mono text-[10px] uppercase tracking-[0.14em] text-paper-faint">
+                  Merge/min
+                </th>
+                <th className="pb-2 pr-3 text-right font-mono text-[10px] uppercase tracking-[0.14em] text-paper-faint">
+                  Net/min
+                </th>
+                <th className="pb-2 text-right font-mono text-[10px] uppercase tracking-[0.14em] text-paper-faint">
+                  ETA to limit
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {data.map((row) => (
+                <PartsRow key={`${row.database}.${row.table}`} row={row} />
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}
+
+/**
+ * KPI tile mirroring the Metrics-tab StatCard (label + icon row, big value,
+ * subtitle) with a tone color for at-risk/diverging signals. The border-b/r
+ * pairs with the grid's border-l/t to draw clean editorial gridlines.
+ */
+function StatCard({
+  label,
+  icon: Icon,
+  value,
+  sub,
+  tone,
+}: {
+  label: string;
+  icon: ElementType;
+  value: string;
+  sub: string;
+  tone: "danger" | "warn" | "ok";
+}) {
+  const valueColor = tone === "danger" ? "text-red-400" : tone === "warn" ? "text-amber-500" : "text-paper";
+  return (
+    <div className="flex flex-col gap-2 border-b border-r border-ink-500 px-5 py-4">
+      <div className="flex items-center justify-between">
+        <span className="font-mono text-[10px] uppercase tracking-[0.18em] text-paper-faint">{label}</span>
+        <Icon className="h-3.5 w-3.5 text-paper-dim" aria-hidden />
+      </div>
+      <span className={cn("font-mono text-[20px] font-semibold leading-none tabular-nums", valueColor)}>
+        {value}
+      </span>
+      <span className="truncate font-mono text-[10px] uppercase tracking-[0.14em] text-paper-faint" title={sub}>
+        {sub}
+      </span>
+    </div>
+  );
+}
+
+function PartsRow({ row }: { row: PartsPressureRow }) {
+  const risk = rowRisk(row);
+  const ratio =
+    row.parts_threshold > 0
+      ? Math.min(1, row.max_parts_in_partition / row.parts_threshold)
+      : 0;
+  const barColor =
+    risk === "danger" ? "bg-red-500" : risk === "warn" ? "bg-amber-500" : "bg-brand";
+  const netColor =
+    row.net_parts_per_min > 0
+      ? "text-red-400"
+      : row.net_parts_per_min < 0
+        ? "text-emerald-400"
+        : "text-paper-muted";
+
+  return (
+    <tr className="border-b border-ink-500/60 transition-colors hover:bg-ink-200/60">
+      <td className="py-1.5 pr-3 font-mono text-[11px] text-paper whitespace-nowrap">
+        <span className="text-paper-muted">{row.database}.</span>
+        {row.table}
+      </td>
+      <td className="py-1.5 pr-3 min-w-[160px]">
+        <div className="flex items-center gap-2">
+          <div className="h-1.5 flex-1 overflow-hidden rounded-full bg-ink-300">
+            <div className={cn("h-full rounded-full", barColor)} style={{ width: `${ratio * 100}%` }} />
+          </div>
+          <span className="font-mono text-[11px] text-paper-muted whitespace-nowrap">
+            {formatCompactNumber(row.max_parts_in_partition)}/{formatCompactNumber(row.parts_threshold)}
+          </span>
+        </div>
+      </td>
+      <td className="py-1.5 pr-3 text-right font-mono text-[11px] text-paper-muted">
+        {formatCompactNumber(row.active_parts)}
+      </td>
+      <td className="py-1.5 pr-3 text-right font-mono text-[11px] text-paper-muted">
+        {formatRate(row.insert_parts_per_min)}
+      </td>
+      <td className="py-1.5 pr-3 text-right font-mono text-[11px] text-paper-muted">
+        {formatRate(row.merge_parts_per_min)}
+      </td>
+      <td className={cn("py-1.5 pr-3 text-right font-mono text-[11px]", netColor)}>
+        {row.net_parts_per_min > 0 ? "+" : ""}
+        {formatRate(row.net_parts_per_min)}
+      </td>
+      <td
+        className={cn(
+          "py-1.5 text-right font-mono text-[11px]",
+          risk === "danger" ? "text-red-400 font-semibold" : "text-paper-muted",
+        )}
+      >
+        {formatEta(row.eta_minutes)}
+      </td>
+    </tr>
+  );
+}

--- a/src/features/fleet/components/FleetAlertDeliveryDialog.tsx
+++ b/src/features/fleet/components/FleetAlertDeliveryDialog.tsx
@@ -57,6 +57,7 @@ export default function FleetAlertDeliveryDialog({
   const [memoryPercent, setMemoryPercent] = useState(85);
   const [queryMemoryGb, setQueryMemoryGb] = useState(0);
   const [longQueryMin, setLongQueryMin] = useState(0);
+  const [partsEtaMin, setPartsEtaMin] = useState(0);
   const [slackUrl, setSlackUrl] = useState("");
   const [emailUser, setEmailUser] = useState("");
   const [emailTo, setEmailTo] = useState("");
@@ -77,6 +78,7 @@ export default function FleetAlertDeliveryDialog({
     setMemoryPercent(data.rules.memoryPercent);
     setQueryMemoryGb(data.rules.queryMemoryGb);
     setLongQueryMin(data.rules.longQueryMin);
+    setPartsEtaMin(data.rules.partsEtaMin);
     setSlackUrl("");
     setGoogleChatUrl("");
     setEmailUser(data.email.user);
@@ -95,7 +97,7 @@ export default function FleetAlertDeliveryDialog({
         enabled,
         aiRcaOnBreach,
         aiRcaModelId: resolvedRcaModelId,
-        rules: { memoryPercent, queryMemoryGb, longQueryMin },
+        rules: { memoryPercent, queryMemoryGb, longQueryMin, partsEtaMin },
         slackWebhookUrl: slackUrl.trim() || undefined,
         slackEnabled,
         googleChatWebhookUrl: googleChatUrl.trim() || undefined,
@@ -126,7 +128,7 @@ export default function FleetAlertDeliveryDialog({
     mutationFn: (which: "slack" | "googleChat" | "email") =>
       updateFleetAlertConfig({
         enabled,
-        rules: { memoryPercent, queryMemoryGb, longQueryMin },
+        rules: { memoryPercent, queryMemoryGb, longQueryMin, partsEtaMin },
         ...(which === "slack" ? { removeSlack: true } : {}),
         ...(which === "googleChat" ? { removeGoogleChat: true } : {}),
         ...(which === "email" ? { removeEmail: true } : {}),
@@ -202,6 +204,7 @@ export default function FleetAlertDeliveryDialog({
                 <NumField label="Node mem %" value={memoryPercent} min={0} max={100} onChange={setMemoryPercent} />
                 <NumField label="Query GB" value={queryMemoryGb} min={0} max={1024} onChange={setQueryMemoryGb} />
                 <NumField label="Query min" value={longQueryMin} min={0} max={1440} onChange={setLongQueryMin} />
+                <NumField label="Parts ETA min" value={partsEtaMin} min={0} max={1440} onChange={setPartsEtaMin} />
               </div>
             </div>
 

--- a/src/features/fleet/components/FleetAlertsBell.tsx
+++ b/src/features/fleet/components/FleetAlertsBell.tsx
@@ -129,6 +129,16 @@ export default function FleetAlertsBell({
             value={config.longQueryThresholdMinutes}
             onValue={(n) => setConfig({ longQueryThresholdMinutes: n })}
           />
+          <RuleRow
+            label="Parts limit ETA under"
+            unit="min"
+            min={1}
+            max={1440}
+            enabled={config.partsPressureEnabled}
+            onToggle={(v) => setConfig({ partsPressureEnabled: v })}
+            value={config.partsEtaThresholdMinutes}
+            onValue={(n) => setConfig({ partsEtaThresholdMinutes: n })}
+          />
         </div>
 
         {/* Delivery — dimmed along with the rules when the master switch is

--- a/src/features/fleet/components/FleetCard.tsx
+++ b/src/features/fleet/components/FleetCard.tsx
@@ -23,6 +23,7 @@ import {
   summaryFromSnapshot,
   longestQueryFromSnapshot,
   lastExceptionFromSnapshot,
+  partsPressureFromSnapshot,
   type FleetCardStatus,
 } from "@/hooks/useFleetMetrics";
 import type { FleetConnectionSnapshot } from "@/api/fleet";
@@ -139,6 +140,12 @@ export default function FleetCard({
   const snapshotLongest = useSnapshot ? longestQueryFromSnapshot(snapshot) : undefined;
   const snapshotException = useSnapshot ? lastExceptionFromSnapshot(snapshot) : undefined;
 
+  // Worst (soonest) projected "too many parts" ETA across this node's tables —
+  // parts pressure is snapshot-only on the fleet view. Diverging tables only.
+  const worstParts = partsPressureFromSnapshot(snapshot)
+    .filter((p) => p.netPartsPerMin > 0 && p.etaMinutes >= 0)
+    .sort((a, b) => a.etaMinutes - b.etaMinutes)[0];
+
   const effectiveSummary = snapshotSummary ?? summary.data;
   const effectiveLongest =
     snapshotLongest !== undefined ? snapshotLongest : longest.data;
@@ -207,13 +214,16 @@ export default function FleetCard({
     }
   };
 
+  // A node that doesn't report a memory ceiling (no OSMemoryTotal / cgroup
+  // limit / max_server_memory_usage) comes back with total = 0. Show the used
+  // figure over an honest "—" rather than a phantom "/ 0 Bytes → 0%".
+  const hasMemoryTotal = (effectiveSummary?.memoryTotalBytes ?? 0) > 0;
   const memoryUsedDisplay = effectiveSummary
-    ? `${formatBytes(effectiveSummary.memoryUsedBytes)} / ${formatBytes(effectiveSummary.memoryTotalBytes)}`
+    ? `${formatBytes(effectiveSummary.memoryUsedBytes)} / ${hasMemoryTotal ? formatBytes(effectiveSummary.memoryTotalBytes) : "—"}`
     : "—";
   const memoryPercentValue = effectiveSummary?.memoryPercent ?? 0;
-  const memoryPercentDisplay = effectiveSummary
-    ? `${memoryPercentValue.toFixed(0)}%`
-    : "—";
+  const memoryPercentDisplay =
+    effectiveSummary && hasMemoryTotal ? `${memoryPercentValue.toFixed(0)}%` : "—";
 
   return (
     <TooltipProvider delayDuration={250}>
@@ -356,6 +366,12 @@ export default function FleetCard({
           label="Max replica lag"
           value={effectiveSummary ? `${effectiveSummary.maxReplicaLagSeconds.toFixed(1)}s` : "—"}
           sub={effectiveSummary?.maxLagReplica || "no replicas"}
+          mono
+        />
+        <Tile
+          label="Parts limit ETA"
+          value={worstParts ? formatElapsed(worstParts.etaMinutes * 60) : "—"}
+          sub={worstParts ? `${worstParts.database}.${worstParts.table}` : "converging"}
           mono
         />
         {effectiveException ? (

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -38,6 +38,7 @@ export {
   useClusters,
   useClusterNames,
   useTopTables,
+  usePartsPressure,
 } from './useQuery';
 
 // Auth hooks

--- a/src/hooks/useFleetAlerts.ts
+++ b/src/hooks/useFleetAlerts.ts
@@ -24,6 +24,7 @@ import {
   summaryFromSnapshot,
   longestQueryFromSnapshot,
   topMemoryQueriesFromSnapshot,
+  partsPressureFromSnapshot,
   type FleetLongestQuery,
 } from "./useFleetMetrics";
 import type { FleetConnectionSnapshot } from "@/api";
@@ -43,6 +44,9 @@ export interface AlertConfig {
   longQueryEnabled: boolean;
   /** A single query running longer than this many minutes fires. */
   longQueryThresholdMinutes: number;
+  partsPressureEnabled: boolean;
+  /** A table projected to hit its parts limit within this many minutes fires. */
+  partsEtaThresholdMinutes: number;
 }
 
 const DEFAULT_CONFIG: AlertConfig = {
@@ -54,6 +58,8 @@ const DEFAULT_CONFIG: AlertConfig = {
   queryMemoryThresholdGb: 10,
   longQueryEnabled: false,
   longQueryThresholdMinutes: 5,
+  partsPressureEnabled: false,
+  partsEtaThresholdMinutes: 60,
 };
 
 const STORAGE_KEY = "chouse-fleet:alert-config";
@@ -115,6 +121,16 @@ function fmtDuration(seconds: number): string {
   if (seconds < 3600) return `${Math.floor(seconds / 60)}m`;
   return `${(seconds / 3600).toFixed(1)}h`;
 }
+
+function fmtMinutes(minutes: number): string {
+  if (!Number.isFinite(minutes) || minutes < 0) return "—";
+  if (minutes < 1) return "<1m";
+  if (minutes < 60) return `${Math.round(minutes)}m`;
+  return `${(minutes / 60).toFixed(1)}h`;
+}
+
+/** Mirror of the server alerter: re-arm once ETA climbs this far past the limit. */
+const PARTS_ETA_CLEAR_RATIO = 1.25;
 
 function queryDetail(q: FleetLongestQuery): string {
   // Strip the leading comment block Redash/BI tools prepend
@@ -201,6 +217,23 @@ function evaluateNode(
         user: q.user || undefined,
         breaching: over,
         clearing: !over,
+      });
+    }
+  }
+
+  if (config.partsPressureEnabled) {
+    // One latch per table. Each parts_pressure row carries a projected ETA to
+    // its parts_to_throw_insert limit (negative = converging / not at risk).
+    for (const p of partsPressureFromSnapshot(snap)) {
+      const diverging = p.netPartsPerMin > 0 && p.etaMinutes >= 0;
+      out.push({
+        ruleKey: "partspressure",
+        instanceId: p.database && p.table ? `${p.database}.${p.table}` : p.table || p.database,
+        metric: "parts pressure",
+        summary: `~${fmtMinutes(p.etaMinutes)} to parts limit`,
+        detail: `${p.database}.${p.table} (${Math.round(p.maxPartsInPartition)}/${Math.round(p.partsThreshold)} parts, +${p.netPartsPerMin.toFixed(1)}/min)`,
+        breaching: diverging && p.etaMinutes < config.partsEtaThresholdMinutes,
+        clearing: !diverging || p.etaMinutes > config.partsEtaThresholdMinutes * PARTS_ETA_CLEAR_RATIO,
       });
     }
   }

--- a/src/hooks/useFleetMetrics.ts
+++ b/src/hooks/useFleetMetrics.ts
@@ -369,6 +369,31 @@ export function topMemoryQueriesFromSnapshot(
   }));
 }
 
+export interface FleetPartsPressure {
+  database: string;
+  table: string;
+  maxPartsInPartition: number;
+  partsThreshold: number;
+  netPartsPerMin: number;
+  etaMinutes: number;
+}
+
+export function partsPressureFromSnapshot(
+  snapshot: FleetConnectionSnapshot | undefined,
+): FleetPartsPressure[] {
+  if (!snapshot?.metrics.parts_pressure) return [];
+  const { data, error } = snapshot.metrics.parts_pressure;
+  if (error || !data) return [];
+  return data.map((row) => ({
+    database: String(row.database ?? ""),
+    table: String(row.table ?? ""),
+    maxPartsInPartition: num(row.max_parts_in_partition),
+    partsThreshold: num(row.parts_threshold),
+    netPartsPerMin: num(row.net_parts_per_min),
+    etaMinutes: num(row.eta_minutes),
+  }));
+}
+
 export function lastExceptionFromSnapshot(
   snapshot: FleetConnectionSnapshot | undefined,
 ): FleetLastException | null | undefined {

--- a/src/hooks/useMonitoringTimeline.ts
+++ b/src/hooks/useMonitoringTimeline.ts
@@ -777,7 +777,11 @@ export interface MutationRow {
   command: string;
   create_time: string;
   parts_to_do: number;
+  /** Table's current active-part count — progress denominator (0 if unknown). */
+  total_parts: number;
   is_done: number;
+  /** 1 once the mutation has been KILLed. */
+  is_killed: number;
   latest_failed_part: string;
   latest_fail_reason: string;
   latest_fail_time: string;
@@ -801,21 +805,32 @@ export function useMutations(
       // DateTime columns used in WHERE / ORDER BY. ClickHouse 24.11 fails
       // with NO_COMMON_TYPE (String vs DateTime) when an alias collides
       // with the column it was derived from in the same SELECT.
+      // total_parts joins the table's current active-part count so the UI can
+      // render approximate progress (1 − parts_to_do / total_parts).
       const sql = `
+        WITH active_parts AS (
+          SELECT database, table, count() AS total_parts
+          FROM system.parts
+          WHERE active
+          GROUP BY database, table
+        )
         SELECT
-          database,
-          table,
-          mutation_id,
-          command,
-          formatDateTime(create_time, '%Y-%m-%d %H:%i:%S') AS create_time_str,
-          parts_to_do,
-          is_done,
-          latest_failed_part,
-          latest_fail_reason,
-          formatDateTime(latest_fail_time, '%Y-%m-%d %H:%i:%S') AS latest_fail_time_str
-        FROM system.mutations
-        WHERE is_done = 0 OR create_time >= now() - INTERVAL 7 DAY
-        ORDER BY is_done ASC, create_time DESC
+          m.database AS database,
+          m.table AS table,
+          m.mutation_id AS mutation_id,
+          m.command AS command,
+          formatDateTime(m.create_time, '%Y-%m-%d %H:%i:%S') AS create_time_str,
+          m.parts_to_do AS parts_to_do,
+          coalesce(a.total_parts, 0) AS total_parts,
+          m.is_done AS is_done,
+          m.is_killed AS is_killed,
+          m.latest_failed_part AS latest_failed_part,
+          m.latest_fail_reason AS latest_fail_reason,
+          formatDateTime(m.latest_fail_time, '%Y-%m-%d %H:%i:%S') AS latest_fail_time_str
+        FROM system.mutations m
+        LEFT JOIN active_parts a ON m.database = a.database AND m.table = a.table
+        WHERE m.is_done = 0 OR m.create_time >= now() - INTERVAL 7 DAY
+        ORDER BY m.is_done ASC, m.create_time DESC
         LIMIT 500
       `;
       const result = await queryApi.executeQuery(sql);
@@ -826,7 +841,9 @@ export function useMutations(
         command: String(row.command ?? ""),
         create_time: String(row.create_time_str ?? ""),
         parts_to_do: num(row.parts_to_do),
+        total_parts: num(row.total_parts),
         is_done: num(row.is_done),
+        is_killed: num(row.is_killed),
         latest_failed_part: String(row.latest_failed_part ?? ""),
         latest_fail_reason: String(row.latest_fail_reason ?? ""),
         latest_fail_time: String(row.latest_fail_time_str ?? ""),

--- a/src/hooks/useQuery.ts
+++ b/src/hooks/useQuery.ts
@@ -47,6 +47,7 @@ export const queryKeys = {
   recentQueries: (limit?: number, username?: string, connectionId?: string) => ['recentQueries', limit, username, connectionId] as const,
   productionMetrics: (interval: number, connectionId?: string) => ['productionMetrics', interval, connectionId] as const,
   topTables: (limit: number, connectionId?: string) => ['topTables', limit, connectionId] as const,
+  partsPressure: (interval: number, connectionId?: string) => ['partsPressure', interval, connectionId] as const,
 
   // Saved Queries
   savedQueries: (connectionId?: string) => connectionId ? ['savedQueries', connectionId] as const : ['savedQueries'] as const,
@@ -1185,6 +1186,28 @@ export function useTopTables(
     queryFn: () => metricsApi.getTopTables(limit),
     enabled: hasConnection,
     staleTime: 60000,
+    ...options,
+  });
+}
+
+/**
+ * Hook to fetch per-table parts pressure (insert-vs-merge race + "too many parts" eta)
+ */
+export function usePartsPressure(
+  intervalMinutes: number = 10,
+  options?: Partial<UseQueryOptions<metricsApi.PartsPressureRow[], Error>>
+) {
+  // Check if there's an active connection
+  const { activeConnectionId, sessionId } = useAuthStore();
+  const hasConnection = !!(activeConnectionId && sessionId);
+
+  return useQuery({
+    queryKey: queryKeys.partsPressure(intervalMinutes, activeConnectionId || undefined),
+    queryFn: () => metricsApi.getPartsPressure(intervalMinutes),
+    enabled: hasConnection,
+    staleTime: 30000,
+    retry: false,
+    refetchOnWindowFocus: false,
     ...options,
   });
 }

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -34,6 +34,20 @@ describe('lib/utils', () => {
       expect(formatBytes(1536)).toBe('1.5 KB');
     });
 
+    it('should format large units beyond TB', () => {
+      expect(formatBytes(Math.pow(1024, 4))).toBe('1 TB');
+      expect(formatBytes(Math.pow(1024, 5))).toBe('1 PB');
+      expect(formatBytes(Math.pow(1024, 6))).toBe('1 EB');
+    });
+
+    it('should clamp an out-of-range sentinel instead of rendering "undefined"', () => {
+      // The ~2^63 "no cgroup limit" sentinel previously indexed past `sizes`
+      // and rendered "8 undefined". It must clamp to the largest known unit.
+      const result = formatBytes(Math.pow(2, 63));
+      expect(result).not.toContain('undefined');
+      expect(result.endsWith(' EB')).toBe(true);
+    });
+
     it('should handle zero bytes', () => {
       expect(formatBytes(0)).toBe('0 Bytes');
     });

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -9,8 +9,10 @@ export function formatBytes(bytes: number) {
   if (bytes === 0) return "0 Bytes";
   if (!bytes) return "";
   const k = 1024;
-  const sizes = ["Bytes", "KB", "MB", "GB", "TB"];
-  const i = Math.floor(Math.log(bytes) / Math.log(k));
+  const sizes = ["Bytes", "KB", "MB", "GB", "TB", "PB", "EB"];
+  // Clamp the unit index so an out-of-range value (e.g. a ~2^63 sentinel that
+  // slips through) can't index past `sizes` and render "8 undefined".
+  const i = Math.min(Math.floor(Math.log(bytes) / Math.log(k)), sizes.length - 1);
   return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + " " + sizes[i];
 }
 

--- a/src/pages/ClusterActivity.tsx
+++ b/src/pages/ClusterActivity.tsx
@@ -1,9 +1,10 @@
 import { useEffect, useMemo, useState } from "react";
-import { Search, AlertTriangle, CheckCircle2, Network, Wrench, Activity, Layers, Database, Hourglass, Boxes, GitBranch, ServerCog } from "lucide-react";
+import { Search, AlertTriangle, CheckCircle2, Network, Wrench, Activity, Layers, Database, Hourglass, Boxes, GitBranch, ServerCog, FlaskConical, type LucideIcon } from "lucide-react";
 
 import { Input } from "@/components/ui/input";
 import { SkeletonRows } from "@/components/common/Skeletons";
 import { PaginationBar } from "@/components/monitoring/PaginationBar";
+import { DdlSimulator } from "@/components/monitoring/DdlSimulator";
 import {
   useMutations,
   useReplicationQueue,
@@ -39,7 +40,7 @@ function formatBytes(bytes: number): string {
   return `${v >= 100 || i === 0 ? v.toFixed(0) : v.toFixed(1)} ${units[i]}`;
 }
 
-type ClusterView = "mutations" | "replication" | "topology" | "distribution" | "ddl";
+type ClusterView = "mutations" | "replication" | "topology" | "distribution" | "ddl" | "simulator";
 
 interface ClusterActivityPageProps {
   embedded?: boolean;
@@ -79,6 +80,22 @@ const COPY: Record<ClusterView, { title: string; hint: string; rationale: string
     rationale:
       "ON CLUSTER DDL is applied node-by-node through ZooKeeper/Keeper. Entries that aren't 'Finished', or carry an exception, mean a schema change didn't propagate everywhere — a classic source of replica divergence.",
   },
+  simulator: {
+    title: "DDL simulator",
+    hint: "Estimate an ALTER before running it",
+    rationale:
+      "Mutations (ALTER UPDATE/DELETE) rewrite whole parts in the background and can run for hours. This estimates the cost — rows matched, parts and bytes rewritten, projected duration, and whether free disk can hold the transient rewrite — without executing anything.",
+  },
+};
+
+/** Per-view icon, shared by the sub-tabs and the rationale strip. */
+const VIEW_ICON: Record<ClusterView, LucideIcon> = {
+  mutations: Wrench,
+  replication: Network,
+  topology: ServerCog,
+  distribution: Boxes,
+  ddl: GitBranch,
+  simulator: FlaskConical,
 };
 
 export default function ClusterActivityPage({
@@ -176,8 +193,10 @@ export default function ClusterActivityPage({
   return (
     <div className="h-full overflow-hidden">
       <div className={cn("flex h-full flex-col gap-4", embedded ? "p-4" : "p-6")}>
-        {/* Sub-tabs */}
-        <div className="flex shrink-0 items-center gap-2 border-b border-ink-500">
+        {/* Sub-tabs — same title · hint underline pattern as the Parts tab, so
+            the Monitoring sub-tabs stay consistent. The row scrolls on narrow
+            widths instead of cramping (this view has more tabs than Parts). */}
+        <div className="scrollbar-hide flex shrink-0 items-center gap-2 overflow-x-auto border-b border-ink-500">
           {(Object.keys(COPY) as ClusterView[]).map((id) => {
             const tab = COPY[id];
             const activeTab = view === id;
@@ -187,7 +206,7 @@ export default function ClusterActivityPage({
                 type="button"
                 onClick={() => setView(id)}
                 className={cn(
-                  "group relative flex items-center gap-2 px-3 py-2 font-mono text-[11px] uppercase tracking-[0.14em] transition-colors",
+                  "group relative flex shrink-0 items-center gap-2 whitespace-nowrap px-3 py-2 font-mono text-[11px] uppercase tracking-[0.14em] transition-colors",
                   activeTab ? "text-paper" : "text-paper-muted hover:text-paper"
                 )}
               >
@@ -209,17 +228,10 @@ export default function ClusterActivityPage({
         {/* Rationale strip */}
         <div className="flex items-start gap-3 rounded-xs border border-ink-500 bg-ink-100 px-4 py-3">
           <span className="grid h-7 w-7 shrink-0 place-items-center rounded-xs border border-ink-500 bg-ink-200 text-paper-muted">
-            {view === "mutations" ? (
-              <Wrench className="h-3.5 w-3.5" aria-hidden />
-            ) : view === "replication" ? (
-              <Network className="h-3.5 w-3.5" aria-hidden />
-            ) : view === "topology" ? (
-              <ServerCog className="h-3.5 w-3.5" aria-hidden />
-            ) : view === "distribution" ? (
-              <Boxes className="h-3.5 w-3.5" aria-hidden />
-            ) : (
-              <GitBranch className="h-3.5 w-3.5" aria-hidden />
-            )}
+            {(() => {
+              const Icon = VIEW_ICON[view];
+              return <Icon className="h-3.5 w-3.5" aria-hidden />;
+            })()}
           </span>
           <p className="text-[12px] leading-[1.6] text-paper-muted">{COPY[view].rationale}</p>
         </div>
@@ -306,6 +318,15 @@ export default function ClusterActivityPage({
           </div>
         )}
 
+        {/* DDL simulator — self-contained; bypasses the tabular row/search/pagination body. */}
+        {view === "simulator" && (
+          <div className="flex-1 min-h-0 overflow-auto pr-1">
+            <DdlSimulator />
+          </div>
+        )}
+
+        {view !== "simulator" && (
+          <>
         {/* Filter + summary strip */}
         <div className="flex flex-wrap items-center gap-3 rounded-md border border-ink-500 bg-ink-100 p-3">
           <div className="flex w-full items-center gap-2 md:w-[320px]">
@@ -412,6 +433,8 @@ export default function ClusterActivityPage({
             />
           )}
         </div>
+          </>
+        )}
       </div>
     </div>
   );
@@ -436,6 +459,7 @@ function EmptyState({ view, hasSearch }: { view: ClusterView; hasSearch: boolean
     topology: "No clusters",
     distribution: "Backlog is clean",
     ddl: "DDL queue is clean",
+    simulator: "DDL simulator",
   };
   const BODY: Record<ClusterView, string> = {
     mutations: "No in-flight ALTER UPDATE/DELETE and nothing finished in the last 7 days.",
@@ -443,6 +467,7 @@ function EmptyState({ view, hasSearch }: { view: ClusterView; hasSearch: boolean
     topology: "No clusters defined — this server isn't part of a distributed setup.",
     distribution: "No Distributed-table insert backlog (or there are no Distributed tables).",
     ddl: "No ON CLUSTER DDL in the last day (or no ZooKeeper/Keeper is configured).",
+    simulator: "Enter an ALTER … UPDATE/DELETE above to estimate its impact.",
   };
   const Icon = view === "topology" ? ServerCog : CheckCircle2;
   return (
@@ -467,12 +492,12 @@ function MutationsTable({ rows }: MutationsTableProps) {
     <table className="w-full text-[12px]">
       <thead className="sticky top-0 z-10 bg-ink-200/90 backdrop-blur">
         <tr className="border-b border-ink-500">
-          {["Status", "Database", "Table", "Command", "Parts left", "Created", "Last failure"].map((h, i) => (
+          {["Status", "Database", "Table", "Command", "Progress", "Parts left", "Created", "Last failure"].map((h, i) => (
             <th
               key={h}
               className={cn(
                 "px-3 py-2 font-mono text-[10px] uppercase tracking-[0.14em] text-paper-faint",
-                i === 4 ? "text-right" : "text-left"
+                i === 5 ? "text-right" : "text-left"
               )}
             >
               {h}
@@ -483,6 +508,14 @@ function MutationsTable({ rows }: MutationsTableProps) {
       <tbody>
         {rows.map((m, i) => {
           const isFailing = !!m.latest_fail_reason;
+          // Best-effort progress: 1 − remaining/total. Only meaningful while
+          // running (done rows render full; no denominator → no bar).
+          const pct =
+            m.is_done
+              ? 1
+              : m.total_parts > 0
+                ? Math.min(1, Math.max(0, 1 - m.parts_to_do / m.total_parts))
+                : null;
           return (
             <tr
               key={`${m.mutation_id}-${i}`}
@@ -490,7 +523,7 @@ function MutationsTable({ rows }: MutationsTableProps) {
             >
               <td className="px-3 py-1.5">
                 <StatusChip
-                  state={m.is_done ? "done" : isFailing ? "failing" : "active"}
+                  state={m.is_killed ? "killed" : m.is_done ? "done" : isFailing ? "failing" : "active"}
                 />
               </td>
               <td className="px-3 py-1.5 font-mono text-paper-muted">{m.database}</td>
@@ -500,6 +533,26 @@ function MutationsTable({ rows }: MutationsTableProps) {
                 title={m.command}
               >
                 {m.command}
+              </td>
+              <td className="px-3 py-1.5">
+                {pct === null ? (
+                  <span className="font-mono text-paper-faint">—</span>
+                ) : (
+                  <div className="flex items-center gap-2 min-w-[120px]">
+                    <div className="h-1.5 flex-1 overflow-hidden rounded-full bg-ink-300">
+                      <div
+                        className={cn(
+                          "h-full rounded-full",
+                          isFailing ? "bg-red-500" : m.is_done ? "bg-emerald-500" : "bg-brand"
+                        )}
+                        style={{ width: `${pct * 100}%` }}
+                      />
+                    </div>
+                    <span className="font-mono text-[11px] text-paper-muted tabular-nums">
+                      {Math.round(pct * 100)}%
+                    </span>
+                  </div>
+                )}
               </td>
               <td className="px-3 py-1.5 text-right font-mono text-paper">
                 {m.parts_to_do.toLocaleString()}
@@ -646,11 +699,12 @@ function BlockedChip({
   );
 }
 
-function StatusChip({ state }: { state: "active" | "done" | "failing" }) {
+function StatusChip({ state }: { state: "active" | "done" | "failing" | "killed" }) {
   const map = {
     active: { label: "Active", tone: "border-amber-500/40 text-amber-300" },
     done: { label: "Done", tone: "border-emerald-500/40 text-emerald-300" },
     failing: { label: "Failing", tone: "border-red-500/40 text-red-300" },
+    killed: { label: "Killed", tone: "border-paper-faint/40 text-paper-faint" },
   } as const;
   const c = map[state];
   return (

--- a/src/pages/Metrics.tsx
+++ b/src/pages/Metrics.tsx
@@ -53,8 +53,9 @@ import { Progress } from "@/components/ui/progress";
 import UPlotMetricItemComponent from "@/features/metrics/components/UPlotMetricItemComponent";
 import { ServerMemoryBreakdown } from "@/components/monitoring/ServerMemoryBreakdown";
 import { TopResourceQueriesPanel } from "@/components/monitoring/TopResourceQueriesPanel";
+import { PartsPressureSummary, PartsPressureTable } from "@/components/monitoring/PartsPressurePanel";
 import ConnectionBreakdownPanel from "@/components/monitoring/ConnectionBreakdownPanel";
-import { useMetrics, useProductionMetrics } from "@/hooks";
+import { useMetrics, useProductionMetrics, usePartsPressure } from "@/hooks";
 import { cn, formatBytes as formatBytesUtil, formatCompactNumber, formatNumber } from "@/lib/utils";
 import { useRbacStore, RBAC_PERMISSIONS } from "@/stores";
 
@@ -344,6 +345,58 @@ interface MetricsProps {
   onRefreshChange?: (isRefreshing: boolean) => void;
 }
 
+/**
+ * The header time-range control. Its options are contextual: on the Parts
+ * Pressure tab it offers only short rate windows (5/15/30m) bound to the rate
+ * lookback, since a long average makes the insert/merge ETA misleading;
+ * everywhere else it's the usual historical range driving the time-series.
+ */
+function MetricsRangeSelect({
+  isPartsTab,
+  partsWindowMin,
+  onPartsWindowChange,
+  timeRange,
+  onTimeRangeChange,
+  triggerClassName,
+}: {
+  isPartsTab: boolean;
+  partsWindowMin: number;
+  onPartsWindowChange: (m: number) => void;
+  timeRange: string;
+  onTimeRangeChange: (v: string) => void;
+  triggerClassName: string;
+}) {
+  if (isPartsTab) {
+    return (
+      <Select value={String(partsWindowMin)} onValueChange={(v) => onPartsWindowChange(Number(v))}>
+        <SelectTrigger className={triggerClassName}>
+          <Clock className="mr-2 h-3.5 w-3.5 text-paper-dim" />
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="5">5 minutes</SelectItem>
+          <SelectItem value="15">15 minutes</SelectItem>
+          <SelectItem value="30">30 minutes</SelectItem>
+        </SelectContent>
+      </Select>
+    );
+  }
+  return (
+    <Select value={timeRange} onValueChange={onTimeRangeChange}>
+      <SelectTrigger className={triggerClassName}>
+        <Clock className="mr-2 h-3.5 w-3.5 text-paper-dim" />
+        <SelectValue />
+      </SelectTrigger>
+      <SelectContent>
+        <SelectItem value="15m">15 minutes</SelectItem>
+        <SelectItem value="1h">1 hour</SelectItem>
+        <SelectItem value="6h">6 hours</SelectItem>
+        <SelectItem value="24h">24 hours</SelectItem>
+      </SelectContent>
+    </Select>
+  );
+}
+
 export default function Metrics({
   embedded = false,
   refreshKey,
@@ -389,9 +442,26 @@ export default function Metrics({
     refetchOnWindowFocus: false,
   });
 
+  // Parts pressure shares the page's refresh flow (manual button + auto-refresh
+  // + connection change) so it stays in sync with the other Metrics tabs.
+  // Its rate lookback is a SHORT, dedicated window (not the page time filter):
+  // the insert/merge rate + ETA projection are only meaningful over recent
+  // activity, so a 6h/24h average would be misleading.
+  const [partsWindowMin, setPartsWindowMin] = useState(15);
+  const {
+    data: partsPressureData,
+    isLoading: partsLoading,
+    isFetching: partsFetching,
+    error: partsError,
+    refetch: refetchParts,
+  } = usePartsPressure(partsWindowMin, {
+    refetchInterval: refreshInterval > 0 ? refreshInterval * 1000 : false,
+    refetchOnWindowFocus: false,
+  });
+
   // Combined loading/fetching state
   const isAnyLoading = isLoading || prodLoading;
-  const isAnyFetching = isFetching || prodFetching;
+  const isAnyFetching = isFetching || prodFetching || partsFetching;
 
   // Notify parent of refresh status change
   React.useEffect(() => {
@@ -404,8 +474,9 @@ export default function Metrics({
     setIsRefreshCooldown(true);
     refetch();
     refetchProd();
+    refetchParts();
     setTimeout(() => setIsRefreshCooldown(false), 3000);
-  }, [isRefreshCooldown, isAnyFetching, refetch, refetchProd]);
+  }, [isRefreshCooldown, isAnyFetching, refetch, refetchProd, refetchParts]);
 
   // Calculate QPS trend
   const qpsTrend = useMemo(() => {
@@ -421,19 +492,21 @@ export default function Metrics({
     if (refreshKey) {
       refetch();
       refetchProd();
+      refetchParts();
     }
-  }, [refreshKey, refetch, refetchProd]);
+  }, [refreshKey, refetch, refetchProd, refetchParts]);
 
   // Listen for connection changes and refetch metrics
   React.useEffect(() => {
     const handleConnectionChange = () => {
       refetch();
       refetchProd();
+      refetchParts();
     };
 
     window.addEventListener('clickhouse:connected', handleConnectionChange);
     return () => window.removeEventListener('clickhouse:connected', handleConnectionChange);
-  }, [refetch, refetchProd]);
+  }, [refetch, refetchProd, refetchParts]);
 
   const lastUpdated = dataUpdatedAt ? new Date(dataUpdatedAt).toLocaleTimeString() : "--:--:--";
   const stats = metrics?.currentStats;
@@ -831,18 +904,14 @@ export default function Metrics({
                 <span className="font-mono text-[11px] text-paper-muted">{lastUpdated}</span>
               </div>
 
-              <Select value={internalTimeRange} onValueChange={setInternalTimeRange}>
-                <SelectTrigger className="h-10 w-[130px] rounded-xs border-ink-500 bg-ink-100 font-mono text-[12px] text-paper">
-                  <Clock className="mr-2 h-3.5 w-3.5 text-paper-dim" />
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="15m">15 minutes</SelectItem>
-                  <SelectItem value="1h">1 hour</SelectItem>
-                  <SelectItem value="6h">6 hours</SelectItem>
-                  <SelectItem value="24h">24 hours</SelectItem>
-                </SelectContent>
-              </Select>
+              <MetricsRangeSelect
+                isPartsTab={activeTab === "parts"}
+                partsWindowMin={partsWindowMin}
+                onPartsWindowChange={setPartsWindowMin}
+                timeRange={internalTimeRange}
+                onTimeRangeChange={setInternalTimeRange}
+                triggerClassName="h-10 w-[130px] rounded-xs border-ink-500 bg-ink-100 font-mono text-[12px] text-paper"
+              />
 
               <Select value={String(internalRefreshInterval)} onValueChange={(v) => setInternalRefreshInterval(Number(v))}>
                 <SelectTrigger className="h-9 w-[140px] rounded-xs border-ink-500 bg-ink-100 text-paper hover:border-ink-700 hover:bg-ink-200">
@@ -947,6 +1016,17 @@ export default function Metrics({
                   Merges
                 </TabsTrigger>
                 <TabsTrigger
+                  value="parts"
+                  className={cn(
+                    "rounded-xs gap-2 px-3 py-1.5 font-mono text-[11px] uppercase tracking-[0.14em] transition-colors",
+                    "data-[state=active]:bg-ink-200 data-[state=active]:text-paper",
+                    "data-[state=inactive]:text-paper-dim hover:text-paper hover:bg-ink-200"
+                  )}
+                >
+                  <FileStack className="h-4 w-4" />
+                  Parts Pressure
+                </TabsTrigger>
+                <TabsTrigger
                   value="errors"
                   className={cn(
                     "rounded-xs gap-2 px-3 py-1.5 font-mono text-[11px] uppercase tracking-[0.14em] transition-colors",
@@ -1009,18 +1089,14 @@ export default function Metrics({
             ) : <span />}
 
             {embedded && (
-              <Select value={internalTimeRange} onValueChange={setInternalTimeRange}>
-                <SelectTrigger className="h-8 w-[130px] rounded-xs border-ink-500 bg-ink-100 font-mono text-[11px] text-paper">
-                  <Clock className="mr-2 h-3.5 w-3.5 text-paper-dim" />
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="15m">15 minutes</SelectItem>
-                  <SelectItem value="1h">1 hour</SelectItem>
-                  <SelectItem value="6h">6 hours</SelectItem>
-                  <SelectItem value="24h">24 hours</SelectItem>
-                </SelectContent>
-              </Select>
+              <MetricsRangeSelect
+                isPartsTab={activeTab === "parts"}
+                partsWindowMin={partsWindowMin}
+                onPartsWindowChange={setPartsWindowMin}
+                timeRange={internalTimeRange}
+                onTimeRangeChange={setInternalTimeRange}
+                triggerClassName="h-8 w-[130px] rounded-xs border-ink-500 bg-ink-100 font-mono text-[11px] text-paper"
+              />
             )}
           </div>
 
@@ -1992,6 +2068,36 @@ export default function Metrics({
                   isLoading={prodLoading}
                   chartTitle="Delayed"
                   hideLatestValues
+                />
+              </motion.div>
+            </TabsContent>
+          )}
+
+          {/* Parts Tab - Advanced only */}
+          {hasAdvancedMetrics && (
+            <TabsContent value="parts" className="flex-1 overflow-auto space-y-6 pr-1 min-h-0 data-[state=active]:flex flex-col">
+              <motion.div
+                initial={{ opacity: 0, y: 20 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{ delay: 0.1 }}
+                className="rounded-md border border-ink-500 bg-ink-100"
+              >
+                <PartsPressureSummary
+                  data={partsPressureData ?? []}
+                  windowMinutes={partsWindowMin}
+                  isLoading={partsLoading}
+                />
+              </motion.div>
+              <motion.div
+                initial={{ opacity: 0, y: 20 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{ delay: 0.2 }}
+                className="rounded-md border border-ink-500 bg-ink-100"
+              >
+                <PartsPressureTable
+                  data={partsPressureData ?? []}
+                  isLoading={partsLoading}
+                  error={partsError}
                 />
               </motion.div>
             </TabsContent>

--- a/src/test/mocks/handlers.ts
+++ b/src/test/mocks/handlers.ts
@@ -150,6 +150,69 @@ export const handlers = [
     return HttpResponse.json({ success: true, data });
   }),
 
+  http.get(`${API_BASE}/metrics/parts-pressure`, () => {
+    return HttpResponse.json({
+      success: true,
+      data: [
+        {
+          database: 'default',
+          table: 'events',
+          active_parts: 250,
+          max_parts_in_partition: 240,
+          rows: 1_000_000,
+          bytes: 5_000_000,
+          merges_running: 1,
+          insert_parts_per_min: 12,
+          merge_parts_per_min: 4,
+          parts_threshold: 300,
+          net_parts_per_min: 8,
+          eta_minutes: 7.5,
+        },
+        {
+          database: 'default',
+          table: 'calm',
+          active_parts: 10,
+          max_parts_in_partition: 5,
+          rows: 100,
+          bytes: 200,
+          merges_running: 0,
+          insert_parts_per_min: 1,
+          merge_parts_per_min: 3,
+          parts_threshold: 300,
+          net_parts_per_min: -2,
+          eta_minutes: -1,
+        },
+      ],
+    });
+  }),
+
+  http.post(`${API_BASE}/metrics/ddl/simulate`, async ({ request }) => {
+    const body = (await request.json().catch(() => ({}))) as { statement?: string };
+    const statement = body?.statement ?? '';
+    if (!/^\s*ALTER\s+TABLE/i.test(statement)) {
+      return HttpResponse.json(
+        { success: false, error: 'Only ALTER TABLE … UPDATE/DELETE statements can be simulated.' },
+        { status: 400 },
+      );
+    }
+    return HttpResponse.json({
+      success: true,
+      data: {
+        database: 'demo',
+        table: 'events',
+        kind: 'update',
+        where: 'id < 5',
+        affected_rows: 159,
+        total_rows: 1000,
+        parts_to_rewrite: 300,
+        bytes_to_rewrite: 5_000_000,
+        est_duration_seconds: 1,
+        disk_free_bytes: 9_000_000_000,
+        disk_sufficient: true,
+      },
+    });
+  }),
+
   // Live Queries
   http.get(`${API_BASE}/live-queries`, () => {
     return HttpResponse.json({


### PR DESCRIPTION
## Description

A suite of fleet observability features plus two reliability fixes. Bundled on one branch; each user-visible change carries its own changelog fragment.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Performance improvement

## Related Issue

Closes #261
Closes #264

## Changes Made

**Added**
- **Parts pressure monitoring** — new Parts tab in Metrics surfacing the insert-vs-merge race behind "too many parts"; worst partition vs `parts_to_throw_insert`, live insert/merge rates, projected ETA. Also collected fleet-wide as the `parts_pressure` metric.
- **Predictive "too many parts" alert** — fleet alert rule that fires when a table is projected to hit its `parts_to_throw_insert` limit within a configurable window; configurable in the alert delivery dialog and alerts bell, surfaced as a "Parts limit ETA" tile per fleet card.
- **DDL impact simulator** — read-only "what would this `ALTER` cost" estimator in the Cluster tab (rows matched, parts/bytes rewritten, projected duration, disk headroom) without executing anything.

**Changed**
- **Mutation progress** — Cluster → Mutations now shows an approximate progress bar (parts done / total) and a Killed status.
- **Fleet alert config & Doctor schedule persisted in the shared DB** — alert rules/thresholds, delivery settings, and scheduler config/run-state moved off pod-local disk into the shared RBAC DB; existing `alert-config.json` / `doctor-schedule.json` imported automatically on first upgrade.

**Fixed**
- **SSO one-role-per-user** (#261) — collapse multiple IdP-mapped group matches to the single highest-privilege role via atomic upsert, so a sync never strips a user's role.
- **Fleet memory tile 0% on cgroup-limited nodes** (#264) — fallback chain `OSMemoryTotal` → `CGroupMemoryTotal` → `max_server_memory_usage` for the memory ceiling; `formatBytes()` extended/clamped.
- **Scheduled health scans no longer double-fire under multiple replicas** — gated by an atomic per-slot DB claim.

## Testing

- [x] I have tested this locally
- [x] I have added/updated tests
- [x] All existing tests pass

### Test Results

All suites green:

| Suite | Result |
|---|---|
| `bun run typecheck` | ✅ clean |
| `bun run lint` | ✅ clean |
| Frontend (Vitest, `src/`) | ✅ 365/365 |
| Server (Bun test) | ✅ 66/66 |
| Migrations — SQLite + PostgreSQL (`./scripts/test-migrations.sh`) | ✅ 122/122 (820 assertions) |

New test files: `ddlSimulator.test.ts`, `doctorScheduler.test.ts`, `fleetAlertConfig.test.ts`, `fleetAlerter.test.ts`, plus updates to `migrations.test.ts`, `sso/service.test.ts`, `clickhouse.test.ts`, and frontend `metrics.test.ts` / `utils.test.ts`. Migration changes validated across fresh-install, stepwise, and skip-version upgrade paths on both dialects.

## Changelog Fragment

- [x] Added fragments under `changelogs/unreleased/` (261-sso-single-role, 264-fleet-memory-fallback, fleet-config-in-db, mutation-progress-and-ddl-simulator, parts-pressure-alert, parts-pressure-observatory)

## Checklist

- [x] My code follows the project's code style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] I have checked for breaking changes and documented them (if applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)