### PR TITLE
docs(portfolio): surface Scheduled Queries (DataOps) on the marketing site

### DIFF
--- a/docs/portfolio/src/components/Features.tsx
+++ b/docs/portfolio/src/components/Features.tsx
@@ -5,6 +5,7 @@ import {
   Download, Settings, Eye, Plus, Minus, Activity, Star, Sparkles, Bot, MessageSquare,
   Gauge, MemoryStick, Layers, Stethoscope, Network, SunMoon,
   LayoutGrid, BellRing, TableProperties, Radar,
+  CalendarClock, Clock, GitBranch, RefreshCw, ListChecks,
   type LucideIcon,
 } from "lucide-react";
 import { Section, Container, SectionHeader } from "./Section";
@@ -41,6 +42,18 @@ const GROUPS: FeatureGroup[] = [
       { icon: Zap, title: "Optimize from logs", desc: "Optimize any logged query with Chouse AI — a rewrite with the same result, a before→after EXPLAIN estimate, and one click to open it in the Explorer" },
       { icon: Bot, title: "Diagnose errors & parts", desc: "One-click Chouse AI on a system.errors row or a part-log entry → cause, impact, and ordered fixes (merge pressure, too many parts, partition key)" },
       { icon: MessageSquare, title: "Chat copilot", desc: "Conversational data exploration and chart building against a connection" },
+    ],
+  },
+  {
+    category: "DataOps & Scheduling",
+    icon: CalendarClock,
+    items: [
+      { icon: CalendarClock, title: "Scheduled Queries", desc: "Schedule any read-only SELECT on a daily / weekly / monthly preset or a custom UTC cron — a DataOps page with Overview, Jobs, and Runs" },
+      { icon: Clock, title: "Deterministic windows", desc: "Templated {{slot_start}} / {{slot_end}} / {{prev_run_at}} bind to each run's exact time window, so backfills and replays are reproducible" },
+      { icon: RefreshCw, title: "Materialize write-back", desc: "Optional engine-generated, idempotent write into a destination table — append, replace-partition, or upsert — alongside bounded result snapshots" },
+      { icon: BellRing, title: "Failure alerting", desc: "Transition-based notifications to linked channels on failure and once on recovery — no flapping" },
+      { icon: GitBranch, title: "Runtime Lineage", desc: "Graphs the tables a job actually reads and writes from system.query_log, chaining jobs together and revealing column-level flow on demand" },
+      { icon: ListChecks, title: "Replica-safe scheduler", desc: "In-process per-job-lease scheduler correct across replicas with no leader election, plus a crash-only reaper, bounded retry, and transactional outbox" },
     ],
   },
   {
@@ -112,7 +125,7 @@ export default function Features() {
           eyebrow="What's inside"
           eyebrowIndex={2}
           title="Everything you need to give ClickHouse to a team."
-          description="Seven domains, one consistent UI. Click a category to expand its items."
+          description="Eight domains, one consistent UI. Click a category to expand its items."
         />
 
         <div className="mt-16 grid grid-cols-12 gap-x-6 gap-y-4">

--- a/docs/portfolio/src/components/Highlights.tsx
+++ b/docs/portfolio/src/components/Highlights.tsx
@@ -1,4 +1,4 @@
-import { Shield, Users, FileText, LayoutGrid, Stethoscope, Activity, type LucideIcon } from "lucide-react";
+import { Shield, Users, FileText, LayoutGrid, Stethoscope, Activity, CalendarClock, KeyRound, type LucideIcon } from "lucide-react";
 import { motion } from "framer-motion";
 import { Section, Container, SectionHeader } from "./Section";
 
@@ -9,8 +9,8 @@ interface Highlight {
   meta: string;
 }
 
-// The six pillars that make up the "combination" — a team access layer
-// (security / RBAC / audit) × fleet monitoring × an autonomous AI SRE.
+// The pillars that make up the "combination" — a team access layer
+// (security / RBAC / audit) × fleet monitoring × an autonomous AI SRE × scheduled DataOps.
 const HIGHLIGHTS: Highlight[] = [
   {
     icon: Shield,
@@ -48,6 +48,18 @@ const HIGHLIGHTS: Highlight[] = [
     description: "ClickHouse-native monitoring — query logs, memory breakdown, top-resource queries, replica lag, schema lints. No exporter to install.",
     meta: "No exporter",
   },
+  {
+    icon: CalendarClock,
+    title: "Scheduled queries",
+    description: "Cron-scheduled read-only SELECTs with deterministic time windows, idempotent materialize write-back, failure alerting, and runtime lineage — DataOps without a separate orchestrator.",
+    meta: "Built-in DataOps",
+  },
+  {
+    icon: KeyRound,
+    title: "SSO / OIDC",
+    description: "Sign in with any OIDC or OAuth2 provider — JIT user provisioning, email-based account linking, and optional IdP group → role sync.",
+    meta: "Any provider",
+  },
 ];
 
 export default function Highlights() {
@@ -61,7 +73,7 @@ export default function Highlights() {
           description="Plenty of ClickHouse tools nail one of these — CHouse UI is the combination. The things that matter when money or compliance is on the line."
         />
 
-        <div className="mt-16 grid grid-cols-1 gap-px overflow-hidden rounded-md border border-ink-500 bg-ink-500 sm:grid-cols-2 lg:grid-cols-3">
+        <div className="mt-16 grid grid-cols-1 gap-px overflow-hidden rounded-md border border-ink-500 bg-ink-500 sm:grid-cols-2 lg:grid-cols-4">
           {HIGHLIGHTS.map((h, idx) => {
             const Icon = h.icon;
             return (
@@ -70,7 +82,7 @@ export default function Highlights() {
                 initial={{ opacity: 0, y: 12 }}
                 whileInView={{ opacity: 1, y: 0 }}
                 viewport={{ once: true, margin: "-80px" }}
-                transition={{ duration: 0.5, delay: (idx % 3) * 0.06, ease: [0.16, 1, 0.3, 1] }}
+                transition={{ duration: 0.5, delay: (idx % 4) * 0.06, ease: [0.16, 1, 0.3, 1] }}
                 className="group flex flex-col gap-6 bg-ink-100 p-6 transition-colors hover:bg-ink-200 md:p-8"
               >
                 <div className="flex items-center justify-between">


### PR DESCRIPTION
## Description

Surfaces the new **Scheduled Queries (DataOps)** feature on the portfolio/docs marketing site so it's reflected on the public landing page.

## Type of Change

- [x] Documentation update

## Related Issue

N/A

## Changes Made

- **Features section** (`Features.tsx`): new **DataOps & Scheduling** category with six items — Scheduled Queries, deterministic windows (`{{slot_start}}`/`{{slot_end}}`/`{{prev_run_at}}`), materialize write-back, failure alerting, Runtime Lineage, and the replica-safe scheduler. Bumped the section copy from "Seven domains" → "Eight domains".
- **Highlights section** (`Highlights.tsx`): added **Scheduled queries** and **SSO / OIDC** pillars, then switched the grid from 3 to 4 columns so all eight cards fill two even rows with no empty cells.

## Testing

- [x] I have tested this locally
- [ ] I have added/updated tests
- [x] All existing tests pass

### Test Steps

- `bunx tsc --noEmit` in `docs/portfolio` passes.

## Screenshots

N/A — content/layout only; copy mirrors the existing `changelogs/unreleased/scheduled-queries.md` fragment.

## Changelog Fragment

Not applicable — docs/marketing-site only; the feature's own changelog fragment already exists at `changelogs/unreleased/scheduled-queries.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)