### PR TITLE
fix(alerting): make channel test match real delivery + editable type

### DIFF
--- a/changelogs/unreleased/275-google-chat-alert-delivery.md
+++ b/changelogs/unreleased/275-google-chat-alert-delivery.md
@@ -1,0 +1,7 @@
+type: patch
+
+### Fixed
+- **Alert channel "Send test" now matches real delivery** — a Google Chat webhook saved under a *Slack* channel passed "Send test" but no real breach alert ever arrived (only the in-app feed showed it). The test sent a bare `{text}` body that both providers accept, while production delivery sends provider-specific payloads (Slack Block Kit `attachments` / Google Chat `cardsV2`), which Google Chat rejects with `400` for a Slack-shaped body. The test now sends the same payload shape as real delivery, so a mismatched channel fails the test instead of giving false confidence.
+
+### Changed
+- **Notification channel type is now editable, with a webhook URL/type guard** — a channel's type can be changed while editing (the webhook URL is preserved when switching between Slack and Google Chat), so a mis-typed channel can be corrected in place instead of being deleted and recreated. Saving is blocked with a clear warning when the webhook URL's domain clearly belongs to a different provider than the selected type (a `chat.googleapis.com` URL on a Slack channel, or a `hooks.slack.com` URL on a Google Chat channel).

