### PR TITLE
fix(scheduled-queries): reflect partition input in DDL, tidy staging, clarify output modes

### DIFF
--- a/packages/server/src/routes/scheduled-queries.ts
+++ b/packages/server/src/routes/scheduled-queries.ts
@@ -187,8 +187,11 @@ function validateBody(body: JobBody, canWrite: boolean): void {
       throw AppError.badRequest("Destination database and table are required for materialize jobs");
     }
     if (body.destDatabase === "system") throw AppError.badRequest("Destination cannot be a system table");
-    if (body.outputMode === "replace" && !body.outputConfig?.partitionExpr) {
-      throw AppError.badRequest("replace mode requires output_config.partitionExpr");
+    // Replace only needs an explicit partition expression when it creates the
+    // destination (the DDL must be partitioned). If the table already exists, its
+    // partition key is used and enforced by the engine-fit check at run time.
+    if (body.outputMode === "replace" && body.outputConfig?.createIfMissing && !body.outputConfig?.partitionExpr) {
+      throw AppError.badRequest("replace mode with create-if-missing requires output_config.partitionExpr");
     }
   }
 }

--- a/packages/server/src/services/scheduledQueries/materialize.ts
+++ b/packages/server/src/services/scheduledQueries/materialize.ts
@@ -154,7 +154,11 @@ export function buildCreateTableDDL(job: ScheduledQueryRow, columns: ExpectedCol
   const cfg = job.outputConfig ?? {};
   const cols = columns.map((c) => `  ${ident(c.name)} ${c.type}`).join(",\n");
   const engine = cfg.engine?.trim() || "MergeTree";
-  const partitionBy = cfg.partitionBy?.trim() ? `\nPARTITION BY ${cfg.partitionBy.trim()}` : "";
+  // `replace` collects the partition key as `partitionExpr`; `createIfMissing`
+  // exposes a dedicated `partitionBy`. Prefer the explicit one, falling back to
+  // the replace expression so the user's partition input is reflected in the DDL.
+  const partition = cfg.partitionBy?.trim() || cfg.partitionExpr?.trim();
+  const partitionBy = partition ? `\nPARTITION BY ${partition}` : "";
   const orderBy = cfg.orderBy?.trim() || "tuple()";
   return `CREATE TABLE IF NOT EXISTS ${qualified(job.destDatabase!, job.destTable!)} (\n${cols}\n) ENGINE = ${engine}${partitionBy}\nORDER BY ${orderBy}`;
 }
@@ -238,6 +242,15 @@ export async function executeMaterialize(args: MaterializeArgs): Promise<number 
         abort_signal: signal,
         query_params: { pid: p.partition_id },
       });
+    }
+    // Swap done — staging now holds a redundant full copy of the run's output.
+    // The table itself is kept and reused (CREATE IF NOT EXISTS + TRUNCATE next
+    // run), but free its storage now so we don't retain a run's worth of data
+    // between runs. Best-effort: the next run truncates again, so this is safe.
+    try {
+      await client.command({ query: `TRUNCATE TABLE ${stagingQ}`, query_id: `${queryId}_stg_cleanup`, abort_signal: signal });
+    } catch (err) {
+      logger.warn({ module: "ScheduledQueries", jobId: job.id, err }, "post-replace staging truncate failed (non-fatal)");
     }
     return written;
   }

--- a/src/features/scheduled-queries/JobWizard.tsx
+++ b/src/features/scheduled-queries/JobWizard.tsx
@@ -244,7 +244,11 @@ export function JobWizard({ isOpen, onClose, job, prefill }: JobWizardProps) {
       case "Schedule":
         return form.frequency !== "cron" || form.cronExpr.trim().length > 0;
       case "Output":
-        return form.outputMode === "none" || (form.destDatabase.trim().length > 0 && form.destTable.trim().length > 0);
+        if (form.outputMode === "none") return true;
+        if (form.destDatabase.trim().length === 0 || form.destTable.trim().length === 0) return false;
+        // Replace creates a partitioned table — the partition expression is required when creating it.
+        if (form.outputMode === "replace" && form.createIfMissing && form.partitionExpr.trim().length === 0) return false;
+        return true;
       default:
         return true;
     }
@@ -514,20 +518,58 @@ function ActionsStep({ form, update, channels }: StepProps & { channels: Notific
   );
 }
 
