### PR TITLE
Fix provider-neutral AI structured output

### DIFF
--- a/changelogs/unreleased/000-provider-neutral-ai-structured-output.md
+++ b/changelogs/unreleased/000-provider-neutral-ai-structured-output.md
@@ -1,0 +1,4 @@
+type: patch
+
+### Fixed
+- **Provider-neutral AI structured output** — Scheduled Queries, Data Health, and other structured AI features now negotiate bounded native, tool-calling, and schema-guided JSON strategies without masking authentication, throttling, or timeout errors. Administrators can optionally override the strategy per model from AI settings.

--- a/packages/server/src/rbac/constants/aiModelParams.test.ts
+++ b/packages/server/src/rbac/constants/aiModelParams.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'bun:test';
 import {
   EXTRA_MAX_KEYS,
   PROVIDER_PARAM_KEYS,
+  STRUCTURED_OUTPUT_POLICIES,
   hasAnyParams,
   validateAiModelParams,
   type AiModelParams,
@@ -34,6 +35,7 @@ const cases: Case[] = [
       requestTimeoutMs: 60_000,
       recursionLimit: 64,
       runTimeoutMs: 120_000,
+      structuredOutputPolicy: 'auto',
       extra: { seed: 42, logprobs: true },
     },
     expectErrors: false,
@@ -130,6 +132,7 @@ const cases: Case[] = [
 
   // Empty object is valid everywhere
   { name: 'empty params valid', providerType: 'anthropic', params: {}, expectErrors: false },
+  { name: 'plain structured output works for google', providerType: 'google', params: { structuredOutputPolicy: 'plain' }, expectErrors: false },
 ];
 
 describe('validateAiModelParams', () => {
@@ -153,12 +156,26 @@ describe('PROVIDER_PARAM_KEYS', () => {
     for (const [providerType, keys] of Object.entries(PROVIDER_PARAM_KEYS)) {
       expect(keys).toContain('recursionLimit');
       expect(keys).toContain('runTimeoutMs');
+      expect(keys).toContain('structuredOutputPolicy');
       expect(keys).toContain('temperature');
       // ChatCohere's constructor exposes no output-token cap.
       if (providerType !== 'cohere') {
         expect(keys).toContain('maxTokens');
       }
     }
+  });
+
+  it('allows every structured-output policy for every provider', () => {
+    for (const providerType of Object.keys(PROVIDER_PARAM_KEYS) as ProviderType[]) {
+      for (const structuredOutputPolicy of STRUCTURED_OUTPUT_POLICIES) {
+        expect(validateAiModelParams({ structuredOutputPolicy }, providerType)).toEqual([]);
+      }
+    }
+  });
+
+  it('rejects an invalid structured-output policy defensively', () => {
+    const params: AiModelParams = JSON.parse('{"structuredOutputPolicy":"invalid"}');
+    expect(validateAiModelParams(params, 'openai').join('; ')).toContain('structuredOutputPolicy');
   });
 });
 

--- a/packages/server/src/rbac/constants/aiModelParams.ts
+++ b/packages/server/src/rbac/constants/aiModelParams.ts
@@ -14,6 +14,12 @@ import type { ProviderType } from './aiProviders';
 
 export type ReasoningEffort = 'minimal' | 'low' | 'medium' | 'high';
 export type Verbosity = 'low' | 'medium' | 'high';
+export const STRUCTURED_OUTPUT_POLICIES = ['auto', 'native', 'tool', 'json', 'plain'] as const;
+export type StructuredOutputPolicy = (typeof STRUCTURED_OUTPUT_POLICIES)[number];
+
+export function isStructuredOutputPolicy(value: unknown): value is StructuredOutputPolicy {
+  return typeof value === 'string' && STRUCTURED_OUTPUT_POLICIES.some((policy) => policy === value);
+}
 
 export interface AiSafetySetting {
   category: string;
@@ -71,6 +77,8 @@ export interface AiModelParams {
   recursionLimit?: number;
   /** Wall-clock budget per agent run in ms. Overrides both built-in run timeouts. */
   runTimeoutMs?: number;
+  /** Preferred structured-output strategy. `auto` negotiates with safe fallbacks. */
+  structuredOutputPolicy?: StructuredOutputPolicy;
 
   // — Escape hatch —
   /**
@@ -82,14 +90,19 @@ export interface AiModelParams {
 
 export type AiModelParamKey = keyof AiModelParams;
 
+const ENGINE_KEYS: readonly AiModelParamKey[] = [
+  'recursionLimit',
+  'runTimeoutMs',
+  'structuredOutputPolicy',
+];
+
 const COMMON_KEYS: readonly AiModelParamKey[] = [
   'temperature',
   'topP',
   'maxTokens',
   'stopSequences',
   'maxRetries',
-  'recursionLimit',
-  'runTimeoutMs',
+  ...ENGINE_KEYS,
 ];
 
 const OPENAI_FAMILY_KEYS: readonly AiModelParamKey[] = [
@@ -113,13 +126,13 @@ export const PROVIDER_PARAM_KEYS: Record<ProviderType, readonly AiModelParamKey[
   'google': [...COMMON_KEYS, 'topK', 'thinkingBudgetTokens', 'apiVersion', 'safetySettings'],
   'azure-openai': [...OPENAI_FAMILY_KEYS, 'apiVersion'],
   'groq': [...COMMON_KEYS, 'requestTimeoutMs'],
-  'mistral': ['temperature', 'topP', 'maxTokens', 'maxRetries', 'recursionLimit', 'runTimeoutMs'],
-  'cohere': ['temperature', 'maxRetries', 'recursionLimit', 'runTimeoutMs'],
+  'mistral': ['temperature', 'topP', 'maxTokens', 'maxRetries', ...ENGINE_KEYS],
+  'cohere': ['temperature', 'maxRetries', ...ENGINE_KEYS],
   'ollama': [...COMMON_KEYS, 'topK'],
-  'xai': ['temperature', 'maxTokens', 'stopSequences', 'maxRetries', 'recursionLimit', 'runTimeoutMs'],
+  'xai': ['temperature', 'maxTokens', 'stopSequences', 'maxRetries', ...ENGINE_KEYS],
   'deepseek': [...COMMON_KEYS, 'frequencyPenalty', 'presencePenalty', 'requestTimeoutMs', 'extra'],
-  'cerebras': ['temperature', 'topP', 'maxTokens', 'maxRetries', 'requestTimeoutMs', 'recursionLimit', 'runTimeoutMs'],
-  'bedrock': ['temperature', 'topP', 'maxTokens', 'maxRetries', 'recursionLimit', 'runTimeoutMs'],
+  'cerebras': ['temperature', 'topP', 'maxTokens', 'maxRetries', 'requestTimeoutMs', ...ENGINE_KEYS],
+  'bedrock': ['temperature', 'topP', 'maxTokens', 'maxRetries', ...ENGINE_KEYS],
   'fireworks': OPENAI_FAMILY_KEYS,
   'together': OPENAI_FAMILY_KEYS,
   'openrouter': OPENAI_FAMILY_KEYS,
@@ -227,6 +240,11 @@ export function validateAiModelParams(params: AiModelParams, providerType: Provi
     if (value < bounds.min || value > bounds.max) {
       errors.push(`'${key}' must be between ${bounds.min} and ${bounds.max}`);
     }
+  }
+
+  if (params.structuredOutputPolicy !== undefined
+      && !isStructuredOutputPolicy(params.structuredOutputPolicy)) {
+    errors.push(`'structuredOutputPolicy' must be one of: ${STRUCTURED_OUTPUT_POLICIES.join(', ')}`);
   }
 
   // Per-provider tightenings on top of the generic bounds.

--- a/packages/server/src/rbac/routes/aiModels.test.ts
+++ b/packages/server/src/rbac/routes/aiModels.test.ts
@@ -102,7 +102,7 @@ describe("RBAC AI Models Routes · params", () => {
 
     describe("POST /", () => {
         it("accepts valid openai params and passes them to the service", async () => {
-            const params = { temperature: 0.7, maxTokens: 4096, recursionLimit: 64, extra: { seed: 42 } };
+            const params = { temperature: 0.7, maxTokens: 4096, recursionLimit: 64, structuredOutputPolicy: "auto", extra: { seed: 42 } };
             const res = await post(app, { providerId: "prov-openai", name: "GPT-4o", modelId: "gpt-4o", params });
             expect(res.status).toBe(201);
             expect(mockCreateAiModel).toHaveBeenCalledWith(expect.objectContaining({ params }));
@@ -117,6 +117,12 @@ describe("RBAC AI Models Routes · params", () => {
 
         it("rejects unknown param keys at the schema layer", async () => {
             const res = await post(app, { providerId: "prov-openai", name: "X", modelId: "x", params: { bogus: 1 } });
+            expect(res.status).toBe(400);
+            expect(mockCreateAiModel).not.toHaveBeenCalled();
+        });
+
+        it("rejects an unknown structured-output policy at the schema layer", async () => {
+            const res = await post(app, { providerId: "prov-openai", name: "X", modelId: "x", params: { structuredOutputPolicy: "magic" } });
             expect(res.status).toBe(400);
             expect(mockCreateAiModel).not.toHaveBeenCalled();
         });

--- a/packages/server/src/rbac/routes/aiModels.ts
+++ b/packages/server/src/rbac/routes/aiModels.ts
@@ -16,7 +16,11 @@ import {
     updateAiModel,
     deleteAiModel,
 } from '../services/aiModels';
-import { validateAiModelParams, type AiModelParams } from '../constants/aiModelParams';
+import {
+    STRUCTURED_OUTPUT_POLICIES,
+    validateAiModelParams,
+    type AiModelParams,
+} from '../constants/aiModelParams';
 import { rbacAuthMiddleware, requirePermission, getRbacUser, getClientIp } from '../middleware';
 import { createAuditLogWithContext } from '../services/rbac';
 import { AUDIT_ACTIONS, PERMISSIONS } from '../schema/base';
@@ -44,6 +48,7 @@ const aiModelParamsSchema = z.object({
     safetySettings: z.array(z.object({ category: z.string().min(1), threshold: z.string().min(1) }).strict()).max(10).optional(),
     recursionLimit: z.number().int().min(8).max(1000).optional(),
     runTimeoutMs: z.number().int().min(10_000).max(3_600_000).optional(),
+    structuredOutputPolicy: z.enum(STRUCTURED_OUTPUT_POLICIES).optional(),
     extra: z.record(z.unknown()).optional(),
 }).strict();
 

--- a/packages/server/src/services/ai/engine.test.ts
+++ b/packages/server/src/services/ai/engine.test.ts
@@ -23,9 +23,15 @@ mock.module("deepagents", () => ({
 
 // Mutable so individual tests can attach per-model runtime params.
 let modelParams: Record<string, unknown> | null = null;
+let fallbackModelResult: unknown = { content: "still not json" };
+let fallbackWithStructuredOutput: ((...args: unknown[]) => unknown) | undefined;
+const fallbackModelInvokeMock = mock(async () => fallbackModelResult);
 mock.module("./model", () => ({
   resolveDeepAgentModel: mock(async () => ({
-    model: {},
+    model: {
+      invoke: fallbackModelInvokeMock,
+      ...(fallbackWithStructuredOutput ? { withStructuredOutput: fallbackWithStructuredOutput } : {}),
+    },
     config: { model: { modelId: "gpt-4o", params: modelParams }, provider: { providerType: "openai" } },
     label: "test-model",
   })),
@@ -76,9 +82,12 @@ describe("runStructuredCapability", () => {
     const config = createDeepAgentMock.mock.calls.at(-1)?.[0] as {
       responseFormat?: unknown;
       subagents?: unknown[];
+      systemPrompt?: string;
     };
     expect(config.responseFormat).toBeUndefined();
     expect(config.subagents).toEqual([]);
+    expect(config.systemPrompt).toContain("The final answer must match this JSON Schema exactly");
+    expect(config.systemPrompt).toContain('"foo"');
     expect(registerHarnessProfileMock).toHaveBeenCalled();
     const [, profile] = registerHarnessProfileMock.mock.calls[0] as [
       string,
@@ -102,6 +111,26 @@ describe("runStructuredCapability", () => {
 
     expect(onParseFailure).toHaveBeenCalled();
     expect(output).toEqual({ foo: "recovered" });
+    const agentSignal = (invokeMock.mock.calls.at(-1)?.[1] as { signal?: AbortSignal })?.signal;
+    const fallbackSignal = (fallbackModelInvokeMock.mock.calls.at(-1)?.[1] as { signal?: AbortSignal })?.signal;
+    expect(fallbackSignal).toBe(agentSignal);
+  });
+
+  it("keeps large schemas out of the initial agent prompt", async () => {
+    invokeResult = { messages: [{ content: '{"foo":"from-text"}' }] };
+    const largeSchema = OutputSchema.describe("large schema ".repeat(500));
+
+    await runStructuredCapability(
+      fakeStructuredCapability({ outputSchema: largeSchema }),
+      { q: "hi" },
+      CTX,
+    );
+
+    const config = createDeepAgentMock.mock.calls.at(-1)?.[0] as { systemPrompt?: string };
+    expect(config.systemPrompt).toContain("dedicated formatter will enforce the complete schema");
+    expect(config.systemPrompt).toContain("top-level keys: foo");
+    expect(config.systemPrompt).not.toContain("large schema large schema");
+    expect(config.systemPrompt?.length).toBeLessThan(2_500);
   });
 
   it("returns an evidence-keyed cached result before creating an agent", async () => {
@@ -174,6 +203,28 @@ describe("per-model runtime overrides", () => {
       expect(cfg.signal).toBeInstanceOf(AbortSignal);
     } finally {
       modelParams = null;
+    }
+  });
+
+  it("applies the per-model structured-output policy to structured runs", async () => {
+    const methods: Array<string | undefined> = [];
+    modelParams = { structuredOutputPolicy: "tool" };
+    fallbackWithStructuredOutput = ((_schema: unknown, options: unknown) => {
+      const method = (options as { method?: string } | undefined)?.method;
+      methods.push(method);
+      return { invoke: async () => ({ foo: method }) };
+    }) as (...args: unknown[]) => unknown;
+    try {
+      invokeResult = { messages: [{ content: "not json" }] };
+
+      const output = await runStructuredCapability(fakeStructuredCapability(), { q: "hi" }, CTX);
+
+      expect(output).toEqual({ foo: "functionCalling" });
+      expect(methods).toEqual(["functionCalling"]);
+    } finally {
+      modelParams = null;
+      fallbackWithStructuredOutput = undefined;
+      fallbackModelResult = { content: "still not json" };
     }
   });
 });

--- a/packages/server/src/services/ai/engine.ts
+++ b/packages/server/src/services/ai/engine.ts
@@ -14,6 +14,9 @@ import {
   type FilesystemPermission,
 } from "deepagents";
 import { tool } from "@langchain/core/tools";
+import { toJsonSchema } from "@langchain/core/utils/json_schema";
+import type { ZodType, ZodTypeDef } from "zod";
+import { isStructuredOutputPolicy } from "../../rbac/constants/aiModelParams";
 import { AppError } from "../../types";
 import { resolveDeepAgentModel } from "./model";
 import { structuredOutput } from "./structuredOutput";
@@ -85,6 +88,8 @@ function runtimeOverrides(config: AiConfigWithKey): RuntimeOverrides {
 // clock so a stall surfaces as a retryable error instead of an infinite spinner.
 const STRUCTURED_RUN_TIMEOUT_MS = 4 * 60_000;
 const CHAT_RUN_TIMEOUT_MS = 2 * 60_000;
+const INITIAL_SCHEMA_PROMPT_MAX_CHARS = 2_000;
+const INITIAL_SCHEMA_PROMPT_MAX_KEYS = 20;
 
 function runSignal(timeoutMs: number, externalSignal?: AbortSignal): AbortSignal {
   const timeoutSignal = AbortSignal.timeout(timeoutMs);
@@ -186,6 +191,39 @@ function createAgent(
   }) as DeepAgent;
 }
 
+function structuredInstructions<T>(
+  instructions: string,
+  schema: ZodType<T, ZodTypeDef, unknown>,
+): string {
+  const jsonSchema = toJsonSchema(schema);
+  const serialized = JSON.stringify(jsonSchema);
+  if (serialized.length <= INITIAL_SCHEMA_PROMPT_MAX_CHARS) {
+    return `${instructions}\nThe final answer must match this JSON Schema exactly:\n${serialized}`;
+  }
+
+  let properties: string[] = [];
+  if (typeof jsonSchema === "object" && jsonSchema !== null && "properties" in jsonSchema) {
+    const schemaProperties = jsonSchema.properties;
+    if (schemaProperties && typeof schemaProperties === "object" && !Array.isArray(schemaProperties)) {
+      properties = Object.keys(schemaProperties);
+    }
+  }
+  const shape = properties.length > 0
+    ? ` with these top-level keys: ${properties.slice(0, INITIAL_SCHEMA_PROMPT_MAX_KEYS).join(", ")}${properties.length > INITIAL_SCHEMA_PROMPT_MAX_KEYS ? ", …" : ""}`
+    : "";
+  return `${instructions}\nThe final answer must be one JSON object${shape}. The dedicated formatter will enforce the complete schema.`;
+}
+
+function structuredOutputCacheKey(config: AiConfigWithKey): string {
+  return [
+    config.provider.id,
+    String(config.provider.updatedAt),
+    config.model.id,
+    config.model.modelId,
+    String(config.model.updatedAt),
+  ].join(":");
+}
+
 function stableToolInput(input: unknown): string {
   if (!input || typeof input !== "object") return JSON.stringify(input);
   const sorted = Object.fromEntries(
@@ -245,13 +283,14 @@ async function collectStructuredRun(
   agent: DeepAgent,
   messages: AgentMessage[],
   stepLimit: number,
-  overrides: RuntimeOverrides,
+  recursionLimit: number | undefined,
+  signal: AbortSignal,
 ): Promise<string> {
   const result = await agent.invoke(
     { messages: normalizeMessages(messages) },
     {
-      recursionLimit: overrides.recursionLimit ?? recursionLimitFor(stepLimit),
-      signal: runSignal(overrides.runTimeoutMs ?? STRUCTURED_RUN_TIMEOUT_MS),
+      recursionLimit: recursionLimit ?? recursionLimitFor(stepLimit),
+      signal,
     },
   );
   return finalTextFromState(result);
@@ -261,9 +300,9 @@ async function collectStructuredRun(
  * Run a structured (non-streaming) capability end to end.
  *
  * The capability prompt asks for schema-valid JSON. Parse that final response
- * directly, with one forced structured-output call only when parsing fails.
- * Avoiding a response-format tool on every agent step keeps provider behavior
- * consistent and prevents schema-retry loops on compatible endpoints.
+ * directly, then use the model's bounded structured-output policy only when
+ * parsing fails. Avoiding a response-format tool on every agent step keeps
+ * provider behavior consistent and prevents schema-retry loops.
  */
 export async function runStructuredCapability<TInput, TPrepared, TParsed, TOutput>(
   cap: StructuredCapability<TInput, TPrepared, TParsed, TOutput>,
@@ -278,8 +317,13 @@ export async function runStructuredCapability<TInput, TPrepared, TParsed, TOutpu
     const { model, config, label } = await resolveDeepAgentModel(ctx.modelId);
     const invokedToolCalls: InvokedToolCall[] = [];
     const tools = guardDuplicateTools(await cap.tools(prepared, ctx), invokedToolCalls);
-    const instructions = await cap.instructions(prepared, ctx);
+    const instructions = structuredInstructions(
+      await cap.instructions(prepared, ctx),
+      cap.outputSchema,
+    );
     const messages = await cap.messages(prepared, ctx);
+    const overrides = runtimeOverrides(config);
+    const signal = runSignal(overrides.runTimeoutMs ?? STRUCTURED_RUN_TIMEOUT_MS);
     registerFastHarnessProfile(config);
     const agent = createAgent(model, tools, instructions);
 
@@ -287,7 +331,8 @@ export async function runStructuredCapability<TInput, TPrepared, TParsed, TOutpu
       agent,
       messages,
       cap.tuning?.stopAtSteps ?? 10,
-      runtimeOverrides(config),
+      overrides.recursionLimit,
+      signal,
     );
     const steps = invokedToolCalls.map((call) => ({ tool: call.name, input: call.args }));
 
@@ -309,6 +354,11 @@ export async function runStructuredCapability<TInput, TPrepared, TParsed, TOutpu
       raw,
       fallbackMessages,
       maxOutputTokens: cap.tuning?.maxOutputTokens,
+      policy: isStructuredOutputPolicy(config.model.params?.structuredOutputPolicy)
+        ? config.model.params.structuredOutputPolicy
+        : "auto",
+      strategyCacheKey: structuredOutputCacheKey(config),
+      signal,
       module: `AI:${cap.id}`,
     });
 

--- a/packages/server/src/services/ai/structuredOutput.test.ts
+++ b/packages/server/src/services/ai/structuredOutput.test.ts
@@ -1,24 +1,233 @@
-import { describe, expect, it, mock } from "bun:test";
+import { beforeEach, describe, expect, it, mock } from "bun:test";
 import { ChatOpenAI } from "@langchain/openai";
 import { z } from "zod";
 
-import { structuredOutput } from "./structuredOutput";
+import {
+  clearStructuredOutputStrategyCache,
+  structuredOutput,
+} from "./structuredOutput";
+
+const OutputSchema = z.object({ answer: z.string() });
+
+interface StatusError extends Error {
+  status: number;
+}
+
+function providerError(message: string, status: number): StatusError {
+  return Object.assign(new Error(message), { status });
+}
+
+function baseOptions(model: ChatOpenAI) {
+  return {
+    model,
+    schema: OutputSchema,
+    raw: "not json",
+    fallbackMessages: [{ role: "user" as const, content: "return an answer" }],
+  };
+}
 
 describe("structuredOutput", () => {
-  it("forces function calling for ChatOpenAI-compatible models", async () => {
-    const model = new ChatOpenAI({ apiKey: "test", model: "deepseek-chat" });
-    const invoke = mock(async () => ({ answer: "ok" }));
+  beforeEach(() => {
+    clearStructuredOutputStrategyCache();
+  });
+
+  it("returns schema-valid raw JSON without another model call", async () => {
+    const model = new ChatOpenAI({ apiKey: "test", model: "unused" });
+    const invoke = mock(async () => ({ content: "unused" }));
+    Object.defineProperty(model, "invoke", { value: invoke });
+
+    const result = await structuredOutput({
+      ...baseOptions(model),
+      raw: '{"answer":"raw"}',
+    });
+
+    expect(result).toEqual({ answer: "raw" });
+    expect(invoke).not.toHaveBeenCalled();
+  });
+
+  it("lets the adapter choose its preferred method in auto mode", async () => {
+    const model = new ChatOpenAI({ apiKey: "test", model: "gateway-model" });
+    const invoke = mock(async () => ({ answer: "adapter" }));
     const withStructuredOutput = mock((_schema: z.ZodType<unknown>, _options?: { method?: string }) => ({ invoke }));
     Object.defineProperty(model, "withStructuredOutput", { value: withStructuredOutput });
 
-    const result = await structuredOutput({
-      model,
-      schema: z.object({ answer: z.string() }),
-      raw: "not json",
-      fallbackMessages: [{ role: "user", content: "return an answer" }],
-    });
+    const result = await structuredOutput(baseOptions(model));
 
-    expect(result).toEqual({ answer: "ok" });
-    expect(withStructuredOutput.mock.calls[0]?.[1]).toEqual({ method: "functionCalling" });
+    expect(result).toEqual({ answer: "adapter" });
+    expect(withStructuredOutput.mock.calls[0]?.[1]).toBeUndefined();
+  });
+
+  it("falls back from an unsupported adapter method to tool calling", async () => {
+    const model = new ChatOpenAI({ apiKey: "test", model: "gateway-model" });
+    const methods: Array<string | undefined> = [];
+    const withStructuredOutput = mock((_schema: z.ZodType<unknown>, options?: { method?: string }) => {
+      methods.push(options?.method);
+      return {
+        invoke: async () => {
+          if (options?.method === undefined) throw providerError("response_format unsupported", 400);
+          return { answer: "tool" };
+        },
+      };
+    });
+    Object.defineProperty(model, "withStructuredOutput", { value: withStructuredOutput });
+
+    const result = await structuredOutput(baseOptions(model));
+
+    expect(result).toEqual({ answer: "tool" });
+    expect(methods).toEqual([undefined, "functionCalling"]);
+  });
+
+  it("uses plain JSON repair after schema-invalid structured output", async () => {
+    const model = new ChatOpenAI({ apiKey: "test", model: "gateway-model" });
+    const methods: Array<string | undefined> = [];
+    const withStructuredOutput = mock((_schema: z.ZodType<unknown>, options?: { method?: string }) => {
+      methods.push(options?.method);
+      return { invoke: async () => ({ answer: 42 }) };
+    });
+    const repairInvoke = mock(async () => ({ content: '```json\n{"answer":"repaired"}\n```' }));
+    Object.defineProperty(model, "withStructuredOutput", { value: withStructuredOutput });
+    Object.defineProperty(model, "invoke", { value: repairInvoke });
+
+    const result = await structuredOutput(baseOptions(model));
+
+    expect(result).toEqual({ answer: "repaired" });
+    expect(methods).toEqual([undefined]);
+    const repairMessages = repairInvoke.mock.calls[0]?.[0];
+    expect(repairMessages.at(-1)?.content).toContain("JSON Schema");
+    expect(repairMessages.at(-1)?.content).toContain('"answer"');
+  });
+
+  it("does not cascade transient provider failures into billed fallback calls", async () => {
+    const model = new ChatOpenAI({ apiKey: "test", model: "gateway-model" });
+    const withStructuredOutput = mock(() => ({
+      invoke: async () => {
+        throw providerError("failed to parse upstream rate-limit response", 429);
+      },
+    }));
+    const repairInvoke = mock(async () => ({ content: '{"answer":"unexpected"}' }));
+    Object.defineProperty(model, "withStructuredOutput", { value: withStructuredOutput });
+    Object.defineProperty(model, "invoke", { value: repairInvoke });
+
+    await expect(structuredOutput(baseOptions(model))).rejects.toThrow("failed to parse upstream");
+    expect(withStructuredOutput).toHaveBeenCalledTimes(1);
+    expect(repairInvoke).not.toHaveBeenCalled();
+  });
+
+  it("does not cascade authentication failures into fallback calls", async () => {
+    const model = new ChatOpenAI({ apiKey: "test", model: "gateway-model" });
+    const withStructuredOutput = mock(() => ({
+      invoke: async () => {
+        throw providerError("API key is invalid", 401);
+      },
+    }));
+    const repairInvoke = mock(async () => ({ content: '{"answer":"unexpected"}' }));
+    Object.defineProperty(model, "withStructuredOutput", { value: withStructuredOutput });
+    Object.defineProperty(model, "invoke", { value: repairInvoke });
+
+    await expect(structuredOutput(baseOptions(model))).rejects.toThrow("API key is invalid");
+    expect(withStructuredOutput).toHaveBeenCalledTimes(1);
+    expect(repairInvoke).not.toHaveBeenCalled();
+  });
+
+  it("honors explicit native, tool, json, and plain policies", async () => {
+    const expectedMethods = new Map([
+      ["native", "jsonSchema"],
+      ["tool", "functionCalling"],
+      ["json", "jsonMode"],
+    ]);
+
+    for (const [policy, expectedMethod] of expectedMethods) {
+      const model = new ChatOpenAI({ apiKey: "test", model: `${policy}-model` });
+      const withStructuredOutput = mock((_schema: z.ZodType<unknown>, options?: { method?: string }) => ({
+        invoke: async () => ({ answer: options?.method ?? "missing" }),
+      }));
+      Object.defineProperty(model, "withStructuredOutput", { value: withStructuredOutput });
+
+      const result = await structuredOutput({
+        ...baseOptions(model),
+        policy: policy === "native" || policy === "tool" || policy === "json" ? policy : "auto",
+      });
+
+      expect(result).toEqual({ answer: expectedMethod });
+      expect(withStructuredOutput.mock.calls[0]?.[1]?.method).toBe(expectedMethod);
+    }
+
+    const plainModel = new ChatOpenAI({ apiKey: "test", model: "plain-model" });
+    const withStructuredOutput = mock(() => ({ invoke: async () => ({ answer: "unexpected" }) }));
+    const plainInvoke = mock(async () => ({ content: '{"answer":"plain"}' }));
+    Object.defineProperty(plainModel, "withStructuredOutput", { value: withStructuredOutput });
+    Object.defineProperty(plainModel, "invoke", { value: plainInvoke });
+
+    const plainResult = await structuredOutput({ ...baseOptions(plainModel), policy: "plain" });
+    expect(plainResult).toEqual({ answer: "plain" });
+    expect(withStructuredOutput).not.toHaveBeenCalled();
+  });
+
+  it("repairs JSON when the adapter has no structured-output API", async () => {
+    const model = new ChatOpenAI({ apiKey: "test", model: "basic-model" });
+    const repairInvoke = mock(async () => ({ content: '{"answer":"plain"}' }));
+    Object.defineProperty(model, "withStructuredOutput", { value: undefined });
+    Object.defineProperty(model, "invoke", { value: repairInvoke });
+
+    const result = await structuredOutput(baseOptions(model));
+
+    expect(result).toEqual({ answer: "plain" });
+    expect(repairInvoke).toHaveBeenCalledTimes(1);
+  });
+
+  it("caches a successful auto strategy for the versioned model key", async () => {
+    const model = new ChatOpenAI({ apiKey: "test", model: "gateway-model" });
+    const methods: Array<string | undefined> = [];
+    const withStructuredOutput = mock((_schema: z.ZodType<unknown>, options?: { method?: string }) => {
+      methods.push(options?.method);
+      return {
+        invoke: async () => {
+          if (options?.method === undefined) throw providerError("response_format unsupported", 400);
+          return { answer: "tool" };
+        },
+      };
+    });
+    Object.defineProperty(model, "withStructuredOutput", { value: withStructuredOutput });
+
+    const opts = { ...baseOptions(model), strategyCacheKey: "provider:model:v1" };
+    expect(await structuredOutput(opts)).toEqual({ answer: "tool" });
+    expect(await structuredOutput(opts)).toEqual({ answer: "tool" });
+    expect(methods).toEqual([undefined, "functionCalling", "functionCalling"]);
+  });
+
+  it("renegotiates an auto strategy after its cache entry expires", async () => {
+    const originalNow = Date.now;
+    let now = 1_000;
+    Object.defineProperty(Date, "now", { configurable: true, value: () => now });
+    try {
+      const model = new ChatOpenAI({ apiKey: "test", model: "gateway-model" });
+      const methods: Array<string | undefined> = [];
+      const withStructuredOutput = mock((_schema: z.ZodType<unknown>, options?: { method?: string }) => {
+        methods.push(options?.method);
+        return {
+          invoke: async () => {
+            if (options?.method === undefined) throw providerError("response_format unsupported", 400);
+            return { answer: "tool" };
+          },
+        };
+      });
+      Object.defineProperty(model, "withStructuredOutput", { value: withStructuredOutput });
+
+      const opts = { ...baseOptions(model), strategyCacheKey: "provider:model:v1" };
+      expect(await structuredOutput(opts)).toEqual({ answer: "tool" });
+      expect(await structuredOutput(opts)).toEqual({ answer: "tool" });
+      now += 16 * 60_000;
+      expect(await structuredOutput(opts)).toEqual({ answer: "tool" });
+
+      expect(methods).toEqual([
+        undefined,
+        "functionCalling",
+        "functionCalling",
+        undefined,
+        "functionCalling",
+      ]);
+    } finally {
+      Object.defineProperty(Date, "now", { configurable: true, value: originalNow });
+    }
   });
 });

--- a/packages/server/src/services/ai/structuredOutput.ts
+++ b/packages/server/src/services/ai/structuredOutput.ts
@@ -5,13 +5,17 @@
  * Strategy:
  *   1. Try to parse the agent's free text as the schema (whole text → fenced
  *      block → first {...} span).
- *   2. If that fails, fall back to a dedicated LangChain structured-output call
- *      that forces the model to emit schema-valid JSON from its own notes.
+ *   2. Apply the model's configured structured-output policy. Auto mode lets
+ *      the adapter choose first, then tries tool calling only when the adapter
+ *      explicitly rejects its preferred mechanism.
+ *   3. Finish with provider-neutral plain JSON repair when structured formats
+ *      are unavailable or the model emitted schema-invalid output.
  */
 
 import type { BaseChatModel } from "@langchain/core/language_models/chat_models";
-import { ChatOpenAI } from "@langchain/openai";
+import { toJsonSchema } from "@langchain/core/utils/json_schema";
 import { z } from "zod";
+import type { StructuredOutputPolicy } from "../../rbac/constants/aiModelParams";
 import { AppError } from "../../types";
 import { logger } from "../../utils/logger";
 import type { AgentMessage } from "./types";
@@ -57,43 +61,268 @@ export interface StructuredOutputOptions<T> {
   /** Messages for the structured fallback (system + user). */
   fallbackMessages: AgentMessage[];
   maxOutputTokens?: number;
+  /** Per-model policy. Missing values preserve the automatic behavior. */
+  policy?: StructuredOutputPolicy;
+  /** Invalidates the successful-strategy cache when model/provider config changes. */
+  strategyCacheKey?: string;
+  /** Shared wall-clock signal for the agent run and every fallback attempt. */
+  signal?: AbortSignal;
   /** Logging module tag. */
   module?: string;
 }
 
+type StructuredOutputStrategy = "adapter" | "native" | "tool" | "json" | "plain";
+type FailureClass = "unsupported" | "output" | "transient" | "fatal";
+
+interface AttemptSummary {
+  strategy: "raw" | StructuredOutputStrategy;
+  classification: FailureClass;
+  error: string;
+}
+
+const STRATEGY_CACHE_MAX = 256;
+const STRATEGY_CACHE_TTL_MS = 15 * 60_000;
+
+interface CachedStrategy {
+  strategy: StructuredOutputStrategy;
+  expiresAt: number;
+}
+
+const successfulStrategyCache = new Map<string, CachedStrategy>();
+
+/** Test/reset hook; production invalidation normally happens through the versioned cache key. */
+export function clearStructuredOutputStrategyCache(): void {
+  successfulStrategyCache.clear();
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function summarizedError(error: unknown): string {
+  return errorMessage(error).slice(0, 500);
+}
+
+function numericStatus(error: unknown): number | undefined {
+  if (!error || typeof error !== "object") return undefined;
+  const errorRecord = error as Record<string, unknown>;
+  for (const key of ["status", "statusCode"] as const) {
+    const value = errorRecord[key];
+    if (typeof value === "number" && Number.isInteger(value)) return value;
+  }
+  return undefined;
+}
+
+function classifyFailure(error: unknown): FailureClass {
+  const status = numericStatus(error);
+  const message = errorMessage(error).toLowerCase();
+
+  // These are local validation failures, not provider 5xx responses.
+  if (error instanceof z.ZodError
+      || (error instanceof AppError && error.code === "AI_PARSE_ERROR")) {
+    return "output";
+  }
+
+  if (status === 401 || status === 403
+      || message.includes("authentication")
+      || message.includes("unauthorized")
+      || message.includes("api key")
+      || message.includes("permission denied")) {
+    return "fatal";
+  }
+
+  if (status === 408 || status === 409 || status === 425 || status === 429
+      || (status !== undefined && status >= 500)
+      || message.includes("aborterror")
+      || message.includes("timed out")
+      || message.includes("timeout")
+      || message.includes("rate limit")
+      || message.includes("overloaded")
+      || message.includes("temporarily unavailable")
+      || message.includes("econn")) {
+    return "transient";
+  }
+
+  if (message.includes("unstructured response")
+      || message.includes("invalid json")
+      || message.includes("could not parse")
+      || message.includes("failed to parse")
+      || message.includes("no tool calls")
+      || message.includes("did not call")) {
+    return "output";
+  }
+
+  if (message.includes("unsupported")
+      || message.includes("not supported")
+      || message.includes("only supports")
+      || message.includes("unrecognized structured output method")
+      || message.includes("does not expose native structured output")
+      || message.includes("response_format")
+      || message.includes("response format")
+      || message.includes("json_schema")
+      || message.includes("json schema")
+      || message.includes("tool_choice")
+      || message.includes("function calling")
+      || message.includes("invalid argument")) {
+    return "unsupported";
+  }
+
+  return "fatal";
+}
+
+function messageText(message: unknown): string {
+  if (!message || typeof message !== "object" || !("content" in message)) return "";
+  const content = message.content;
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return "";
+  return content
+    .map((part) => {
+      if (typeof part === "string") return part;
+      if (part && typeof part === "object" && "text" in part) return String(part.text);
+      return "";
+    })
+    .join("");
+}
+
+function formattingMessages<T>(opts: StructuredOutputOptions<T>): AgentMessage[] {
+  const schema = JSON.stringify(toJsonSchema(opts.schema));
+  return [
+    ...opts.fallbackMessages,
+    {
+      role: "user",
+      content: `Return only one JSON object matching this JSON Schema. Do not use markdown or code fences.\n${schema}`,
+    },
+  ];
+}
+
+function rememberStrategy(cacheKey: string | undefined, strategy: StructuredOutputStrategy): void {
+  if (!cacheKey) return;
+  successfulStrategyCache.delete(cacheKey);
+  successfulStrategyCache.set(cacheKey, {
+    strategy,
+    expiresAt: Date.now() + STRATEGY_CACHE_TTL_MS,
+  });
+  if (successfulStrategyCache.size <= STRATEGY_CACHE_MAX) return;
+  const oldest = successfulStrategyCache.keys().next().value;
+  if (typeof oldest === "string") successfulStrategyCache.delete(oldest);
+}
+
+function cachedStrategy(cacheKey: string | undefined): StructuredOutputStrategy | undefined {
+  if (!cacheKey) return undefined;
+  const cached = successfulStrategyCache.get(cacheKey);
+  if (!cached) return undefined;
+  if (cached.expiresAt <= Date.now()) {
+    successfulStrategyCache.delete(cacheKey);
+    return undefined;
+  }
+  return cached.strategy;
+}
+
+function uniqueStrategies(strategies: StructuredOutputStrategy[]): StructuredOutputStrategy[] {
+  return strategies.filter((strategy, index) => strategies.indexOf(strategy) === index);
+}
+
+function strategiesFor(
+  policy: StructuredOutputPolicy,
+  cacheKey: string | undefined,
+): StructuredOutputStrategy[] {
+  switch (policy) {
+    case "native":
+      return ["native", "plain"];
+    case "tool":
+      return ["tool", "plain"];
+    case "json":
+      return ["json", "plain"];
+    case "plain":
+      return ["plain"];
+    case "auto": {
+      const cached = cachedStrategy(cacheKey);
+      return uniqueStrategies([...(cached ? [cached] : []), "adapter", "tool", "plain"]);
+    }
+  }
+}
+
+async function invokeStructuredStrategy<T>(
+  opts: StructuredOutputOptions<T>,
+  strategy: Exclude<StructuredOutputStrategy, "plain">,
+  messages: AgentMessage[],
+): Promise<T> {
+  if (!opts.model.withStructuredOutput) {
+    throw new Error("Model adapter does not expose native structured output");
+  }
+
+  const structured = strategy === "adapter"
+    ? opts.model.withStructuredOutput(opts.schema)
+    : opts.model.withStructuredOutput(opts.schema, {
+        method: strategy === "native"
+          ? "jsonSchema"
+          : strategy === "tool"
+            ? "functionCalling"
+            : "jsonMode",
+      });
+  const object = await structured.invoke(messages, { signal: opts.signal });
+  return opts.schema.parse(object);
+}
+
+async function invokePlainStrategy<T>(
+  opts: StructuredOutputOptions<T>,
+  messages: AgentMessage[],
+): Promise<T> {
+  const response = await opts.model.invoke(messages, { signal: opts.signal });
+  return extractJson(messageText(response), opts.schema);
+}
+
 /**
- * Parse the agent's text into `schema`, falling back to a forced structured
- * LangChain call when the free text doesn't parse. Returns null only if
- * both paths fail (callers decide whether that's fatal).
+ * Parse the agent's text into `schema`, then negotiate bounded fallback
+ * strategies. Provider/transient failures are rethrown so the shared AI error
+ * mapper preserves their status instead of hiding them behind a parse error.
  */
 export async function structuredOutput<T>(
   opts: StructuredOutputOptions<T>,
 ): Promise<T | null> {
+  const attempts: AttemptSummary[] = [];
   try {
     return extractJson(opts.raw, opts.schema);
-  } catch {
-    /* free-text didn't parse — force structured output */
+  } catch (error) {
+    attempts.push({
+      strategy: "raw",
+      classification: "output",
+      error: summarizedError(error),
+    });
   }
 
-  try {
-    if (!opts.model.withStructuredOutput) return null;
-    // ChatOpenAI infers a response-format method from the model name string
-    // (only "gpt-3*"/"gpt-4*" get tool-calling by default) — any other name,
-    // including third-party "openai-compatible" models routed through this
-    // same class, is bumped to OpenAI's strict `json_schema` response format,
-    // which most compatible proxies don't implement. Force tool calling,
-    // which every OpenAI-compatible provider supports.
-    const structured = opts.model.withStructuredOutput(
-      opts.schema,
-      opts.model instanceof ChatOpenAI ? { method: "functionCalling" } : undefined,
-    );
-    const object = await structured.invoke(opts.fallbackMessages);
-    return opts.schema.parse(object);
-  } catch (e) {
-    logger.warn(
-      { module: opts.module ?? "AIEngine", err: e instanceof Error ? e.message : String(e) },
-      "Structured output fallback failed",
-    );
-    return null;
+  const policy = opts.policy ?? "auto";
+  const messages = formattingMessages(opts);
+  let skipToPlain = false;
+
+  for (const strategy of strategiesFor(policy, opts.strategyCacheKey)) {
+    if (skipToPlain && strategy !== "plain") continue;
+    try {
+      const output = strategy === "plain"
+        ? await invokePlainStrategy(opts, messages)
+        : await invokeStructuredStrategy(opts, strategy, messages);
+      rememberStrategy(policy === "auto" ? opts.strategyCacheKey : undefined, strategy);
+      logger.debug(
+        {
+          module: opts.module ?? "AIEngine",
+          policy,
+          strategy,
+          fallbackAttempts: attempts.length,
+        },
+        "Structured output fallback succeeded",
+      );
+      return output;
+    } catch (error) {
+      const classification = classifyFailure(error);
+      attempts.push({ strategy, classification, error: summarizedError(error) });
+      if (classification === "fatal" || classification === "transient") throw error;
+      if (classification === "output") skipToPlain = true;
+    }
   }
+
+  logger.warn(
+    { module: opts.module ?? "AIEngine", policy, attempts },
+    "Structured output fallback failed",
+  );
+  return null;
 }

--- a/packages/server/src/services/aiConfig.test.ts
+++ b/packages/server/src/services/aiConfig.test.ts
@@ -114,6 +114,21 @@ describe("initializeDeepAgentModel · openai", () => {
     expect(m.timeout).toBe(60_000);
     expect(m.modelKwargs).toEqual({ seed: 42 });
   });
+
+  it("keeps engine-only runtime params out of the provider client", () => {
+    const model = initializeDeepAgentModel(
+      fakeConfig("openai", {
+        recursionLimit: 64,
+        runTimeoutMs: 120_000,
+        structuredOutputPolicy: "tool",
+      }),
+    );
+    const fields = model as ChatOpenAI & Record<string, unknown>;
+    expect(fields.recursionLimit).toBeUndefined();
+    expect(fields.runTimeoutMs).toBeUndefined();
+    expect(fields.structuredOutputPolicy).toBeUndefined();
+    expect(fields.modelKwargs).toEqual({});
+  });
 });
 
 describe("initializeDeepAgentModel · openai-compatible", () => {

--- a/src/constants/aiModelParams.test.ts
+++ b/src/constants/aiModelParams.test.ts
@@ -4,6 +4,7 @@ import {
   PARAM_BOUNDS,
   PROVIDER_PARAM_KEYS,
   REASONING_EFFORT_OPTIONS,
+  STRUCTURED_OUTPUT_POLICIES,
   hasAnyParams,
   validateAiModelParams,
   type AiModelParams,
@@ -37,6 +38,7 @@ const cases: Case[] = [
       requestTimeoutMs: 60_000,
       recursionLimit: 64,
       runTimeoutMs: 120_000,
+      structuredOutputPolicy: 'auto',
       extra: { seed: 42 },
     },
     expectErrors: false,
@@ -65,6 +67,7 @@ const cases: Case[] = [
   { name: 'bedrock rejects extra', providerType: 'bedrock', params: { extra: { a: 1 } }, expectErrors: true, errorIncludes: "'extra'" },
   { name: 'openrouter mirrors openai keys', providerType: 'openrouter', params: { reasoningEffort: 'minimal', extra: { seed: 2 } }, expectErrors: false },
   { name: 'empty params valid', providerType: 'anthropic', params: {}, expectErrors: false },
+  { name: 'plain structured output works for google', providerType: 'google', params: { structuredOutputPolicy: 'plain' }, expectErrors: false },
 ];
 
 // Guard against the server/frontend mirrors drifting: this hardcoded list must
@@ -112,8 +115,22 @@ describe('UI metadata consistency', () => {
   it('covers every provider type in PROVIDER_PARAM_KEYS and REASONING_EFFORT_OPTIONS', () => {
     for (const providerType of PROVIDER_TYPES) {
       expect(PROVIDER_PARAM_KEYS[providerType].length).toBeGreaterThan(0);
+      expect(PROVIDER_PARAM_KEYS[providerType]).toContain('structuredOutputPolicy');
       expect(REASONING_EFFORT_OPTIONS[providerType]).toBeDefined();
     }
+  });
+
+  it('allows every structured-output policy for every provider', () => {
+    for (const providerType of PROVIDER_TYPES) {
+      for (const structuredOutputPolicy of STRUCTURED_OUTPUT_POLICIES) {
+        expect(validateAiModelParams({ structuredOutputPolicy }, providerType)).toEqual([]);
+      }
+    }
+  });
+
+  it('rejects an invalid structured-output policy defensively', () => {
+    const params: AiModelParams = JSON.parse('{"structuredOutputPolicy":"invalid"}');
+    expect(validateAiModelParams(params, 'openai').join('; ')).toContain('structuredOutputPolicy');
   });
 
   it('keeps number-field bounds in sync with PARAM_BOUNDS', () => {

--- a/src/constants/aiModelParams.ts
+++ b/src/constants/aiModelParams.ts
@@ -11,6 +11,12 @@ import type { ProviderType } from './aiProviders';
 
 export type ReasoningEffort = 'minimal' | 'low' | 'medium' | 'high';
 export type Verbosity = 'low' | 'medium' | 'high';
+export const STRUCTURED_OUTPUT_POLICIES = ['auto', 'native', 'tool', 'json', 'plain'] as const;
+export type StructuredOutputPolicy = (typeof STRUCTURED_OUTPUT_POLICIES)[number];
+
+export function isStructuredOutputPolicy(value: unknown): value is StructuredOutputPolicy {
+  return typeof value === 'string' && STRUCTURED_OUTPUT_POLICIES.some((policy) => policy === value);
+}
 
 export interface AiSafetySetting {
   category: string;
@@ -34,10 +40,17 @@ export interface AiModelParams {
   safetySettings?: AiSafetySetting[];
   recursionLimit?: number;
   runTimeoutMs?: number;
+  structuredOutputPolicy?: StructuredOutputPolicy;
   extra?: Record<string, unknown>;
 }
 
 export type AiModelParamKey = keyof AiModelParams;
+
+const ENGINE_KEYS: readonly AiModelParamKey[] = [
+  'recursionLimit',
+  'runTimeoutMs',
+  'structuredOutputPolicy',
+];
 
 const COMMON_KEYS: readonly AiModelParamKey[] = [
   'temperature',
@@ -45,8 +58,7 @@ const COMMON_KEYS: readonly AiModelParamKey[] = [
   'maxTokens',
   'stopSequences',
   'maxRetries',
-  'recursionLimit',
-  'runTimeoutMs',
+  ...ENGINE_KEYS,
 ];
 
 const OPENAI_FAMILY_KEYS: readonly AiModelParamKey[] = [
@@ -68,13 +80,13 @@ export const PROVIDER_PARAM_KEYS: Record<ProviderType, readonly AiModelParamKey[
   'google': [...COMMON_KEYS, 'topK', 'thinkingBudgetTokens', 'apiVersion', 'safetySettings'],
   'azure-openai': [...OPENAI_FAMILY_KEYS, 'apiVersion'],
   'groq': [...COMMON_KEYS, 'requestTimeoutMs'],
-  'mistral': ['temperature', 'topP', 'maxTokens', 'maxRetries', 'recursionLimit', 'runTimeoutMs'],
-  'cohere': ['temperature', 'maxRetries', 'recursionLimit', 'runTimeoutMs'],
+  'mistral': ['temperature', 'topP', 'maxTokens', 'maxRetries', ...ENGINE_KEYS],
+  'cohere': ['temperature', 'maxRetries', ...ENGINE_KEYS],
   'ollama': [...COMMON_KEYS, 'topK'],
-  'xai': ['temperature', 'maxTokens', 'stopSequences', 'maxRetries', 'recursionLimit', 'runTimeoutMs'],
+  'xai': ['temperature', 'maxTokens', 'stopSequences', 'maxRetries', ...ENGINE_KEYS],
   'deepseek': [...COMMON_KEYS, 'frequencyPenalty', 'presencePenalty', 'requestTimeoutMs', 'extra'],
-  'cerebras': ['temperature', 'topP', 'maxTokens', 'maxRetries', 'requestTimeoutMs', 'recursionLimit', 'runTimeoutMs'],
-  'bedrock': ['temperature', 'topP', 'maxTokens', 'maxRetries', 'recursionLimit', 'runTimeoutMs'],
+  'cerebras': ['temperature', 'topP', 'maxTokens', 'maxRetries', 'requestTimeoutMs', ...ENGINE_KEYS],
+  'bedrock': ['temperature', 'topP', 'maxTokens', 'maxRetries', ...ENGINE_KEYS],
   'fireworks': OPENAI_FAMILY_KEYS,
   'together': OPENAI_FAMILY_KEYS,
   'openrouter': OPENAI_FAMILY_KEYS,
@@ -176,6 +188,11 @@ export function validateAiModelParams(params: AiModelParams, providerType: Provi
     if (value < bounds.min || value > bounds.max) {
       errors.push(`'${key}' must be between ${bounds.min} and ${bounds.max}`);
     }
+  }
+
+  if (params.structuredOutputPolicy !== undefined
+      && !isStructuredOutputPolicy(params.structuredOutputPolicy)) {
+    errors.push(`'structuredOutputPolicy' must be one of: ${STRUCTURED_OUTPUT_POLICIES.join(', ')}`);
   }
 
   if (providerType === 'anthropic') {

--- a/src/features/admin/components/AiModels/BaseModelsTab.tsx
+++ b/src/features/admin/components/AiModels/BaseModelsTab.tsx
@@ -23,8 +23,10 @@ import {
     NUMBER_PARAM_FIELDS,
     PROVIDER_PARAM_KEYS,
     REASONING_EFFORT_OPTIONS,
+    STRUCTURED_OUTPUT_POLICIES,
     VERBOSITY_OPTIONS,
     hasAnyParams,
+    isStructuredOutputPolicy,
     validateAiModelParams,
     type AiModelParamKey,
     type AiModelParams,
@@ -61,6 +63,7 @@ function draftFromParams(params: AiModelParams | null | undefined): ParamsDraft 
     if (params.reasoningEffort) draft.reasoningEffort = params.reasoningEffort;
     if (params.verbosity) draft.verbosity = params.verbosity;
     if (params.apiVersion) draft.apiVersion = params.apiVersion;
+    if (params.structuredOutputPolicy) draft.structuredOutputPolicy = params.structuredOutputPolicy;
     return draft;
 }
 
@@ -187,6 +190,10 @@ export default function BaseModelsTab() {
         if (apiVersion && isAllowed('apiVersion')) {
             built.apiVersion = apiVersion;
         }
+        const structuredOutputPolicy = paramsDraft.structuredOutputPolicy;
+        if (structuredOutputPolicy && isAllowed('structuredOutputPolicy') && isStructuredOutputPolicy(structuredOutputPolicy)) {
+            built.structuredOutputPolicy = structuredOutputPolicy;
+        }
 
         if (isAllowed('stopSequences')) {
             const sequences = stopSeqText.split('\n').map(s => s.trim()).filter(s => s.length > 0);
@@ -288,6 +295,7 @@ export default function BaseModelsTab() {
         label: string,
         options: readonly string[],
         description: string,
+        unsetLabel = 'Provider default',
     ) => (
         <label className="flex flex-col gap-1" key={key}>
             <span className={fieldLabelClass}>{label}</span>
@@ -296,7 +304,7 @@ export default function BaseModelsTab() {
                     <SelectValue placeholder="Provider default" />
                 </SelectTrigger>
                 <SelectContent className="rounded-xs border-ink-500 bg-ink-100 text-paper">
-                    <SelectItem value={UNSET}>Provider default</SelectItem>
+                    <SelectItem value={UNSET}>{unsetLabel}</SelectItem>
                     {options.map(option => (
                         <SelectItem key={option} value={option}>{option}</SelectItem>
                     ))}
@@ -470,9 +478,12 @@ export default function BaseModelsTab() {
                                                 {PARAM_GROUPS.map(group => {
                                                     const fields = numberFieldsFor(group);
                                                     const showReasoningEnums = group === 'Reasoning';
+                                                    const showReliabilityEnums = group === 'Reliability & agent';
                                                     const reasoningOptions = REASONING_EFFORT_OPTIONS[providerType];
-                                                    const hasEnums = showReasoningEnums && (
+                                                    const hasEnums = (showReasoningEnums && (
                                                         (isAllowed('reasoningEffort') && reasoningOptions.length > 0) || isAllowed('verbosity')
+                                                    )) || (
+                                                        showReliabilityEnums && isAllowed('structuredOutputPolicy')
                                                     );
                                                     if (fields.length === 0 && !hasEnums) return null;
                                                     return (
@@ -499,6 +510,8 @@ export default function BaseModelsTab() {
                                                                     renderEnumSelect('reasoningEffort', 'Reasoning effort', reasoningOptions, 'Reasoning depth for capable models.')}
                                                                 {showReasoningEnums && isAllowed('verbosity') &&
                                                                     renderEnumSelect('verbosity', 'Verbosity', VERBOSITY_OPTIONS, 'Response verbosity (GPT-5 family).')}
+                                                                {showReliabilityEnums && isAllowed('structuredOutputPolicy') &&
+                                                                    renderEnumSelect('structuredOutputPolicy', 'Structured output', STRUCTURED_OUTPUT_POLICIES, 'Auto negotiates native output and tool calling, then uses plain JSON repair. Choose an override only for provider compatibility.', 'Auto (recommended)')}
                                                             </div>
                                                         </div>
                                                     );


### PR DESCRIPTION
## Summary

- add a provider-neutral structured-output policy with `auto`, `native`, `tool`, `json`, and `plain` modes
- negotiate bounded formatter strategies and fall back to schema-guided plain JSON only for compatibility or output-shape failures
- expose the optional per-model policy in Admin → AI Models → Runtime parameters
- share the run timeout across the agent and formatter calls, bound initial schema prompts, and cache successful strategies with expiry

## Root cause

The formatter forced function calling for every `ChatOpenAI` transport. That class is also used for LiteLLM and other OpenAI-compatible gateways, where the routed provider may reject the generated function schema with `INVALID_ARGUMENT`. The fallback then converted the provider failure into a generic internal error.

## Impact

Structured AI capabilities such as Scheduled Queries and Data Health now let the LangChain adapter select its supported mechanism first, with bounded compatibility fallbacks. Authentication, throttling, timeout, and provider 5xx failures stop immediately instead of triggering additional billed calls. Regular chat/invoke capabilities are unchanged, and engine-only settings are not forwarded to provider SDKs.

No database migration is required because the policy is stored in the existing model params JSON column. Existing models default to `auto`.

## Validation

- `bun run typecheck`
- `bun run lint`
- `bun test packages/server/src/services/ai/structuredOutput.test.ts packages/server/src/services/ai/engine.test.ts`
- focused AI model policy and route tests: 112 passed
- isolated server suites, including Docker-backed PostgreSQL migration and rate-limit tests
- `bunx vitest run --exclude 'packages/server/**'`: 554 passed
- `bun run build`
- `git diff --check`
