### PR TITLE
fix(sso): fail closed on ambiguous role mapping instead of escalating to highest privilege

### DIFF
--- a/changelogs/unreleased/270-sso-fail-closed-roles.md
+++ b/changelogs/unreleased/270-sso-fail-closed-roles.md
@@ -1,0 +1,4 @@
+type: patch
+
+### Fixed
+- **SSO no longer silently escalates privileges** (#270) — when an IdP claim resolved to more than one mapped role, the previous behaviour collapsed to the *highest-privilege* match, so a user in multiple groups could land in an unexpectedly powerful role. Role sync now fails closed: an ambiguous claim assigns no role and keeps the user's existing one, logging a warning so the misconfiguration can be fixed. Multi-group role mappings remain supported — only genuine overlap (one user resolving to several roles) is rejected.

--- a/packages/server/src/rbac/routes/ssoAdmin.test.ts
+++ b/packages/server/src/rbac/routes/ssoAdmin.test.ts
@@ -323,6 +323,17 @@ describe("RBAC SSO Admin Routes", () => {
       expect(JSON.stringify(details)).not.toContain("supersecret");
     });
 
+    it("persists multiple role mappings (multi-group is allowed; login fails closed on overlap)", async () => {
+      const res = await app.request("/sso-admin/providers", {
+        method: "POST",
+        headers: JSON_AUTH,
+        body: JSON.stringify({ ...validBody, id: "multi-map", roleMappingClaim: "groups", roleMapping: "admins:admin,devs:developer" }),
+      });
+      expect(res.status).toBe(201);
+      const arg = mockCreateDbProvider.mock.calls.at(-1)![0] as unknown as { roleMapping?: string };
+      expect(arg.roleMapping).toBe("admins:admin,devs:developer");
+    });
+
     it("persists auth_params passed in the body", async () => {
       const res = await app.request("/sso-admin/providers", {
         method: "POST",

--- a/packages/server/src/rbac/sso/service.test.ts
+++ b/packages/server/src/rbac/sso/service.test.ts
@@ -436,9 +436,9 @@ describe("provisionSsoUser", () => {
   });
 
   // ----------------------------------------------------------------
-  // Test 8b: multi-group claim → collapse to highest-privilege role (#261)
+  // Test 8b: claim resolving to multiple roles → fail closed (#270)
   // ----------------------------------------------------------------
-  it("8b. multi-role mapping: claims {groups:['devs','admins']} mapping to developer+admin → upserts ONE role (admin, highest privilege)", async () => {
+  it("8b. ambiguous mapping: claims {groups:['devs','admins']} resolving to developer+admin → assigns NO role, keeps existing", async () => {
     mockGetUserIdentityResult = existingIdentityRow;
     mockDbUserRow = { ...existingUserRow };
     mockGetUserRolesResult = ["viewer"];
@@ -457,13 +457,136 @@ describe("provisionSsoUser", () => {
 
     await provisionSsoUser(provider, identity);
 
-    // Exactly one role upserted, and it's the highest-privilege one (admin).
+    // Fail closed: no role written at all (no silent escalation), the user keeps
+    // whatever role they already had.
+    expect(mockDb.delete).not.toHaveBeenCalled();
+    expect(mockDbInsertValues.length).toBe(0);
+  });
+
+  // ----------------------------------------------------------------
+  // Test 8c: single matched role still upserts normally.
+  // ----------------------------------------------------------------
+  it("8c. single mapping: claims {groups:['admins']} → upserts the one resolved role (admin)", async () => {
+    mockGetUserIdentityResult = existingIdentityRow;
+    mockDbUserRow = { ...existingUserRow };
+    mockGetUserRolesResult = ["viewer"];
+    mockGetRoleByNameResult = (name: string) =>
+      name === "admin" ? { id: "role-admin", name: "admin", displayName: "Admin" } : null;
+
+    const provider = makeProvider({
+      roleMappingClaim: "groups",
+      roleMapping: { admins: "admin" },
+    });
+    const identity = makeIdentity({ claims: { groups: ["admins"] } });
+
+    await provisionSsoUser(provider, identity);
+
     expect(mockDb.delete).not.toHaveBeenCalled();
     expect(mockDbInsertValues.length).toBe(1);
     const inserted = mockDbInsertValues[0];
     const insertedArr = Array.isArray(inserted) ? inserted : [inserted];
-    expect(insertedArr.length).toBe(1);
     expect((insertedArr[0] as Record<string, unknown>).roleId).toBe("role-admin");
+  });
+
+  // ----------------------------------------------------------------
+  // Test 8d: two groups mapping to the SAME role → not ambiguous, assign it.
+  // Guards that fail-closed keys off distinct *roles*, not distinct group hits.
+  // ----------------------------------------------------------------
+  it("8d. multi-group to one role: mapping {a:admin,b:admin}, claims {groups:['a','b']} → upserts admin (deduped, not fail-closed)", async () => {
+    mockGetUserIdentityResult = existingIdentityRow;
+    mockDbUserRow = { ...existingUserRow };
+    mockGetUserRolesResult = ["viewer"];
+    mockGetRoleByNameResult = (name: string) =>
+      name === "admin" ? { id: "role-admin", name: "admin", displayName: "Admin" } : null;
+
+    const provider = makeProvider({
+      roleMappingClaim: "groups",
+      roleMapping: { a: "admin", b: "admin" },
+    });
+    const identity = makeIdentity({ claims: { groups: ["a", "b"] } });
+
+    await provisionSsoUser(provider, identity);
+
+    expect(mockDb.delete).not.toHaveBeenCalled();
+    expect(mockDbInsertValues.length).toBe(1);
+    const inserted = mockDbInsertValues[0];
+    const insertedArr = Array.isArray(inserted) ? inserted : [inserted];
+    expect((insertedArr[0] as Record<string, unknown>).roleId).toBe("role-admin");
+  });
+
+  // ----------------------------------------------------------------
+  // Test 8e: several groups but only ONE resolves to a known role → assign it.
+  // Guards that ambiguity is measured after unknown roles are dropped.
+  // ----------------------------------------------------------------
+  it("8e. multi-group, one unknown: mapping {a:admin,b:ghost}, claims {groups:['a','b']} → upserts admin (ghost ignored)", async () => {
+    mockGetUserIdentityResult = existingIdentityRow;
+    mockDbUserRow = { ...existingUserRow };
+    mockGetUserRolesResult = ["viewer"];
+    mockGetRoleByNameResult = (name: string) =>
+      name === "admin" ? { id: "role-admin", name: "admin", displayName: "Admin" } : null;
+
+    const provider = makeProvider({
+      roleMappingClaim: "groups",
+      roleMapping: { a: "admin", b: "ghost" },
+    });
+    const identity = makeIdentity({ claims: { groups: ["a", "b"] } });
+
+    await provisionSsoUser(provider, identity);
+
+    expect(mockDb.delete).not.toHaveBeenCalled();
+    expect(mockDbInsertValues.length).toBe(1);
+    const inserted = mockDbInsertValues[0];
+    const insertedArr = Array.isArray(inserted) ? inserted : [inserted];
+    expect((insertedArr[0] as Record<string, unknown>).roleId).toBe("role-admin");
+  });
+
+  // ----------------------------------------------------------------
+  // Test 8f: resolved role equals the user's current role → no write at all.
+  // ----------------------------------------------------------------
+  it("8f. no-op: user already holds the single mapped role → db insert NOT called", async () => {
+    mockGetUserIdentityResult = existingIdentityRow;
+    mockDbUserRow = { ...existingUserRow };
+    mockGetUserRolesResult = ["admin"]; // already exactly the mapped role
+    mockGetRoleByNameResult = (name: string) =>
+      name === "admin" ? { id: "role-admin", name: "admin", displayName: "Admin" } : null;
+
+    const provider = makeProvider({
+      roleMappingClaim: "groups",
+      roleMapping: { admins: "admin" },
+    });
+    const identity = makeIdentity({ claims: { groups: ["admins"] } });
+
+    await provisionSsoUser(provider, identity);
+
+    expect(mockDb.delete).not.toHaveBeenCalled();
+    expect(mockDb.insert).not.toHaveBeenCalled();
+    expect(mockFns.createSessionAndTokens).toHaveBeenCalled();
+  });
+
+  // ----------------------------------------------------------------
+  // Test 8g: ambiguous claim still fails closed even when the user currently
+  // holds one of the resolved roles (no "keep the higher one" shortcut).
+  // ----------------------------------------------------------------
+  it("8g. ambiguous + currently holds one of them: claims resolve to admin+developer, current=developer → no write", async () => {
+    mockGetUserIdentityResult = existingIdentityRow;
+    mockDbUserRow = { ...existingUserRow };
+    mockGetUserRolesResult = ["developer"];
+    mockGetRoleByNameResult = (name: string) => {
+      if (name === "admin") return { id: "role-admin", name: "admin", displayName: "Admin" };
+      if (name === "developer") return { id: "role-developer", name: "developer", displayName: "Developer" };
+      return null;
+    };
+
+    const provider = makeProvider({
+      roleMappingClaim: "groups",
+      roleMapping: { devs: "developer", admins: "admin" },
+    });
+    const identity = makeIdentity({ claims: { groups: ["devs", "admins"] } });
+
+    await provisionSsoUser(provider, identity);
+
+    expect(mockDb.delete).not.toHaveBeenCalled();
+    expect(mockDbInsertValues.length).toBe(0);
   });
 
   // ----------------------------------------------------------------

--- a/packages/server/src/rbac/sso/service.ts
+++ b/packages/server/src/rbac/sso/service.ts
@@ -24,7 +24,7 @@ import { getSsoConfig, type SsoProviderConfig } from './config';
 import type { SsoIdentity } from './client';
 import { logger } from '../../utils/logger';
 import { AppError } from '../../types';
-import { SYSTEM_ROLES, ROLE_HIERARCHY, type SystemRole } from '../schema/base';
+import { SYSTEM_ROLES } from '../schema/base';
 import type { User, UserResponse } from '../schema';
 import type { TokenPair } from '../services/jwt';
 
@@ -203,14 +203,18 @@ async function pickAvailableUsername(base: string): Promise<string> {
 
 /**
  * Set the user's role from the IdP claim. This system is single-role-per-user
- * (a UNIQUE index on rbac_user_roles.user_id), so when an IdP claim matches
- * several mapped groups we MUST collapse to exactly one role — otherwise the
- * multi-row insert violates that index and the login fails, leaving the user
- * role-less. We pick the highest-privilege resolved role (ROLE_HIERARCHY), the
- * same precedence migration 1.27.0 used to collapse legacy multi-role users.
+ * (a UNIQUE index on rbac_user_roles.user_id), and role mappings are gated to a
+ * single entry, so a login should resolve to at most one role.
  *
- * Behaviour preserved:
+ * If a claim nonetheless resolves to MORE than one distinct role (e.g. a stale
+ * multi-entry mapping that predates the gate), we fail closed: we refuse to
+ * assign any of them and keep the user's existing role. Silently collapsing to
+ * the highest-privilege match would be a privilege-escalation footgun (#270),
+ * so ambiguity is treated as a misconfiguration the admin must fix.
+ *
+ * Behaviour:
  *   - If no mapped role resolves to a known role, keep the existing role (avoid lockout).
+ *   - If the claim resolves to >1 distinct role, keep the existing role (fail closed).
  *   - If the user currently holds super_admin, skip sync entirely (avoid demotion).
  *
  * The write is a single atomic upsert keyed on user_id, so the user is never
@@ -278,10 +282,9 @@ async function syncMappedRoles(
     return;
   }
 
-  // Single-role-per-user: collapse multiple matched roles to the highest
-  // privilege one. Logged so admins can see when a user's group membership
-  // resolved to more than one mapping.
-  const chosen = pickHighestPrivilegeRole(targetRoles);
+  // Single-role-per-user: a claim must resolve to exactly one role. More than
+  // one distinct match is ambiguous — fail closed rather than silently picking
+  // a role, which previously escalated to the highest-privilege match (#270).
   if (targetRoles.length > 1) {
     logger.warn(
       {
@@ -289,11 +292,12 @@ async function syncMappedRoles(
         provider: provider.id,
         userId,
         resolvedRoles: targetRoles.map((r) => r.name),
-        chosenRole: chosen.name,
       },
-      'IdP claim mapped to multiple roles; collapsed to highest-privilege role (single-role-per-user)'
+      'IdP claim resolved to multiple roles; refusing to assign and keeping existing role (fix the role mapping to one entry)'
     );
+    return;
   }
+  const chosen = targetRoles[0];
 
   // No change needed when the user already holds exactly the chosen role.
   if (currentNames.length === 1 && currentNames[0] === chosen.name) return;
@@ -316,20 +320,6 @@ async function syncMappedRoles(
     { module: 'SSO', provider: provider.id, userId, role: chosen.name },
     'Synced role from IdP claim'
   );
-}
-
-/**
- * Pick the highest-privilege role from a resolved set, using the canonical
- * ROLE_HIERARCHY. Custom (non-system) roles rank lowest (0); ties break
- * alphabetically so the choice is deterministic. Callers must pass a non-empty
- * array.
- */
-function pickHighestPrivilegeRole<T extends { id: string; name: string }>(roles: T[]): T {
-  const rank = (name: string): number => ROLE_HIERARCHY[name as SystemRole] ?? 0;
-  return [...roles].sort((a, b) => {
-    const diff = rank(b.name) - rank(a.name);
-    return diff !== 0 ? diff : a.name.localeCompare(b.name);
-  })[0];
 }
 
 /** Returns true if the error is a unique-constraint violation (SQLite or PostgreSQL). */

--- a/src/features/admin/components/SsoSettings/index.tsx
+++ b/src/features/admin/components/SsoSettings/index.tsx
@@ -28,6 +28,7 @@ import {
   Check,
   AlertTriangle,
   AlertCircle,
+  Info,
   CheckCircle2,
   Play,
   ArrowLeft,
@@ -1580,6 +1581,16 @@ function ProviderWizard({ open, onClose, editing }: ProviderWizardProps) {
                   roles={roles ?? []}
                   onChange={(rows) => update({ roleMappingRows: rows })}
                 />
+                <p className={cn(HELP_CLASS, "flex items-start gap-1.5")}>
+                  <Info className="mt-0.5 h-3 w-3 shrink-0" />
+                  <span>
+                    A user is assigned one role. If their claim matches several mappings that
+                    resolve to different roles, sign-in assigns no role and keeps their current
+                    one (no silent privilege escalation). Set a low-privilege{" "}
+                    <strong className="font-medium text-paper-dim">Default role</strong> so an
+                    ambiguous first sign-in lands there instead of with no access.
+                  </span>
+                </p>
               </section>
             </div>
           )}


### PR DESCRIPTION
## Description

When SSO role mapping resolved an IdP claim to **more than one role** (a user in multiple mapped groups), role sync silently collapsed to the **highest-privilege** match. This is a privilege-escalation footgun introduced in #266: the assigned role was unpredictable from an admin's perspective and always picked the most powerful option.

This PR makes role sync **fail closed** instead. An ambiguous claim assigns **no** role and keeps the user's existing role (the default role on first login), logging a warning so the misconfiguration can be fixed.

Multi-group mappings remain fully supported — only genuine overlap (one user resolving to several distinct roles) is refused, so disjoint `group → role` setups keep working unchanged.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issue

Closes #270

## Changes Made

- **`packages/server/src/rbac/sso/service.ts`** — `syncMappedRoles` now returns without assigning when a claim resolves to >1 distinct role (fail closed + warn), instead of calling `pickHighestPrivilegeRole`. Removed the now-unused `pickHighestPrivilegeRole` helper and `ROLE_HIERARCHY` / `SystemRole` imports.
- **`src/features/admin/components/SsoSettings/index.tsx`** — added a guidance note under the role-mapping editor explaining one-role-per-user + fail-closed behavior, and recommending a low-privilege **Default role** so an ambiguous first sign-in degrades gracefully instead of landing with no access.
- **Tests** — rewrote the multi-role test to assert fail-closed; added cases for the boundaries the fix hinges on: dedup to the same role (assign), unknown-role filtering (assign single known), no-op when already holding the role, ambiguous-while-holding-one (still fail closed), and a single-match happy path. Added a server-route test asserting multi-row mappings are still accepted/persisted.

### Behavior summary

| Scenario | Before | After |
|---|---|---|
| User in one mapped group | assigned that role | assigned that role (unchanged) |
| User in multiple groups → same role | assigned (deduped) | assigned (deduped) |
| User in multiple groups → different roles | **silently escalated to highest** | **no assignment, keeps current/default + warns** |
| Ambiguous on first login | escalated | gets the configured Default role (or none) |

## Testing

- [x] I have tested this locally
- [x] I have added/updated tests
- [x] All existing tests pass

### Test Steps

- `bun run typecheck` — clean
- `bun run lint` — clean
- `./scripts/test-isolated-server.sh` — 70/70 files pass
- `bunx vitest run --exclude '**/packages/**'` — 37 files / 373 tests pass
- `packages/server/src/rbac/sso/service.test.ts` — 20/20 (incl. new edge cases)

## Changelog Fragment

- [x] Added `changelogs/unreleased/270-sso-fail-closed-roles.md` (`type: patch`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)