+const OUTPUT_MODE_HELP: Record<SqOutputMode, { title: string; what: string; when: string }> = {
+  none: {
+    title: "None (read-only)",
+    what: "Runs the SELECT and evaluates alert conditions only — nothing is written to ClickHouse.",
+    when: "Use for monitoring and data-health checks where you only want to be notified, not to persist results.",
+  },
+  append: {
+    title: "Append",
+    what: "Runs INSERT … SELECT into the destination each run, deduplicated per time slot so a retry never double-writes the same slot.",
+    when: "Use for accumulating immutable rows over time — e.g. appending each run's events or rollups to a growing history table.",
+  },
+  replace: {
+    title: "Replace partition",
+    what: "Writes the run's output to a staging table, then atomically swaps each produced partition into the destination via REPLACE PARTITION. The destination always reflects exactly the latest run with no duplicates.",
+    when: "Use when each run recomputes whole partitions (e.g. rebuilding yesterday's daily aggregate). Requires a MergeTree-family destination with a PARTITION BY key.",
+  },
+  upsert: {
+    title: "Upsert (ReplacingMergeTree)",
+    what: "Runs INSERT … SELECT into a ReplacingMergeTree / Aggregating / Collapsing destination, letting the engine merge duplicate keys by its sorting key.",
+    when: "Use when rows are keyed and updated over time, and you want the newest version of each key to win.",
+  },
+};
+
 function OutputStep({ form, update, preview, onPreview, previewing }: StepProps & { preview: PreviewResult | null; onPreview: () => Promise<unknown>; previewing: boolean }) {
+  const modeHelp = OUTPUT_MODE_HELP[form.outputMode];
   return (
     <>
       <div className={sectionCls}>
         <Label className={labelCls}>Output mode</Label>
-        <Select value={form.outputMode} onValueChange={(v) => update({ outputMode: v as SqOutputMode })}>
-          <SelectTrigger><SelectValue /></SelectTrigger>
-          <SelectContent>
-            <SelectItem value="none">None (read-only)</SelectItem>
-            <SelectItem value="append">Append</SelectItem>
-            <SelectItem value="replace">Replace partition</SelectItem>
-            <SelectItem value="upsert">Upsert (ReplacingMergeTree)</SelectItem>
-          </SelectContent>
-        </Select>
+        <div className="flex items-center gap-2">
+          <Select value={form.outputMode} onValueChange={(v) => update({ outputMode: v as SqOutputMode })}>
+            <SelectTrigger className="flex-1"><SelectValue /></SelectTrigger>
+            <SelectContent>
+              <SelectItem value="none">None (read-only)</SelectItem>
+              <SelectItem value="append">Append</SelectItem>
+              <SelectItem value="replace">Replace partition</SelectItem>
+              <SelectItem value="upsert">Upsert (ReplacingMergeTree)</SelectItem>
+            </SelectContent>
+          </Select>
+          <Popover>
+            <PopoverTrigger asChild>
+              <button type="button" aria-label={`About ${modeHelp.title}`} className="grid h-7 w-7 shrink-0 place-items-center rounded-xs text-paper-faint hover:text-paper">
+                <Info className="h-4 w-4" />
+              </button>
+            </PopoverTrigger>
+            <PopoverContent align="end" side="top" className="w-80 space-y-2 rounded-xs border-ink-500 bg-ink-100 p-3 text-[11px] leading-relaxed text-paper-muted">
+              <p className="font-mono text-[10px] uppercase tracking-[0.14em] text-paper-faint">{modeHelp.title}</p>
+              <p><span className="text-paper">What:</span> {modeHelp.what}</p>
+              <p><span className="text-paper">When:</span> {modeHelp.when}</p>
+            </PopoverContent>
+          </Popover>
+        </div>
       </div>
       {form.outputMode !== "none" && (
         <>
@@ -541,12 +583,6 @@ function OutputStep({ form, update, preview, onPreview, previewing }: StepProps 
               <Input value={form.destTable} onChange={(e) => update({ destTable: e.target.value })} />
             </div>
           </div>
-          {form.outputMode === "replace" && (
-            <div className={sectionCls}>
-              <Label className={labelCls}>Partition expression</Label>
-              <Input value={form.partitionExpr} onChange={(e) => update({ partitionExpr: e.target.value })} placeholder="toYYYYMMDD({{slot_end}})" className="font-mono" />
-            </div>
-          )}
           <ToggleRow label="Create destination table if missing" checked={form.createIfMissing} onChange={(v) => update({ createIfMissing: v })} />
           <div className="space-y-3 border-t border-ink-500 pt-3">
             <p className="font-mono text-[10px] uppercase tracking-[0.14em] text-paper-faint">Read semantics</p>
@@ -564,16 +600,30 @@ function OutputStep({ form, update, preview, onPreview, previewing }: StepProps 
             />
           </div>
           {form.createIfMissing && (
-            <div className="flex gap-2">
-              <div className={cn(sectionCls, "flex-1")}>
-                <Label className={labelCls}>Engine</Label>
-                <Input value={form.engine} onChange={(e) => update({ engine: e.target.value })} />
+            <>
+              <div className="flex gap-2">
+                <div className={cn(sectionCls, "flex-1")}>
+                  <Label className={labelCls}>Engine</Label>
+                  <Input value={form.engine} onChange={(e) => update({ engine: e.target.value })} />
+                </div>
+                <div className={cn(sectionCls, "flex-1")}>
+                  <Label className={labelCls}>ORDER BY</Label>
+                  <Input value={form.orderBy} onChange={(e) => update({ orderBy: e.target.value })} />
+                </div>
               </div>
-              <div className={cn(sectionCls, "flex-1")}>
-                <Label className={labelCls}>ORDER BY</Label>
-                <Input value={form.orderBy} onChange={(e) => update({ orderBy: e.target.value })} />
-              </div>
-            </div>
+              {form.outputMode === "replace" ? (
+                <div className={sectionCls}>
+                  <Label className={labelCls}>Partition by</Label>
+                  <Input value={form.partitionExpr} onChange={(e) => update({ partitionExpr: e.target.value })} placeholder="toYYYYMMDD(event_time)" className="font-mono" />
+                  <p className="text-[11px] text-paper-muted">Required — the table is created partitioned by this expression so each run can swap whole partitions.</p>
+                </div>
+              ) : (
+                <div className={sectionCls}>
+                  <Label className={labelCls}>Partition by (optional)</Label>
+                  <Input value={form.partitionBy} onChange={(e) => update({ partitionBy: e.target.value })} placeholder="toYYYYMMDD(event_time)" className="font-mono" />
+                </div>
+              )}
+            </>
           )}
           <Button variant="outline" onClick={() => void onPreview()} disabled={previewing}>
             {previewing && <Loader2 className="mr-2 h-3.5 w-3.5 animate-spin" />}


### PR DESCRIPTION
## Description

Refinements to the (unreleased) Scheduled Queries materialize flow, addressing several issues found while exercising the Replace-partition output mode.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Related Issue

Closes #

## Changes Made

- **Partition input now reflected in the generated DDL.** `buildCreateTableDDL` only read `partitionBy`, but the Replace form writes the user's input to `partitionExpr` (there is no `partitionBy` UI input), so the `CREATE TABLE` preview always emitted an empty `PARTITION BY`. It now prefers `partitionBy` and falls back to `partitionExpr`, so what the user types is reflected — and a create-if-missing destination actually gets a partition key (required by the engine-fit check for replace).
- **`__sq_staging` no longer retains data between runs.** The staging table is intentionally kept and reused (`CREATE TABLE IF NOT EXISTS … AS <dest>` + `TRUNCATE`), but after the `REPLACE PARTITION` swaps it held a redundant full copy of the run's output until the next run truncated it. A best-effort `TRUNCATE` now runs right after the swaps to free that storage immediately (non-fatal; the next run truncates anyway).
- **Output-mode info popover.** Added an `i` popover to the right of the Output mode selector that explains *what* each mode does and *when* to use it (none / append / replace / upsert), reacting to the current selection.
- **Consistent partition input across modes.** Create-if-missing now exposes an optional **Partition by** input for append/upsert, and the replace partition expression moved into that same block (required only when creating the table). Server validation was relaxed to match: replace requires `partitionExpr` only with create-if-missing — when the destination already exists, its real partition key is used and enforced by the engine-fit check at run/preview time.

## Testing

- [x] I have tested this locally
- [ ] I have added/updated tests
- [x] All existing tests pass

### Test Steps

- `bun run typecheck` — clean
- `bun run lint` — clean

## Changelog Fragment

Not required — these are refinements to the Scheduled Queries feature, which is still unreleased (its fragment already lives in `changelogs/unreleased/scheduled-queries.md`), so they ride that fragment's release.

## Additional Notes

Replace still stores its partition into `partitionExpr` while append/upsert use `partitionBy`; they remain separate config keys (DDL prefers `partitionBy`, falls back to `partitionExpr`) so existing jobs keep working. These can be collapsed into a single `partitionBy` key while the feature is unreleased if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)