### PR TITLE
Hide guide-only UI outside active onboarding chapters

### DIFF
--- a/src/components/common/AiChatBubble.tsx
+++ b/src/components/common/AiChatBubble.tsx
@@ -42,6 +42,7 @@ import {
 import { toast } from 'sonner';
 import { log } from '@/lib/log';
 import { useOnboardingSurfaceDismissAction } from '@/lib/onboardingSurfaces';
+import { useOnboardingGuideActive } from '@/features/onboarding';
 import { AiChartRenderer } from '@/components/common/AiChartRenderer';
 import {
     MessageSquare,
@@ -951,6 +952,7 @@ function AiChatUnavailableTrigger({ isLoading, isMobile }: AiChatUnavailableTrig
 
 export default function AiChatBubble() {
     const hasPermission = useRbacStore((s) => s.hasPermission(RBAC_PERMISSIONS.AI_CHAT));
+    const guideActive = useOnboardingGuideActive();
     const activeConnectionId = useAuthStore((s) => s.activeConnectionId);
     const [aiEnabled, setAiEnabled] = useState<boolean | null>(null);
     const [aiModels, setAiModels] = useState<AiModelSimple[]>([]);
@@ -1438,12 +1440,14 @@ export default function AiChatBubble() {
         await runInvoke(threadId, prompt, [{ role: 'user', content: prompt }]);
     }, [isInvoking, activeThreadId, runInvoke, activeConnectionId, selectedModelId]);
 
-    // Permission controls whether the guide includes this step. When AI status is
-    // unresolved or disabled, keep a stable shell so the step never points at an
-    // element that appears late or does not exist on a fresh installation.
     if (!hasPermission) return null;
     if (aiEnabled !== true) {
-        return <AiChatUnavailableTrigger isLoading={aiEnabled === null} isMobile={isMobile} />;
+        // While a guide chapter runs, keep a disabled shell so the AI step never
+        // points at an element that appears late or does not exist on a fresh
+        // installation. Outside guides, an unavailable assistant renders nothing.
+        return guideActive
+            ? <AiChatUnavailableTrigger isLoading={aiEnabled === null} isMobile={isMobile} />
+            : null;
     }
 
     return (

--- a/src/features/data-health/DatasetsTab.test.tsx
+++ b/src/features/data-health/DatasetsTab.test.tsx
@@ -1,7 +1,13 @@
 import { fireEvent, render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { DatasetsTab } from "./DatasetsTab";
+
+const guideActiveMock = vi.fn<() => boolean>(() => false);
+
+vi.mock("@/features/onboarding", () => ({
+  useOnboardingGuideActive: () => guideActiveMock(),
+}));
 
 vi.mock("@/stores", () => ({
   RBAC_PERMISSIONS: {
@@ -16,8 +22,11 @@ vi.mock("@/stores", () => ({
 vi.mock("@/features/data-health/hooks", () => ({
   useDataHealthPromises: () => ({
     data: [{
+      checks: [],
+      criticality: "high",
       databaseName: "analytics",
       id: "promise-1",
+      lastHealthyAt: null,
       name: "Orders are fresh",
       status: "healthy",
       tableName: "orders",
@@ -37,11 +46,31 @@ vi.mock("@/features/data-health/PromiseWizard", () => ({
 }));
 
 describe("DatasetsTab onboarding targets", () => {
-  it("keeps the create target available while a promise detail is selected", () => {
+  beforeEach(() => {
+    guideActiveMock.mockReturnValue(false);
+  });
+
+  it("keeps the create target available while a promise detail is selected during a guide", () => {
+    guideActiveMock.mockReturnValue(true);
     render(<DatasetsTab selectedPromiseId="promise-1" onSelectedPromiseChange={vi.fn()} />);
 
     const target = document.querySelector('[data-onboarding-id="dataops-health-create"]');
     expect(target).not.toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: "New promise" }));
+    expect(screen.getByText("New promise wizard")).toBeTruthy();
+  });
+
+  it("hides the detail-view create button when no guide is running", () => {
+    render(<DatasetsTab selectedPromiseId="promise-1" onSelectedPromiseChange={vi.fn()} />);
+
+    expect(screen.getByText("Selected promise detail")).toBeTruthy();
+    expect(document.querySelector('[data-onboarding-id="dataops-health-create"]')).toBeNull();
+    expect(screen.queryByRole("button", { name: "New promise" })).toBeNull();
+  });
+
+  it("still offers the create button on the list view without a guide", () => {
+    render(<DatasetsTab onSelectedPromiseChange={vi.fn()} />);
+
     fireEvent.click(screen.getByRole("button", { name: "New promise" }));
     expect(screen.getByText("New promise wizard")).toBeTruthy();
   });

--- a/src/features/data-health/DatasetsTab.tsx
+++ b/src/features/data-health/DatasetsTab.tsx
@@ -7,6 +7,7 @@ import { Card } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle } from "@/components/ui/alert-dialog";
+import { useOnboardingGuideActive } from "@/features/onboarding";
 import { useRbacStore, RBAC_PERMISSIONS } from "@/stores";
 import type { DataHealthPromise } from "@/api/dataHealth";
 import { useDataHealthPromises, useDeleteDataHealthPromise, useRunDataHealthPromise } from "./hooks";
@@ -19,6 +20,7 @@ export function DatasetsTab({ selectedPromiseId, onSelectedPromiseChange }: { se
   const canEdit = useRbacStore((state) => state.hasPermission(RBAC_PERMISSIONS.DATA_HEALTH_EDIT));
   const canRun = useRbacStore((state) => state.hasPermission(RBAC_PERMISSIONS.DATA_HEALTH_RUN));
   const canDelete = useRbacStore((state) => state.hasPermission(RBAC_PERMISSIONS.DATA_HEALTH_DELETE));
+  const guideActive = useOnboardingGuideActive();
   const runMutation = useRunDataHealthPromise();
   const deleteMutation = useDeleteDataHealthPromise();
   const [search, setSearch] = useState("");
@@ -41,7 +43,9 @@ export function DatasetsTab({ selectedPromiseId, onSelectedPromiseChange }: { se
   if (selected) {
     return (
       <div className="space-y-4">
-        {canEdit && (
+        {/* Guide anchor only: the "create" step must resolve even while a
+            promise detail replaces the list view. Hidden outside guides. */}
+        {canEdit && guideActive && (
           <div className="flex justify-end">
             <Button
               data-onboarding-id="dataops-health-create"

--- a/src/features/onboarding/index.ts
+++ b/src/features/onboarding/index.ts
@@ -1,4 +1,5 @@
 export { OnboardingProvider } from "./OnboardingProvider";
+export { useOnboardingGuideActive } from "./store";
 export {
   AUTHENTICATED_ROUTE_INVENTORY,
   NON_GUIDED_ROUTE_INVENTORY,

--- a/src/features/onboarding/store.test.ts
+++ b/src/features/onboarding/store.test.ts
@@ -55,6 +55,18 @@ describe("onboarding store", () => {
     useOnboardingStore.getState().reset();
   });
 
+  it("useOnboardingGuideActive tracks whether a chapter is running", async () => {
+    const { useOnboardingGuideActive, useOnboardingStore } = await import("./store");
+    const { act, renderHook } = await import("@testing-library/react");
+    const { result } = renderHook(() => useOnboardingGuideActive());
+
+    expect(result.current).toBe(false);
+    act(() => useOnboardingStore.setState({ activeChapterId: "explorer" }));
+    expect(result.current).toBe(true);
+    act(() => useOnboardingStore.setState({ activeChapterId: null }));
+    expect(result.current).toBe(false);
+  });
+
   it("loads server progress and opens the hub for a new user", async () => {
     const { useOnboardingStore } = await import("./store");
     await useOnboardingStore.getState().initialize("user-1");

--- a/src/features/onboarding/store.ts
+++ b/src/features/onboarding/store.ts
@@ -462,3 +462,12 @@ export const useOnboardingStore = create<OnboardingState>((set, get) => ({
 
   clearPersistenceError: (): void => set({ persistenceError: null }),
 }));
+
+/**
+ * Whether a contextual guide chapter is currently running. UI that exists only
+ * to give a guide step a stable anchor (e.g. duplicate create buttons on detail
+ * views) should render only while this is true.
+ */
+export function useOnboardingGuideActive(): boolean {
+  return useOnboardingStore((state) => state.activeChapterId !== null);
+}

--- a/src/features/scheduled-queries/JobsTab.test.tsx
+++ b/src/features/scheduled-queries/JobsTab.test.tsx
@@ -1,7 +1,13 @@
 import { fireEvent, render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { JobsTab } from "./JobsTab";
+
+const guideActiveMock = vi.fn<() => boolean>(() => false);
+
+vi.mock("@/features/onboarding", () => ({
+  useOnboardingGuideActive: () => guideActiveMock(),
+}));
 
 vi.mock("@/stores", () => ({
   RBAC_PERMISSIONS: {
@@ -39,11 +45,31 @@ vi.mock("@/features/scheduled-queries/JobWizard", () => ({
 }));
 
 describe("JobsTab onboarding targets", () => {
-  it("keeps the create target available while a job detail is selected", () => {
+  beforeEach(() => {
+    guideActiveMock.mockReturnValue(false);
+  });
+
+  it("keeps the create target available while a job detail is selected during a guide", () => {
+    guideActiveMock.mockReturnValue(true);
     render(<JobsTab selectedJobId="job-1" onSelectedJobChange={vi.fn()} />);
 
     const target = document.querySelector('[data-onboarding-id="dataops-scheduled-create"]');
     expect(target).not.toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: "New job" }));
+    expect(screen.getByText("New job wizard")).toBeTruthy();
+  });
+
+  it("hides the detail-view create button when no guide is running", () => {
+    render(<JobsTab selectedJobId="job-1" onSelectedJobChange={vi.fn()} />);
+
+    expect(screen.getByText("Selected job detail")).toBeTruthy();
+    expect(document.querySelector('[data-onboarding-id="dataops-scheduled-create"]')).toBeNull();
+    expect(screen.queryByRole("button", { name: "New job" })).toBeNull();
+  });
+
+  it("still offers the create button on the list view without a guide", () => {
+    render(<JobsTab onSelectedJobChange={vi.fn()} />);
+
     fireEvent.click(screen.getByRole("button", { name: "New job" }));
     expect(screen.getByText("New job wizard")).toBeTruthy();
   });

--- a/src/features/scheduled-queries/JobsTab.tsx
+++ b/src/features/scheduled-queries/JobsTab.tsx
@@ -30,6 +30,7 @@ import {
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
 import { cn } from "@/lib/utils";
+import { useOnboardingGuideActive } from "@/features/onboarding";
 import { useRbacStore, RBAC_PERMISSIONS } from "@/stores";
 import type { ScheduledQuery } from "@/api/scheduledQueries";
 import { useScheduledQueries, useDeleteScheduledQuery, useRunScheduledQuery, useUpdateScheduledQuery, useJobOwners } from "./hooks";
@@ -57,6 +58,7 @@ export function JobsTab({ selectedJobId, onSelectedJobChange }: { selectedJobId?
   const canDelete = hasPermission(RBAC_PERMISSIONS.SCHEDULED_QUERIES_DELETE);
   const canRun = hasPermission(RBAC_PERMISSIONS.SCHEDULED_QUERIES_RUN);
   const canViewAll = hasPermission(RBAC_PERMISSIONS.SCHEDULED_QUERIES_VIEW_ALL);
+  const guideActive = useOnboardingGuideActive();
 
   const { data: jobs, isLoading } = useScheduledQueries();
   const { options: ownerOptions, nameOf: ownerName } = useJobOwners(jobs, canViewAll);
@@ -139,7 +141,9 @@ export function JobsTab({ selectedJobId, onSelectedJobChange }: { selectedJobId?
   if (selectedJob) {
     return (
       <div className="space-y-4">
-        {canEdit && (
+        {/* Guide anchor only: the "create" step must resolve even while a job
+            detail replaces the list view. Hidden outside contextual guides. */}
+        {canEdit && guideActive && (
           <div className="flex justify-end">
             <Button
               data-onboarding-id="dataops-scheduled-create"


### PR DESCRIPTION
## Description

The unified onboarding feature (#303) added a few UI elements purely so guide steps always had a stable anchor to target. Because they weren't gated on the guide actually running, they rendered for every user at all times:

- A duplicate "New job" button on the Scheduled Query job detail view
- A duplicate "New promise" button on the Data Health promise detail view
- A permanently disabled AI-assistant trigger shown whenever AI is unavailable/loading

This PR gates all three behind whether an onboarding chapter is currently active, so they only appear while a guide step needs them.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- Added `useOnboardingGuideActive()` to `src/features/onboarding/store.ts` (exported via the feature barrel), reading `activeChapterId !== null` from the onboarding store.
- `JobsTab.tsx`: the detail-view "New job" button now renders only when `canEdit && guideActive`.
- `DatasetsTab.tsx`: the detail-view "New promise" button now renders only when `canEdit && guideActive`.
- `AiChatBubble.tsx`: the disabled `AiChatUnavailableTrigger` shell now renders only when `guideActive`; otherwise nothing renders when AI is off/loading, matching pre-onboarding behavior.
- Updated `JobsTab.test.tsx` and `DatasetsTab.test.tsx` to cover both guide-active (anchor present) and guide-inactive (button hidden) states, plus the list view still offering create unconditionally.
- Added a `store.test.ts` case for the new hook.

## Testing

- [x] I have tested this locally
- [x] I have added/updated tests
- [x] All existing tests pass

### Test Steps

1. `bun run typecheck` / `bun run lint` — clean.
2. `bunx vitest run --dir src` — 549/549 passing.
3. Manually verified in the running app (`bun run dev`):
   - Opened a scheduled query's detail view with no guide running → no "New job" button.
   - Restarted the "Automate data operations" onboarding chapter with that same detail still open → the "New job" anchor reappeared and the coachmark correctly highlighted it on the "Create with five review points" step.
   - Exited the guide → button disappeared again.
   - Repeated the no-guide check on a Data Health promise detail view → no "New promise" button.

## Changelog Fragment

Skipped — internal fix to onboarding-only UI, not a new user-visible change (the original feature already shipped in #303 without a fragment for this bug).

## Checklist

- [x] My code follows the project's code style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] I have tested the changes in the relevant environment (development)