--- a/packages/server/src/services/alerting/deliver.ts
+++ b/packages/server/src/services/alerting/deliver.ts
@@ -36,13 +36,44 @@ export async function sendChannelTest(
     case ChannelType.Slack: {
       const url = String(config.webhookUrl ?? "");
       if (!url) throw new Error("Slack webhook URL is not set");
-      await postJson(url, { text: `${TEST_TITLE}\n${TEST_TEXT}` });
+      // Mirror the REAL breach payload shape (Block Kit `attachments`), not a
+      // bare `{text}`. A bare text body is accepted by both Slack AND Google
+      // Chat, so it silently passes for a channel that's typed Slack but points
+      // at a Google Chat webhook — then real alerts (which DO send `attachments`)
+      // get rejected 400 by Google Chat. Sending the real shape here makes the
+      // test fail for that mismatch, instead of giving false confidence.
+      await postJson(url, {
+        text: `${TEST_TITLE}\n${TEST_TEXT}`,
+        attachments: [
+          {
+            color: "#16a34a",
+            blocks: [
+              { type: "header", text: { type: "plain_text", text: TEST_TITLE, emoji: true } },
+              { type: "section", text: { type: "mrkdwn", text: TEST_TEXT } },
+            ],
+          },
+        ],
+      });
       return true;
     }
     case ChannelType.GoogleChat: {
       const url = String(config.webhookUrl ?? "");
       if (!url) throw new Error("Google Chat webhook URL is not set");
-      await postJson(url, { text: `${TEST_TITLE}\n${TEST_TEXT}` });
+      // Mirror the REAL breach payload shape (`cardsV2`). Same reasoning as
+      // Slack above — a bare `{text}` would pass even against a Slack webhook,
+      // masking a type/URL mismatch. The card forces a faithful round-trip.
+      await postJson(url, {
+        text: TEST_TITLE,
+        cardsV2: [
+          {
+            cardId: "alerting-test",
+            card: {
+              header: { title: TEST_TITLE },
+              sections: [{ widgets: [{ textParagraph: { text: TEST_TEXT } }] }],
+            },
+          },
+        ],
+      });
       return true;
     }
     case ChannelType.Webhook: {

--- a/src/features/alerting/ChannelDialog.tsx
+++ b/src/features/alerting/ChannelDialog.tsx
@@ -9,7 +9,7 @@
 import React, { useEffect, useState } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
-import { Loader2, Radio } from "lucide-react";
+import { Loader2, Radio, AlertTriangle } from "lucide-react";
 
 import { log } from "@/lib/log";
 import { Button } from "@/components/ui/button";
@@ -97,8 +97,32 @@ export function ChannelDialog({ open, channel, onClose }: ChannelDialogProps) {
 
   const onTypeChange = (next: ChannelType) => {
     setType(next);
-    setConfig(defaultConfigFor(CHANNEL_FIELD_SPECS[next]));
+    // Preserve values for keys shared between the old and new type — most
+    // importantly `webhookUrl`, shared by Slack & Google Chat. This lets an
+    // operator fix a mis-typed channel (e.g. a Google Chat webhook saved as
+    // Slack) by just flipping the type, without re-pasting the URL.
+    setConfig((prev) => {
+      const base = defaultConfigFor(CHANNEL_FIELD_SPECS[next]);
+      const nextKeys = new Set(CHANNEL_FIELD_SPECS[next].map((s) => s.key));
+      const carried: Record<string, unknown> = {};
+      for (const [k, v] of Object.entries(prev)) {
+        if (nextKeys.has(k) && v !== "" && v !== undefined && v !== null) carried[k] = v;
+      }
+      return { ...base, ...carried };
+    });
   };
+
+  // Guard against the silent-failure trap: a webhook URL whose domain clearly
+  // belongs to a DIFFERENT provider than the selected type. Sending Slack
+  // Block Kit to a Google Chat webhook (or vice versa) is rejected at delivery
+  // time but the bare-text "Send test" used to pass — so we block it up front.
+  const webhookUrl = typeof config.webhookUrl === "string" ? config.webhookUrl : "";
+  const urlTypeMismatch =
+    type === ChannelType.Slack && /chat\.googleapis\.com/i.test(webhookUrl)
+      ? "This looks like a Google Chat webhook URL, but the channel type is Slack. Switch the type to Google Chat — otherwise alerts go out in Slack format and Google Chat rejects them."
+      : type === ChannelType.GoogleChat && /hooks\.slack\.com/i.test(webhookUrl)
+        ? "This looks like a Slack webhook URL, but the channel type is Google Chat. Switch the type to Slack."
+        : null;
 
   const mutation = useMutation({
     mutationFn: async () => {
@@ -123,7 +147,7 @@ export function ChannelDialog({ open, channel, onClose }: ChannelDialogProps) {
     },
   });
 
-  const canSave = name.trim().length > 0 && !mutation.isPending;
+  const canSave = name.trim().length > 0 && !mutation.isPending && !urlTypeMismatch;
 
   return (
     <Dialog open={open} onOpenChange={(o) => !o && onClose()}>
@@ -152,7 +176,7 @@ export function ChannelDialog({ open, channel, onClose }: ChannelDialogProps) {
 
           <div className="space-y-1.5">
             <Label className={LABEL_CLASS}>Type</Label>
-            <Select value={type} onValueChange={(v) => onTypeChange(v as ChannelType)} disabled={isEdit}>
+            <Select value={type} onValueChange={(v) => onTypeChange(v as ChannelType)}>
               <SelectTrigger>
                 <SelectValue />
               </SelectTrigger>
@@ -195,6 +219,13 @@ export function ChannelDialog({ open, channel, onClose }: ChannelDialogProps) {
               </div>
             );
           })}
+
+          {urlTypeMismatch && (
+            <div className="flex items-start gap-2 rounded-xs border border-amber-300 bg-amber-50 px-3 py-2 text-[12px] text-amber-800 dark:border-amber-900/60 dark:bg-amber-950/40 dark:text-amber-300">
+              <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" aria-hidden />
+              <span>{urlTypeMismatch}</span>
+            </div>
+          )}
 
           <div className="flex items-center justify-between border-t border-ink-500 pt-3">
             <Label className={LABEL_CLASS}>Enabled</Label>


### PR DESCRIPTION
## Description

A notification channel created as **Slack** but pointed at a **Google Chat** webhook passed "Send test", yet no real breach alert ever arrived in Google Chat — alerts only showed in the in-app feed. The "Send test" action sent a bare `{ "text": "…" }` body, which **both** Slack and Google Chat accept, so a type/URL mismatch passed silently. Production breach delivery, however, sends provider-specific payloads (Slack Block Kit `attachments` / Google Chat `cardsV2`), and Google Chat rejects a Slack-shaped body with `400` — so every real alert was logged, recorded to the feed, and then dropped.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issue

N/A — found during internal testing.

## Changes Made

- **`packages/server/src/services/alerting/deliver.ts`** — `sendChannelTest` now sends the same payload shape as production delivery for each type (Slack Block Kit `attachments`, Google Chat `cardsV2`) instead of a bare `{ text }`. A channel whose type doesn't match its webhook now **fails** "Send test" instead of giving false confidence.
- **`src/features/alerting/ChannelDialog.tsx`** —
  - The channel **type is now editable when editing** (it was locked after creation). The `webhookUrl` is preserved when switching between Slack and Google Chat, so a mis-typed channel can be corrected in place instead of delete-and-recreate.
  - Added a **URL/type guard**: saving is blocked with an inline warning when the webhook URL's domain clearly belongs to a different provider than the selected type (`chat.googleapis.com` on a Slack channel, or `hooks.slack.com` on a Google Chat channel).

## Testing

- [x] I have tested this locally

### Test Steps
1. Create a channel with type **Slack** but paste a **Google Chat** webhook URL → previously "Send test" passed; now it fails (Google Chat rejects the Block Kit body). The new dialog guard also blocks the save up front for the known mismatched domains.
2. Edit the channel → switch type to **Google Chat** (URL preserved) → **Send test** now delivers a `cardsV2` card successfully, and real breach alerts are delivered too.
- Typecheck passes on root + server. Deployed to a running v3.6.0 instance and verified boot + the new test payloads.
- No automated tests added (delivery is network I/O to external webhooks); existing suite not affected by these changes.

## Changelog Fragment

- [x] Added `changelogs/unreleased/275-google-chat-alert-delivery.md` (`type: patch`)

## Checklist

- [x] My code follows the project's code style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors

## Additional Notes

The changelog fragment is named `275-…` as a best guess for the PR number — rename it to match the actual PR number if it differs. Operationally, any **existing** mis-typed channel still needs its type corrected once (now possible in-place via the editable type), since the fix prevents *new* mistakes but doesn't rewrite stored channel rows.