### PR TITLE
Add clear & rerun for Scheduled Queries and Data Health (ADR 0007)

### DIFF
--- a/changelogs/unreleased/308-clear-and-rerun.md
+++ b/changelogs/unreleased/308-clear-and-rerun.md
@@ -1,0 +1,4 @@
+type: minor
+
+### Added
+- **Clear & rerun (ADR 0007)** — every run in a Scheduled Query's history and a Data Health promise's evaluation timeline gains a per-run **Rerun** action that re-executes exactly that slot over its original window; rerunning a materializing slot automatically re-verifies its linked Data Health promises over the same window. The recovery planner additionally supports range reruns — including already-succeeded slots — and Data Health promises gain a "Rerun range" action. Replays are idempotent: samples are replaced in place, and only the newest slot can change current status, incidents, or notifications — historical slots are corrected silently.

--- a/docs/adr/0007-clear-and-rerun-for-scheduled-jobs-and-data-health.md
+++ b/docs/adr/0007-clear-and-rerun-for-scheduled-jobs-and-data-health.md
@@ -1,0 +1,355 @@
+# 0007 — Clear & Rerun for Scheduled Jobs and Data Health
+
+**Status:** Accepted
+
+## Context
+
+Scheduled Queries (ADR 0002) execute slot-keyed runs over deterministic windows
+(`{{slot_start}}`/`{{slot_end}}`), and materialize writes are already idempotent per
+slot (`insert_deduplication_token = jobId:slotAt` for append/upsert; staging +
+atomic `REPLACE PARTITION` for replace). A recovery endpoint
+(`POST /scheduled-queries/:id/recovery`) already backfills a `from..to` range with
+plan-preview → confirm → execute, a `rerunSuccessful` flag, and a 30-slot cap.
+Data Health (ADR 0003/0006) evaluates promises over injected windows
+(`ExecuteOptions.window`) and records per-slot samples with a
+`UNIQUE (check_id, slot_at, origin)` key; incident logic is computed from
+slot-ordered streaks, so corrected history recomputes naturally.
+
+What is missing is **Airflow-style "clear" semantics** — re-run a slot and have the
+system converge on the re-run's result — end to end:
+
+1. **Recovery never reaches chained Data Health.** `runner.execute()` skips
+   `runChainedDataHealth` when `suppressNotifications` is set (which recovery always
+   sets), and even without that gate `claimSlot` would reject an old slot because the
+   job's `last_run_at` lease has moved on. A user who backfills a pipeline cannot
+   re-verify the promises protecting its output over the same windows.
+2. **Data Health re-evaluation is dedup-not-replace.** `insertEvaluations` uses
+   `ON CONFLICT … DO NOTHING`, so re-running a slot silently keeps the stale sample.
+   A "clear & rerun" must overwrite.
+3. **Replaying an old slot would clobber current state.** `processDataHealthSuccess`
+   unconditionally sets the promise's live status, transitions incidents, and
+   enqueues notifications. Re-evaluating last Tuesday must not flip today's health
+   state or page anyone. (This is a *latent* bug today: running the existing
+   scheduled-query recovery against a `data_health_check` job's own cadence already
+   takes the full-transition path with historical windows.)
+4. **No range rerun for Data Health itself.** `/data-health/:id/run` always uses
+   `slotAt = Date.now()`; there is no equivalent of the recovery range endpoint for
+   promises. (`/backtest` runs historical slots but is deliberately ephemeral — it
+   persists nothing.)
+
+Everything ships as **one feature in one release** — no phasing. No schema change is
+required: the samples unique key and the outbox `dedup_key` unique key already exist
+in both dialects, so there is **no migration** (and therefore no
+`migrations.ts`/`VERSION_CHECKS` obligation).
+
+## Decision
+
+### Product model
+
+- **Per-run rerun is the primary surface.** Every run in a job's run history and a
+  promise's evaluation timeline has a **Rerun** action (Airflow's "clear task
+  instance"): `POST /scheduled-queries/runs/:runId/rerun` and
+  `POST /data-health/:id/runs/:runId/rerun` re-execute exactly that run's slot
+  over its deterministic window with replay semantics. A rerun of a materializing
+  slot **always** replays its chained Data Health promises over the same window —
+  re-verifying what the rerun rewrote is the point of the action, so it is not
+  optional there.
+- **Scheduled query recovery gains chained re-verification.** The existing recovery
+  dialog/endpoint gets a flag (default-on in the UI, opt-in at the API): after each
+  slot's successful materialize rerun, every enabled promise chained to the job
+  re-evaluates **over the same window that rerun wrote**, in replay mode. The
+  dialog also exposes the pre-existing `rerunSuccessful` flag ("clear & rerun
+  slots that already succeeded"), which previously had no UI.
+- **Data Health promises gain their own range rerun.** A new
+  `POST /data-health/:id/recovery` mirrors the scheduled recovery contract
+  (plan-preview → `execute` + `confirm` → capped execution) and re-evaluates the
+  promise's slots in the range, replacing their samples.
+- **Replay semantics (the core invariant).** A *replay* run:
+  - re-executes with full RBAC/read-only re-validation, exactly like any run;
+  - **replaces** the slot's live samples (upsert instead of `DO NOTHING`);
+  - if the slot is **strictly older** than the newest previously evaluated live
+    slot: writes samples only — no promise-status update, no incident transition,
+    no notification;
+  - if the slot **is** the newest slot: full semantics — status re-derives,
+    streak-based incident transitions run over the (now corrected) slot history,
+    and notifications flow through the existing `dedup_key` outbox, which caps them
+    at one per incident transition.
+  - a **failed** replay records its run row and stops — it never marks the promise
+    `unknown`, never opens execution incidents, never notifies.
+
+### Execution model (D1–D6)
+
+- **D1 — `replay` is an `ExecuteOptions` flag,** threaded from the two recovery
+  routes through `runner.execute()` into the Data Health processing functions. The
+  live path (flag absent) is byte-for-byte unchanged.
+- **D2 — Chained replays bypass `claimSlot`.** The lease exists to make *live*
+  event fires at-most-once across replicas; a user-confirmed replay is explicitly
+  re-running an already-claimed slot. The replay chain still re-checks
+  `promise.enabled` and the health job's `enabled`/`kind`, and never touches
+  `last_run_at` — the scheduler's cadence is unaffected. Concurrent recoveries can
+  double-run a health slot; both runs are read-only and the sample upsert is
+  last-write-wins, so this is benign.
+- **D3 — Replayed chained runs are stamped `trigger: "manual"`** (like recovery
+  runs today): the reaper never auto-retries them, and run history distinguishes
+  them from live `event` fires.
+- **D4 — Anomaly baselines must not peek at the future.** For replay runs,
+  `metricHistory` is filtered to samples with `slot_at <` the replayed slot, so
+  robust-bounds checks see only what a live run at that slot could have seen. Live
+  runs keep the unfiltered history. Schema-contract checks evaluate the *current*
+  schema even for historical slots (the historical schema is unknowable); accepted.
+- **D5 — Slot derivation for `POST /data-health/:id/recovery`:**
+  - *event-triggered promise* → the upstream job's **distinct successful run slots**
+    in the range (ground truth of what the pipeline delivered), each evaluated over
+    `resolveWindow(upstream, slot)`;
+  - *cron/daily/weekly/monthly promise* → `fireTimesBetween(healthJob, from, to)`
+    from the current cadence, each over `resolveWindow(healthJob, slot)`;
+  - *manual-frequency promise* → the promise's own distinct recorded live sample
+    slots in the range (there is no cadence to derive from).
+  Windows are recomputed from the **current** schedule; if the cadence was edited
+  since, historical ranges may differ — surfaced as a plan warning, same trade-off
+  the existing scheduled recovery already makes.
+- **D6 — Upstream-failure propagation stays suppressed during recovery.** A failed
+  backfill of an old slot must not mark chained promises `unknown` or open
+  execution incidents; the existing `suppressNotifications` gate on
+  `processUpstreamFailure` already provides this and is kept.
+
+### Notification matrix
+
+| Event | Notification |
+|---|---|
+| Replay of an old slot (any outcome) | none |
+| Replay of the newest slot causing a real incident transition | one, via existing outbox `dedup_key` |
+| Replay run fails to execute | none (run row records the error) |
+| Upstream recovery slot fails | none (unchanged recovery behavior) |
+
+### Performance
+
+No hot-path change. Replays run through the existing runner with all existing caps
+(`priority 10`, 4 GiB memory cap, `max_execution_time`, result-row caps), recovery
+stays sequential and capped at 30 executed slots per request, and each chained
+health check is one single-row aggregate SELECT. New DB work is one indexed upsert
+per check per replayed slot plus two indexed point lookups — negligible on SQLite
+and PostgreSQL. The scheduler tick, claim path, and live run path are untouched.
+
+## Consequences
+
+- Backfilled pipelines can be re-verified end to end with one action, and corrected
+  history recomputes incident streaks correctly (a fixed old slot can legitimately
+  contribute to a recovery streak on the next newest-slot evaluation).
+- The latent stale-state clobbering when recovering a health job's own cadence is
+  fixed by the same mechanism.
+- Sample rows for a slot are mutable under replay (run_id/values/evidence change;
+  row `id` is stable). Anyone treating `data_health_samples` as append-only history
+  must not — the run rows remain the immutable history.
+- Replaying the newest slot can open/escalate/recover incidents. This is intended:
+  the newest slot *defines* current health. The outbox dedup key bounds the noise.
+- A promise whose upstream never succeeded in the range yields an empty plan — the
+  UI must communicate "nothing to rerun" rather than erroring.
+
+## Alternatives considered
+
+- **Delete-then-insert instead of upsert for samples.** Loses row-id stability and
+  needs a transaction to avoid a windowless gap under concurrent reads; the unique
+  key already supports `DO UPDATE` on both dialects. Rejected.
+- **Recompute promise status after every replayed slot** (not just the newest).
+  Requires re-deriving state from the newest slot's samples inside every replay and
+  reasoning about interleaving with live runs; the "newest slot wins, older slots
+  are samples-only" rule gives the same converged result with far less machinery.
+- **A new `replay` trigger enum value.** Would ripple through frontend types and
+  run-history UI for cosmetic benefit; `manual` + replay flag on the request path
+  is sufficient. Rejected.
+- **Queue recovery through the scheduler instead of in-request.** Better for very
+  large backfills but adds a persistent queue and progress UI; the existing 30-slot
+  in-request contract is kept (already the shipped recovery behavior).
+- **Deriving event-promise slots from the promise's own past runs** instead of the
+  upstream's successful slots. Misses slots where the chain was skipped (disabled
+  promise, pre-feature history) — the upstream's delivered slots are the ground
+  truth of what can be verified.
+
+---
+
+## Implementation plan (single PR, end to end)
+
+Every touch point, in dependency order. No migrations; no `VERSION_CHECKS` entry
+needed.
+
+### 1. Data Health store — `packages/server/src/services/dataHealth/store.ts`
+
+- `insertEvaluations(promiseId, runId, slotAt, evaluations, opts?)` — replace the
+  positional `origin` default parameter with
+  `opts: { origin?: "live" | "backtest"; replace?: boolean }` (single caller:
+  `execution.ts`). When `replace` is true, use one dialect-shared statement:
+  `INSERT … ON CONFLICT (check_id, slot_at, origin) DO UPDATE SET run_id = excluded.run_id,
+  outcome = excluded.outcome, observed_value = excluded.observed_value,
+  expected_lower = excluded.expected_lower, expected_upper = excluded.expected_upper,
+  evidence = excluded.evidence, created_at = excluded.created_at`
+  (valid on SQLite ≥ 3.24 and PostgreSQL; the `UNIQUE (check_id, slot_at, origin)`
+  constraint exists in both dialects since the samples table was created). The
+  non-replace branches stay exactly as they are.
+- `latestLiveSlotAt(promiseId): Promise<number | null>` —
+  `SELECT MAX(slot_at) … WHERE promise_id = ? AND origin = 'live'` (covered by
+  `dh_samples_promise_slot_idx`).
+- `listLiveSlotsBetween(promiseId, fromMs, toMs, limit): Promise<number[]>` —
+  `SELECT DISTINCT slot_at … WHERE promise_id = ? AND origin = 'live' AND slot_at
+  BETWEEN ? AND ? ORDER BY slot_at ASC LIMIT ?` (manual-frequency path, D5).
+- `metricHistory(promiseId, limitPerCheck = 100, beforeSlot?: number)` — add the
+  optional strict upper bound `AND slot_at < ?` (D4). Existing callers pass nothing
+  and are unchanged.
+
+### 2. Scheduled Queries store — `packages/server/src/services/scheduledQueries/store.ts`
+
+- `listSuccessfulSlotsBetween(queryId, fromMs, toMs, limit = 100): Promise<number[]>`
+  — `SELECT DISTINCT slot_at FROM scheduled_query_runs WHERE query_id = ? AND
+  status = 'success' AND slot_at BETWEEN ? AND ? ORDER BY slot_at ASC LIMIT ?`
+  (event-promise slot derivation, D5).
+
+### 3. Data Health execution — `packages/server/src/services/dataHealth/execution.ts`
+
+- `processDataHealthSuccess(job, runId, slotAt, observed, client, params, opts?: { replay?: boolean })`:
+  - When `opts.replay`: read `latestLiveSlotAt(promise.id)` **before** inserting
+    this run's samples; fetch history via `metricHistory(promise.id, 100, slotAt)`.
+  - Evaluate checks exactly as today (including schema-contract handling).
+  - Insert samples with `{ replace: true }` when replaying.
+  - If `opts.replay && latest != null && slotAt < latest`: return
+    `{ conditionMet, conditionValue, message, notified: false }` immediately —
+    skipping `updatePromiseEvaluation`, both incident transitions, and all outbox
+    enqueues. The run row still records the evaluation outcome.
+  - Otherwise (live run, or replay of the newest slot) the existing full path runs
+    unchanged — `transitionDataIncident`'s slot-streak logic now sees the corrected
+    samples, and the outbox `dedup_key` (`data-health:<incidentId>:<type>`) already
+    dedupes notifications.
+- `processDataHealthError` — untouched; the runner simply does not call it for
+  replays (step 4).
+
+### 4. Runner — `packages/server/src/services/scheduledQueries/runner.ts`
+
+- `ExecuteOptions` gains `replay?: boolean` and `chainReplay?: boolean` (JSDoc:
+  set only by the recovery routes; absent on every live path).
+- In `execute()`:
+  - success + `kind === "data_health_check"` → pass `{ replay: opts.replay }` to
+    `processDataHealthSuccess`;
+  - error + `kind === "data_health_check"` → call `processDataHealthError` only
+    when `!opts.replay`;
+  - the post-finalize chain block becomes:
+    - `status === "success" && !opts.suppressNotifications` → live chain
+      (unchanged);
+    - `status === "success" && opts.suppressNotifications && opts.chainReplay` →
+      `runChainedDataHealth(job, opts.slotAt, window, { replay: true })`;
+    - error path unchanged (`processUpstreamFailure` still gated by
+      `!opts.suppressNotifications`, D6).
+- `runChainedDataHealth(upstream, slotAt, window, opts?: { replay?: boolean })`:
+  - live (no flag): identical to today, including `claimSlot`;
+  - replay: skip `claimSlot` (D2), keep the `promise.enabled` / health-job
+    `enabled`/`kind` guards, compute `attempt = countRunsForSlot + 1`, and execute
+    with `{ trigger: "manual", slotAt, attempt, window, replay: true,
+    suppressNotifications: true }` (D3).
+
+### 5. Scheduled recovery route — `packages/server/src/routes/scheduled-queries.ts`
+
+- `recoverySchema` gains `rerunChainedHealth: z.boolean().default(false)` (Zod v3).
+- Plan response (both preview and execute) gains
+  `chainedPromises: Array<{ id, name, enabled }>` from
+  `listPromisesByUpstreamJobId(job.id)`, and one more conditional warning: when
+  `job.query` contains `{{prev_run_at}}`, note that the recomputed window depends
+  on prior successes and may not reproduce the original range.
+- The execute loop passes `replay: true` and
+  `chainReplay: body.rerunChainedHealth` in the `ExecuteOptions`. (`replay: true`
+  is inert for `sql_query` jobs and fixes the latent stale-state clobbering when
+  the target is a `data_health_check` job.)
+- Audit details gain `rerunChainedHealth`.
+
+### 6. Data Health recovery route — `packages/server/src/routes/data-health.ts`
+
+New `POST /data-health/:id/recovery`, `requirePermission(PERMISSIONS.DATA_HEALTH_RUN)`,
+body (Zod v3): `{ from: int, to: int, execute: bool = false, confirm: bool = false }`
+with the same `from <= to` refinement as the scheduled route.
+
+1. `loadVisiblePromise` (owner scoping identical to `/run`), load the backing job,
+   `AppError.internal` if missing / wrong kind.
+2. Derive `slots: Array<{ slotAt, window, hasSamples }>` per D5 (event → upstream
+   successful slots via `listSuccessfulSlotsBetween` + `resolveWindow(upstream, slot)`;
+   cadence → `fireTimesBetween` + `resolveWindow(healthJob, slot)`; manual →
+   `listLiveSlotsBetween`); `hasSamples` from comparing against the promise's live
+   slots in range. Cap the preview at 100 slots (same constant as scheduled).
+3. Warnings: 100-slot preview cap; "windows recomputed from the current schedule";
+   for event promises with zero upstream successes, the plan is empty (not an
+   error).
+4. `!execute` → return `{ plan, runnable, warnings }`. `execute && !confirm` →
+   `AppError.badRequest`. More than 30 runnable slots → `AppError.badRequest`
+   (same contract as scheduled recovery).
+5. Execute sequentially: `runner.execute(healthJob, { trigger: "manual", slotAt,
+   attempt: 1, window, replay: true, suppressNotifications: true })`, collecting
+   run rows.
+6. Audit: `AUDIT_ACTIONS.DATA_HEALTH_PROMISE_RUN` with
+   `details: { recovery: true, from, to, slots: runs.length }`.
+
+### 7. Frontend API clients (tests required — `src/api/*` rule)
+
+- `src/api/scheduledQueries.ts` — `recoverScheduledQuery` input gains
+  `rerunChainedHealth?: boolean`; `ScheduledRecoveryResult` gains
+  `chainedPromises?: Array<{ id: string; name: string; enabled: boolean }>`.
+- `src/api/dataHealth.ts` — new
+  `DataHealthRecoveryResult { plan: Array<{ slotAt: number; hasSamples: boolean }>;
+  runnable: number; warnings: string[]; runs?: DataHealthRun[] }` and
+  `recoverDataHealthPromise(id, input: { from: number; to: number;
+  execute?: boolean; confirm?: boolean })`.
+- Extend `src/api/scheduledQueries.test.ts` and `src/api/dataHealth.test.ts` with
+  MSW handlers covering both preview and execute shapes.
+
+### 8. Frontend UI
+
+- `src/features/scheduled-queries/JobDetail.tsx` — in the existing recovery
+  dialog: when the preview returns `chainedPromises.length > 0`, render a checkbox
+  ("Also rerun linked Data Health promises over the same windows") listing the
+  promise names, default unchecked; pass the flag on execute; surface the new
+  warnings verbatim.
+- `src/features/data-health/PromiseDetail.tsx` — a "Rerun range" action next to
+  "Run now" (gated by `PermissionGuard` on `DATA_HEALTH_RUN`), opening a dialog
+  that mirrors the JobDetail recovery flow: from/to datetime-local inputs
+  (default: last 7 days), Plan → slot list with an "already evaluated" marker and
+  warnings, then Confirm & Execute; on completion, toast the run count and refetch
+  the promise + timeline queries. Empty plan renders "No slots to rerun in this
+  range", with the execute button disabled.
+- Client errors follow the standard pattern (`toast.error` + `log.error`).
+
+### 9. Server tests (Bun, via `./scripts/test-isolated-server.sh`)
+
+- `dataHealth/store.test.ts` — replace-mode upsert: insert a slot, replay it with
+  different values, assert one row per (check, slot), updated values/run_id,
+  stable row id; `latestLiveSlotAt` (empty → null, ignores `backtest` origin);
+  `listLiveSlotsBetween` bounds/ordering/dedup; `metricHistory` `beforeSlot`
+  filtering (and unfiltered default unchanged).
+- New `dataHealth/execution.test.ts` (mock the store/client boundaries as the
+  existing evaluator/diagnostics tests do):
+  - replay of an old slot: samples replaced, `updatePromiseEvaluation` /
+    incident transitions / outbox never invoked;
+  - replay of the newest slot: full path invoked;
+  - live run: behavior identical with the new signature defaults.
+- `scheduledQueries/store.test.ts` — `listSuccessfulSlotsBetween` (status filter,
+  range bounds, DISTINCT, ordering, limit).
+- Runner chain gating: unit-test the decision table (live chain / replay chain /
+  no chain) — extract the gate condition into a small pure helper if needed to
+  keep it testable without a ClickHouse client.
+
+### 10. Housekeeping
+
+- Changelog fragment `changelogs/unreleased/<pr>-clear-and-rerun.md`, `type: minor`,
+  `### Added` (chained recovery + Data Health range rerun).
+- Update the ADR index in `docs/adr/README.md` (done alongside this ADR).
+- Pre-merge gate: `bun run lint`, `bun run typecheck`, `bunx vitest run`,
+  `./scripts/test-isolated-server.sh`; dead-code scan of touched files per
+  `.rules/DEAD_CODE.md`.
+
+### No-regression invariants (each is asserted by a test above)
+
+1. Live scheduled/manual/event runs never set `replay`/`chainReplay` — with both
+   flags absent, `execute()`'s behavior is unchanged, including notifications.
+2. Replays never call `claimSlot` and never write `last_run_at` — scheduler cadence
+   and the multi-replica lease are untouched.
+3. Every replay goes through `execute()`'s existing read-only re-validation and
+   owner data-access re-check — recovery cannot become a privilege bypass.
+4. Old-slot replays cannot change promise status, incidents, or notify.
+5. Sample uniqueness per (check, slot, origin) is preserved under replay; `backtest`
+   origin rows are never touched.
+6. Outbox `dedup_key` uniqueness bounds notifications from newest-slot replays.
+7. No change to `rbac/db/migrations.ts` — schema is untouched.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -31,6 +31,7 @@ We use a lightweight [MADR](https://adr.github.io/madr/)-style template:
 | [0004](0004-dataops-ai-operator-assistance.md) | Evidence-grounded DataOps AI operator assistance | Accepted |
 | [0005](0005-unified-first-install-onboarding.md) | Unified first-install and product onboarding | Accepted |
 | [0006](0006-event-triggered-data-health.md) | Event-triggered Data Health (pipeline-chained promises) | Accepted |
+| [0007](0007-clear-and-rerun-for-scheduled-jobs-and-data-health.md) | Clear & Rerun for Scheduled Jobs and Data Health | Accepted |
 
 ## Conventions
 

--- a/packages/server/src/routes/data-health.ts
+++ b/packages/server/src/routes/data-health.ts
@@ -11,7 +11,7 @@ import { compileDataHealthQuery, eventTimeTypeFromSchema, isDateOnlyEventTimeTyp
 import { backtestDataHealth, buildFailingRowsQuery, runFailingRowsDiagnostic } from "../services/dataHealth/diagnostics";
 import * as healthStore from "../services/dataHealth/store";
 import { DATA_HEALTH_EVENT_TIME_ENCODINGS, dataHealthCheckDefinitionSchema } from "../services/dataHealth/types";
-import { isValidTimeZone, nextFireTimes, validateCron } from "../services/scheduledQueries/cadence";
+import { fireTimesBetween, isValidTimeZone, nextFireTimes, validateCron } from "../services/scheduledQueries/cadence";
 import * as runner from "../services/scheduledQueries/runner";
 import * as scheduledStore from "../services/scheduledQueries/store";
 import { DATA_HEALTH_FREQUENCIES, type ScheduledQueryRow, type SqFrequency } from "../services/scheduledQueries/types";
@@ -691,6 +691,115 @@ dataHealth.post("/:id/run", requirePermission(PERMISSIONS.DATA_HEALTH_RUN), asyn
   await createAuditLogWithContext(c, AUDIT_ACTIONS.DATA_HEALTH_PROMISE_RUN, currentUser(c).sub, { resourceType: "data_health_promise", resourceId: promise.id });
   return ok(c, { run });
 });
+
+/**
+ * Clear & rerun ONE historical evaluation (ADR 0007) — re-evaluates that run's
+ * slot over the same window (the upstream's window for event promises) and
+ * replaces the slot's samples. Replay semantics apply: only the newest slot can
+ * change current status or incidents.
+ */
+dataHealth.post("/:id/runs/:runId/rerun", requirePermission(PERMISSIONS.DATA_HEALTH_RUN), async (c) => {
+  const promise = await loadVisiblePromise(c, requireParam(c, "id"));
+  const healthJob = await scheduledStore.getJob(promise.scheduledQueryId);
+  if (!healthJob || healthJob.kind !== "data_health_check") throw AppError.internal("Data Health execution job is missing");
+  const original = await scheduledStore.getRun(requireParam(c, "runId"));
+  if (!original || original.queryId !== healthJob.id) throw AppError.notFound("Run not found");
+  let window: runner.WindowParams | undefined;
+  if (promise.upstreamJobId) {
+    const upstream = await scheduledStore.getJob(promise.upstreamJobId);
+    if (upstream) window = await runner.resolveWindow(upstream, original.slotAt);
+  }
+  const attempt = (await scheduledStore.countRunsForSlot(healthJob.id, original.slotAt)) + 1;
+  const run = await runner.execute(healthJob, {
+    trigger: "manual",
+    slotAt: original.slotAt,
+    attempt,
+    window,
+    replay: true,
+    suppressNotifications: true,
+  });
+  await createAuditLogWithContext(c, AUDIT_ACTIONS.DATA_HEALTH_PROMISE_RUN, currentUser(c).sub, {
+    resourceType: "data_health_promise",
+    resourceId: promise.id,
+    details: { rerunOf: original.id, slotAt: original.slotAt },
+  });
+  return ok(c, { run });
+});
+
+const healthRecoverySchema = z.object({
+  from: z.number().int(),
+  to: z.number().int(),
+  execute: z.boolean().default(false),
+  confirm: z.boolean().default(false),
+}).refine((value) => value.from <= value.to, "Start must precede end");
+
+/**
+ * Clear & rerun a promise over a time range (ADR 0007). Slots come from the
+ * ground truth for the promise's run mode (D5): an event promise re-verifies the
+ * upstream's successfully delivered slots; a cron-cadence promise re-derives fire
+ * times from its CURRENT schedule; a manual promise re-evaluates its recorded
+ * slots. Every replayed slot replaces its samples; only the newest slot can move
+ * status/incidents (enforced inside the runner's replay path).
+ */
+dataHealth.post(
+  "/:id/recovery",
+  requirePermission(PERMISSIONS.DATA_HEALTH_RUN),
+  zValidator("json", healthRecoverySchema),
+  async (c) => {
+    const promise = await loadVisiblePromise(c, requireParam(c, "id"));
+    const body = c.req.valid("json");
+    const healthJob = await scheduledStore.getJob(promise.scheduledQueryId);
+    if (!healthJob || healthJob.kind !== "data_health_check") throw AppError.internal("Data Health execution job is missing");
+
+    const warnings: string[] = [];
+    let slots: number[] = [];
+    // The job whose cadence defines each slot's window (the upstream for event promises).
+    let windowJob: ScheduledQueryRow = healthJob;
+    if (promise.upstreamJobId) {
+      const upstream = await scheduledStore.getJob(promise.upstreamJobId);
+      if (!upstream) {
+        warnings.push("The linked upstream job no longer exists; nothing to rerun");
+      } else {
+        windowJob = upstream;
+        slots = await scheduledStore.listSuccessfulSlotsBetween(upstream.id, body.from, body.to, 100);
+        if (slots.length === 0) warnings.push("The upstream pipeline has no successful runs in this range");
+      }
+    } else if (healthJob.frequency === "manual") {
+      slots = await healthStore.listLiveSlotsBetween(promise.id, body.from, body.to, 100);
+      if (slots.length === 0) warnings.push("No evaluated slots in this range");
+    } else {
+      slots = fireTimesBetween(healthJob, body.from, body.to, 100);
+      warnings.push("Windows are recomputed from the current schedule; if the schedule changed since, historical ranges may differ");
+    }
+    if (slots.length === 100) warnings.push("Range reached the 100-slot preview limit");
+
+    const evaluated = new Set(await healthStore.listLiveSlotsBetween(promise.id, body.from, body.to, 100));
+    const plan = slots.map((slotAt) => ({ slotAt, hasSamples: evaluated.has(slotAt) }));
+    if (!body.execute) return ok(c, { plan, runnable: plan.length, warnings });
+    if (!body.confirm) throw AppError.badRequest("Recovery execution requires explicit confirmation");
+    if (plan.length > 30) throw AppError.badRequest("Execute at most 30 recovery slots per request");
+
+    const runs = [];
+    for (const slot of plan) {
+      const window = await runner.resolveWindow(windowJob, slot.slotAt);
+      const run = await runner.execute(healthJob, {
+        trigger: "manual",
+        slotAt: slot.slotAt,
+        attempt: 1,
+        window,
+        replay: true,
+        suppressNotifications: true,
+      });
+      if (run) runs.push(run);
+    }
+    await createAuditLogWithContext(c, AUDIT_ACTIONS.DATA_HEALTH_PROMISE_RUN, currentUser(c).sub, {
+      resourceType: "data_health_promise",
+      resourceId: promise.id,
+      details: { recovery: true, from: body.from, to: body.to, slots: runs.length },
+    });
+    return ok(c, { plan, runnable: plan.length, warnings, runs });
+  },
+);
 
 dataHealth.delete("/:id", requirePermission(PERMISSIONS.DATA_HEALTH_DELETE), async (c) => {
   const promise = await loadVisiblePromise(c, requireParam(c, "id"));

--- a/packages/server/src/routes/scheduled-queries.ts
+++ b/packages/server/src/routes/scheduled-queries.ts
@@ -379,6 +379,7 @@ const recoverySchema = z.object({
   execute: z.boolean().default(false),
   confirm: z.boolean().default(false),
   rerunSuccessful: z.boolean().default(false),
+  rerunChainedHealth: z.boolean().default(false),
 }).refine((value) => value.from <= value.to, "Start must precede end");
 
 scheduledQueries.post(
@@ -392,27 +393,66 @@ scheduledQueries.post(
     const existing = await Promise.all(slots.map((slotAt) => store.hasSuccessfulRunForSlot(job.id, slotAt)));
     const plan = slots.map((slotAt, index) => ({ slotAt, alreadySucceeded: existing[index] }));
     const runnable = plan.filter((slot) => body.rerunSuccessful || !slot.alreadySucceeded);
+    const chainedPromises = (await listPromisesByUpstreamJobId(job.id))
+      .map((promise) => ({ id: promise.id, name: promise.name, enabled: promise.enabled }));
     const warnings = [
       ...(slots.length === 100 ? ["Range reached the 100-slot preview limit"] : []),
       ...(job.outputMode === "append" ? ["Append recovery depends on ClickHouse deduplication being enabled for the destination engine"] : []),
       ...(job.outputMode === "upsert" ? ["Upsert recovery deduplicates eventually after merges"] : []),
+      ...(job.query.includes("{{prev_run_at}}") ? ["This query uses {{prev_run_at}}; its window depends on prior successes and a rerun may not reproduce the original range"] : []),
     ];
-    if (!body.execute) return ok(c, { plan, runnable: runnable.length, warnings });
+    if (!body.execute) return ok(c, { plan, runnable: runnable.length, warnings, chainedPromises });
     if (!body.confirm) throw AppError.badRequest("Recovery execution requires explicit confirmation");
     if (runnable.length > 30) throw AppError.badRequest("Execute at most 30 recovery slots per request");
     const runs = [];
     for (const slot of runnable) {
-      const run = await runner.execute(job, { trigger: "manual", slotAt: slot.slotAt, attempt: 1, suppressNotifications: true });
+      const run = await runner.execute(job, {
+        trigger: "manual",
+        slotAt: slot.slotAt,
+        attempt: 1,
+        suppressNotifications: true,
+        replay: true,
+        chainReplay: body.rerunChainedHealth,
+      });
       if (run) runs.push(run);
     }
     await createAuditLogWithContext(c, AUDIT_ACTIONS.SCHEDULED_QUERY_RUN, userId(c), {
       resourceType: "scheduled_query",
       resourceId: job.id,
-      details: { recovery: true, from: body.from, to: body.to, slots: runs.length },
+      details: { recovery: true, from: body.from, to: body.to, slots: runs.length, rerunChainedHealth: body.rerunChainedHealth },
     });
-    return ok(c, { plan, runnable: runnable.length, warnings, runs });
+    return ok(c, { plan, runnable: runnable.length, warnings, chainedPromises, runs });
   },
 );
+
+/**
+ * Clear & rerun ONE historical run's slot (ADR 0007) — the per-run analogue of
+ * the range recovery. Re-executes the run's slot over its deterministic window
+ * with replay semantics, and — because a rerun of a materializing slot must
+ * re-verify what it rewrote — always replays chained Data Health promises over
+ * the same window. Notifications stay suppressed.
+ */
+scheduledQueries.post("/runs/:runId/rerun", requirePermission(PERMISSIONS.SCHEDULED_QUERIES_RUN), async (c) => {
+  const original = await store.getRun(requireParam(c, "runId"));
+  if (!original) throw AppError.notFound("Run not found");
+  const job = await loadVisibleJob(c, original.queryId);
+  if (job.kind !== "sql_query") throw AppError.badRequest("Use the Data Health rerun for health check runs");
+  const attempt = (await store.countRunsForSlot(job.id, original.slotAt)) + 1;
+  const run = await runner.execute(job, {
+    trigger: "manual",
+    slotAt: original.slotAt,
+    attempt,
+    suppressNotifications: true,
+    replay: true,
+    chainReplay: true,
+  });
+  await createAuditLogWithContext(c, AUDIT_ACTIONS.SCHEDULED_QUERY_RUN, userId(c), {
+    resourceType: "scheduled_query",
+    resourceId: job.id,
+    details: { rerunOf: original.id, slotAt: original.slotAt },
+  });
+  return ok(c, { run });
+});
 
 // --- runs -------------------------------------------------------------------
 

--- a/packages/server/src/services/dataHealth/execution.ts
+++ b/packages/server/src/services/dataHealth/execution.ts
@@ -50,6 +50,17 @@ function evaluationSummary(name: string, result: ReturnType<typeof evaluateDataH
   return `${name}: ${breached.map((check) => `${check.checkKey} (${check.observedValue ?? "no value"})`).join(", ")}`;
 }
 
+export interface ProcessDataHealthOptions {
+  /**
+   * Replay (clear & rerun, ADR 0007): replace the slot's samples instead of
+   * keeping them, bound anomaly history to earlier slots, and — when the slot is
+   * strictly older than the newest evaluated slot — skip status updates, incident
+   * transitions, and notifications entirely. Only the newest slot defines current
+   * health.
+   */
+  replay?: boolean;
+}
+
 export async function processDataHealthSuccess(
   job: ScheduledQueryRow,
   runId: string,
@@ -57,10 +68,17 @@ export async function processDataHealthSuccess(
   observed: Record<string, unknown>,
   client: ClickHouseClient,
   params: Record<string, string>,
+  opts: ProcessDataHealthOptions = {},
 ): Promise<DataHealthRunEvaluation> {
   const promise = await store.getPromiseByJobId(job.id);
   if (!promise) throw new Error("Data Health promise metadata is missing for the scheduled job");
-  const [checks, history] = await Promise.all([store.getChecks(promise.id), store.metricHistory(promise.id)]);
+  // The newest previously-evaluated slot, read BEFORE this run's samples land, so
+  // "older than newest" compares against prior history (a first-ever slot is newest).
+  const latestLiveSlot = opts.replay ? await store.latestLiveSlotAt(promise.id) : null;
+  const [checks, history] = await Promise.all([
+    store.getChecks(promise.id),
+    store.metricHistory(promise.id, 100, opts.replay ? slotAt : undefined),
+  ]);
   const result = evaluateDataHealth(checks, observed, history);
   const schemaChecks = checks.filter((check): check is SchemaContractCheck => check.type === "schema_contract" && check.enabled);
   if (schemaChecks.length > 0) {
@@ -89,9 +107,19 @@ export async function processDataHealthSuccess(
     const breaches = result.checks.filter((check) => check.outcome === "breach");
     result.state = breaches.some((check) => check.severity === "critical") ? "unhealthy" : breaches.length > 0 ? "degraded" : "healthy";
   }
-  await store.insertEvaluations(promise.id, runId, slotAt, result.checks);
-  await store.updatePromiseEvaluation(promise.id, result.state, Date.now());
+  await store.insertEvaluations(promise.id, runId, slotAt, result.checks, { replace: opts.replay });
   const summary = evaluationSummary(promise.name, result);
+  // Replay of a slot older than the newest evaluated slot rewrites its samples
+  // only — current status, incidents, and channels belong to the newest slot.
+  if (opts.replay && latestLiveSlot != null && slotAt < latestLiveSlot) {
+    return {
+      conditionMet: result.state === "degraded" || result.state === "unhealthy",
+      conditionValue: result.state,
+      message: result.state === "healthy" ? null : summary,
+      notified: false,
+    };
+  }
+  await store.updatePromiseEvaluation(promise.id, result.state, Date.now());
   const executionRecovery = await store.transitionExecutionIncident(promise, false, runId, `${promise.name} monitor execution recovered`);
   const transition = await store.transitionDataIncident(promise, result.state, runId, summary);
   let notified = false;

--- a/packages/server/src/services/dataHealth/store.test.ts
+++ b/packages/server/src/services/dataHealth/store.test.ts
@@ -1,12 +1,14 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { sql } from "drizzle-orm";
 
+import type { ClickHouseClient } from "@clickhouse/client";
+
 import { closeDatabase } from "../../rbac/db";
 import { runMigrations } from "../../rbac/db/migrations";
 import { freshDatabase, rawRun } from "../../rbac/db/migrationTestHarness";
 import * as scheduledStore from "../scheduledQueries/store";
-import type { DataHealthCheckDefinition } from "./types";
-import { currentDataHealthJob, processUpstreamFailure } from "./execution";
+import type { DataHealthCheckDefinition, DataHealthMetricEvaluation } from "./types";
+import { currentDataHealthJob, processDataHealthSuccess, processUpstreamFailure } from "./execution";
 import * as store from "./store";
 
 const jobInput: scheduledStore.JobInput = {
@@ -209,6 +211,81 @@ describe("Data Health store", () => {
     // Disabled promises are left untouched.
     expect((await store.getPromise(disabledPromiseId))?.status).toBe("unknown"); // creation default, unchanged
     expect((await store.listIncidents(disabledPromiseId)).length).toBe(0);
+  });
+
+  it("replaces a slot's samples on replay and reports slot helpers", async () => {
+    const jobId = await scheduledStore.createJob(jobInput, "owner-1", "data_health_check");
+    const promiseId = await store.createPromiseMetadata(promiseInput(jobId));
+    await store.replaceChecks(promiseId, checks);
+    expect(await store.latestLiveSlotAt(promiseId)).toBeNull();
+
+    const evaluation = (outcome: "pass" | "breach", value: number): DataHealthMetricEvaluation[] => [{
+      checkKey: "rows", type: "row_count", severity: "critical", outcome, observedValue: value, expectedLower: 100, expectedUpper: null, message: outcome,
+    }];
+
+    await store.insertEvaluations(promiseId, "run-1", 1_000, evaluation("breach", 50));
+    // Default mode keeps the first sample for a slot (dedup, not replace).
+    await store.insertEvaluations(promiseId, "run-dup", 1_000, evaluation("pass", 120));
+    let samples = await store.listSamples(promiseId);
+    expect(samples.length).toBe(1);
+    expect(samples[0]).toMatchObject({ runId: "run-1", outcome: "breach", observedValue: 50 });
+    const originalId = samples[0].id;
+
+    // Replay overwrites in place: same row id, new run/outcome/values.
+    await store.insertEvaluations(promiseId, "run-replay", 1_000, evaluation("pass", 120), { replace: true });
+    samples = await store.listSamples(promiseId);
+    expect(samples.length).toBe(1);
+    expect(samples[0]).toMatchObject({ id: originalId, runId: "run-replay", outcome: "pass", observedValue: 120 });
+
+    await store.insertEvaluations(promiseId, "run-2", 2_000, evaluation("breach", 40));
+    expect(await store.latestLiveSlotAt(promiseId)).toBe(2_000);
+    expect(await store.listLiveSlotsBetween(promiseId, 0, 5_000)).toEqual([1_000, 2_000]);
+    expect(await store.listLiveSlotsBetween(promiseId, 1_500, 5_000)).toEqual([2_000]);
+    // History is newest-slot-first; the replay bound hides the replayed slot and later.
+    expect(await store.metricHistory(promiseId)).toEqual({ rows: [40, 120] });
+    expect(await store.metricHistory(promiseId, 100, 2_000)).toEqual({ rows: [120] });
+
+    // Backtest-origin rows never count as live history or slots.
+    await store.insertEvaluations(promiseId, "run-bt", 9_000, evaluation("pass", 130), { origin: "backtest" });
+    expect(await store.latestLiveSlotAt(promiseId)).toBe(2_000);
+    expect(await store.listLiveSlotsBetween(promiseId, 0, 10_000)).toEqual([1_000, 2_000]);
+  });
+
+  it("replays old slots silently and lets only the newest slot move status and incidents", async () => {
+    const jobId = await scheduledStore.createJob(jobInput, "owner-1", "data_health_check");
+    const promiseId = await store.createPromiseMetadata(promiseInput(jobId));
+    await store.replaceChecks(promiseId, checks);
+    const job = await scheduledStore.getJob(jobId);
+    if (!job) throw new Error("Scheduled job was not created");
+    // No schema_contract checks are configured, so the client is never used.
+    const client = {} as unknown as ClickHouseClient;
+    const params: Record<string, string> = {};
+
+    // Live evaluation of slot 2000 → healthy baseline.
+    const live = await processDataHealthSuccess(job, "run-live", 2_000, { rows: 120 }, client, params);
+    expect(live.conditionValue).toBe("healthy");
+    expect((await store.getPromise(promiseId))?.status).toBe("healthy");
+
+    // Replaying an OLDER slot with breaching data rewrites its samples only.
+    const replayOld = await processDataHealthSuccess(job, "run-replay-old", 1_000, { rows: 10 }, client, params, { replay: true });
+    expect(replayOld.conditionValue).toBe("unhealthy");
+    expect(replayOld.notified).toBe(false);
+    expect((await store.getPromise(promiseId))?.status).toBe("healthy");
+    expect((await store.listIncidents(promiseId)).length).toBe(0);
+    expect((await scheduledStore.listClaimableOutbox(10)).length).toBe(0);
+    const oldSamples = (await store.listSamples(promiseId)).filter((sample) => sample.slotAt === 1_000);
+    expect(oldSamples.length).toBe(1);
+    expect(oldSamples[0]).toMatchObject({ runId: "run-replay-old", outcome: "breach" });
+
+    // Replaying the NEWEST slot takes the full path: status and incidents move.
+    await processDataHealthSuccess(job, "run-replay-new", 2_000, { rows: 20 }, client, params, { replay: true });
+    expect((await store.getPromise(promiseId))?.status).toBe("unhealthy");
+    const incidents = await store.listIncidents(promiseId);
+    expect(incidents.length).toBe(1);
+    expect(incidents[0]).toMatchObject({ kind: "data", status: "open" });
+    const newestSamples = (await store.listSamples(promiseId)).filter((sample) => sample.slotAt === 2_000);
+    expect(newestSamples.length).toBe(1);
+    expect(newestSamples[0]).toMatchObject({ runId: "run-replay-new", outcome: "breach", observedValue: 20 });
   });
 
   it("keeps generated health jobs out of normal Scheduled Queries lists and overview", async () => {

--- a/packages/server/src/services/dataHealth/store.ts
+++ b/packages/server/src/services/dataHealth/store.ts
@@ -270,13 +270,20 @@ export async function getChecks(promiseId: string): Promise<DataHealthCheckDefin
   }));
 }
 
+export interface InsertEvaluationsOptions {
+  origin?: "live" | "backtest";
+  /** Replay mode: overwrite an existing sample for the same (check, slot, origin) instead of keeping it. */
+  replace?: boolean;
+}
+
 export async function insertEvaluations(
   promiseId: string,
   runId: string,
   slotAt: number,
   evaluations: DataHealthMetricEvaluation[],
-  origin: "live" | "backtest" = "live",
+  opts: InsertEvaluationsOptions = {},
 ): Promise<void> {
+  const origin = opts.origin ?? "live";
   const checkRows = await all(sql`SELECT id, check_key FROM data_health_promise_checks WHERE promise_id = ${promiseId}`);
   const ids = new Map(checkRows.map((row) => [String(row.check_key), String(row.id)]));
   const now = Date.now();
@@ -284,6 +291,27 @@ export async function insertEvaluations(
     const checkId = ids.get(evaluation.checkKey);
     if (!checkId) continue;
     const evidence = JSON.stringify({ message: evaluation.message });
+    if (opts.replace) {
+      // Same syntax on SQLite (>=3.24) and PostgreSQL; the UNIQUE (check_id,
+      // slot_at, origin) constraint is the conflict target. The row id is stable.
+      await run(sql`
+        INSERT INTO data_health_samples (
+          id, promise_id, check_id, run_id, origin, outcome, observed_value,
+          expected_lower, expected_upper, evidence, slot_at, created_at
+        ) VALUES (
+          ${randomUUID()}, ${promiseId}, ${checkId}, ${runId}, ${origin}, ${evaluation.outcome}, ${evaluation.observedValue},
+          ${evaluation.expectedLower}, ${evaluation.expectedUpper}, ${evidence}, ${slotAt}, ${now}
+        ) ON CONFLICT (check_id, slot_at, origin) DO UPDATE SET
+          run_id = excluded.run_id,
+          outcome = excluded.outcome,
+          observed_value = excluded.observed_value,
+          expected_lower = excluded.expected_lower,
+          expected_upper = excluded.expected_upper,
+          evidence = excluded.evidence,
+          created_at = excluded.created_at
+      `);
+      continue;
+    }
     if (getDatabaseType() === "sqlite") {
       await run(sql`
         INSERT OR IGNORE INTO data_health_samples (
@@ -308,18 +336,40 @@ export async function insertEvaluations(
   }
 }
 
-export async function metricHistory(promiseId: string, limitPerCheck = 100): Promise<Record<string, number[]>> {
+export async function metricHistory(promiseId: string, limitPerCheck = 100, beforeSlot?: number): Promise<Record<string, number[]>> {
   const checks = await all(sql`SELECT id, check_key FROM data_health_promise_checks WHERE promise_id = ${promiseId}`);
   const history: Record<string, number[]> = {};
+  // Replays bound history to slots strictly before the replayed slot so anomaly
+  // baselines never see data a live run at that slot could not have seen (ADR 0007 D4).
+  const slotBound = beforeSlot == null ? sql`` : sql`AND slot_at < ${beforeSlot}`;
   for (const check of checks) {
     const rows = await all(sql`
       SELECT observed_value FROM data_health_samples
-      WHERE check_id = ${String(check.id)} AND observed_value IS NOT NULL AND outcome IN ('pass', 'breach')
+      WHERE check_id = ${String(check.id)} AND observed_value IS NOT NULL AND outcome IN ('pass', 'breach') ${slotBound}
       ORDER BY slot_at DESC LIMIT ${limitPerCheck}
     `);
     history[String(check.check_key)] = rows.map((row) => Number(row.observed_value)).filter(Number.isFinite);
   }
   return history;
+}
+
+/** The newest live-evaluated slot for a promise, or null when it has never evaluated. */
+export async function latestLiveSlotAt(promiseId: string): Promise<number | null> {
+  const rows = await all(sql`
+    SELECT MAX(slot_at) AS latest FROM data_health_samples
+    WHERE promise_id = ${promiseId} AND origin = 'live'
+  `);
+  return rows[0]?.latest == null ? null : Number(rows[0].latest);
+}
+
+/** Distinct live-evaluated slots in [fromMs, toMs], ascending (manual-cadence replays, ADR 0007 D5). */
+export async function listLiveSlotsBetween(promiseId: string, fromMs: number, toMs: number, limit = 100): Promise<number[]> {
+  const rows = await all(sql`
+    SELECT DISTINCT slot_at FROM data_health_samples
+    WHERE promise_id = ${promiseId} AND origin = 'live' AND slot_at >= ${fromMs} AND slot_at <= ${toMs}
+    ORDER BY slot_at ASC LIMIT ${limit}
+  `);
+  return rows.map((row) => Number(row.slot_at));
 }
 
 export async function updatePromiseEvaluation(id: string, state: Exclude<DataHealthPromiseState, "paused">, evaluatedAt: number): Promise<void> {

--- a/packages/server/src/services/scheduledQueries/runner.test.ts
+++ b/packages/server/src/services/scheduledQueries/runner.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "bun:test";
+
+import { chainActionFor } from "./runner";
+
+const materializing = { kind: "sql_query", outputMode: "replace" } as const;
+const readOnly = { kind: "sql_query", outputMode: "none" } as const;
+const healthJob = { kind: "data_health_check", outputMode: "none" } as const;
+
+describe("chainActionFor", () => {
+  it("chains live after a successful unsuppressed materialize run (ADR 0006)", () => {
+    expect(chainActionFor(materializing, "success", {})).toBe("live");
+  });
+
+  it("propagates upstream failure only on unsuppressed runs", () => {
+    expect(chainActionFor(materializing, "error", {})).toBe("upstream-failure");
+    expect(chainActionFor(materializing, "error", { suppressNotifications: true })).toBe("none");
+    expect(chainActionFor(materializing, "error", { suppressNotifications: true, chainReplay: true })).toBe("none");
+  });
+
+  it("keeps recovery silent unless the replay chain is explicitly requested (ADR 0007)", () => {
+    expect(chainActionFor(materializing, "success", { suppressNotifications: true })).toBe("none");
+    expect(chainActionFor(materializing, "success", { suppressNotifications: true, chainReplay: true })).toBe("replay");
+  });
+
+  it("never chains read-only or health jobs", () => {
+    expect(chainActionFor(readOnly, "success", {})).toBe("none");
+    expect(chainActionFor(readOnly, "success", { suppressNotifications: true, chainReplay: true })).toBe("none");
+    expect(chainActionFor(healthJob, "success", {})).toBe("none");
+    expect(chainActionFor(healthJob, "success", { suppressNotifications: true, chainReplay: true })).toBe("none");
+  });
+});

--- a/packages/server/src/services/scheduledQueries/runner.ts
+++ b/packages/server/src/services/scheduledQueries/runner.ts
@@ -181,6 +181,19 @@ export interface ExecuteOptions {
    * sees exactly the slice the pipeline just wrote (ADR 0006).
    */
   window?: WindowParams;
+  /**
+   * Clear & rerun (ADR 0007): set ONLY by the recovery routes, never on a live
+   * path. Data Health replays replace the slot's samples, and a replay of a
+   * non-newest slot never touches promise status, incidents, or notifications.
+   * A failed replay records its run row without marking the promise unknown.
+   */
+  replay?: boolean;
+  /**
+   * Recovery opt-in (ADR 0007): after a successful suppressed (recovery) run of a
+   * materializing job, replay its chained Data Health promises over this run's
+   * window. Ignored on live runs — those chain through the ADR 0006 path.
+   */
+  chainReplay?: boolean;
 }
 
 /** Insert the `running` row and return the run id (the ClickHouse query_id). */
@@ -261,7 +274,7 @@ export async function execute(job: ScheduledQueryRow, opts: ExecuteOptions): Pro
         window: { slot_start: params.sq_slot_start, slot_end: params.sq_slot_end, prev_run_at: params.sq_prev_run_at },
       });
       if (job.kind === "data_health_check") {
-        const evaluation = await processDataHealthSuccess(job, runId, opts.slotAt, outcome.snapshot[0] ?? {}, client, params);
+        const evaluation = await processDataHealthSuccess(job, runId, opts.slotAt, outcome.snapshot[0] ?? {}, client, params, { replay: opts.replay });
         conditionValue = evaluation.conditionValue;
         conditionMet = evaluation.conditionMet;
         message = evaluation.message;
@@ -307,7 +320,9 @@ export async function execute(job: ScheduledQueryRow, opts: ExecuteOptions): Pro
       }
     }
     logger.warn({ module: "ScheduledQueries", jobId: job.id, runId, err: message }, "Scheduled query run failed");
-    if (job.kind === "data_health_check") {
+    // A failed REPLAY only records its run row — re-checking history must never
+    // mark the promise unknown or open execution incidents (ADR 0007).
+    if (job.kind === "data_health_check" && !opts.replay) {
       try {
         notified = await processDataHealthError(job, runId, message);
       } catch (healthError) {
@@ -337,24 +352,42 @@ export async function execute(job: ScheduledQueryRow, opts: ExecuteOptions): Pro
     finishedAt,
   });
 
-  // ADR 0006 — event-triggered Data Health. Only materializing SQL jobs can have
-  // chained promises; recovery backfills (suppressNotifications) stay silent.
-  if (job.kind === "sql_query" && job.outputMode !== "none" && !opts.suppressNotifications) {
-    if (status === "success") {
-      await runChainedDataHealth(job, opts.slotAt, window);
-    } else {
-      try {
-        await processUpstreamFailure(job, runId, message ?? "unknown error");
-      } catch (err) {
-        logger.warn(
-          { module: "DataHealth", jobId: job.id, runId, err: err instanceof Error ? err.message : String(err) },
-          "Failed to propagate upstream failure to chained Data Health promises",
-        );
-      }
+  const chained = chainActionFor(job, status, opts);
+  if (chained === "live" || chained === "replay") {
+    await runChainedDataHealth(job, opts.slotAt, window, { replay: chained === "replay" });
+  } else if (chained === "upstream-failure") {
+    try {
+      await processUpstreamFailure(job, runId, message ?? "unknown error");
+    } catch (err) {
+      logger.warn(
+        { module: "DataHealth", jobId: job.id, runId, err: err instanceof Error ? err.message : String(err) },
+        "Failed to propagate upstream failure to chained Data Health promises",
+      );
     }
   }
 
   return store.getRun(runId);
+}
+
+export type ChainAction = "live" | "replay" | "upstream-failure" | "none";
+
+/**
+ * Post-finalize Data Health chain decision. Only materializing SQL jobs can have
+ * chained promises. Live runs chain per ADR 0006 (with upstream-failure
+ * propagation); recovery backfills stay silent unless `chainReplay` explicitly
+ * opts a successful slot into a replay chain (ADR 0007).
+ */
+export function chainActionFor(
+  job: Pick<ScheduledQueryRow, "kind" | "outputMode">,
+  status: SqStatus,
+  opts: Pick<ExecuteOptions, "suppressNotifications" | "chainReplay">,
+): ChainAction {
+  if (job.kind !== "sql_query" || job.outputMode === "none") return "none";
+  if (status === "success") {
+    if (!opts.suppressNotifications) return "live";
+    return opts.chainReplay ? "replay" : "none";
+  }
+  return opts.suppressNotifications ? "none" : "upstream-failure";
 }
 
 /**
@@ -365,7 +398,7 @@ export async function execute(job: ScheduledQueryRow, opts: ExecuteOptions): Pro
  * chained run records on the promise (inside `execute`) and never affects the
  * upstream run, which is already finalized.
  */
-async function runChainedDataHealth(upstream: ScheduledQueryRow, slotAt: number, window: WindowParams): Promise<void> {
+async function runChainedDataHealth(upstream: ScheduledQueryRow, slotAt: number, window: WindowParams, chainOpts: { replay?: boolean } = {}): Promise<void> {
   let promises: Awaited<ReturnType<typeof listPromisesByUpstreamJobId>>;
   try {
     promises = await listPromisesByUpstreamJobId(upstream.id);
@@ -381,6 +414,14 @@ async function runChainedDataHealth(upstream: ScheduledQueryRow, slotAt: number,
     try {
       const healthJob = await store.getJob(promise.scheduledQueryId);
       if (!healthJob || healthJob.kind !== "data_health_check" || !healthJob.enabled) continue;
+      if (chainOpts.replay) {
+        // A user-confirmed replay re-runs an already-claimed slot: skip the
+        // at-most-once claim (and never touch last_run_at) — the sample upsert
+        // makes double-execution benign (ADR 0007 D2/D3).
+        const attempt = (await store.countRunsForSlot(healthJob.id, slotAt)) + 1;
+        await execute(healthJob, { trigger: "manual", slotAt, attempt, window, replay: true, suppressNotifications: true });
+        continue;
+      }
       const won = await store.claimSlot(healthJob.id, slotAt, Date.now(), RUNNER_ID);
       if (!won) continue; // this upstream slot already triggered the promise
       const attempt = (await store.countRunsForSlot(healthJob.id, slotAt)) + 1;

--- a/packages/server/src/services/scheduledQueries/store.test.ts
+++ b/packages/server/src/services/scheduledQueries/store.test.ts
@@ -49,6 +49,24 @@ describe("scheduled queries overview connection scope", () => {
     expect((await store.getJob(id))?.timezone).toBe("UTC");
   });
 
+  it("lists distinct successful slots in a range, ascending and bounded", async () => {
+    const id = await store.createJob(jobInput("producer", "connection-1"), "owner-1");
+    const seed = async (runId: string, slotAt: number, status: "success" | "error"): Promise<void> => {
+      await store.insertRun({ id: runId, queryId: id, trigger: "scheduled", slotAt, attempt: 1, runnerId: "test", deadline: slotAt + 1_000, startedAt: slotAt });
+      await store.finalizeRun(runId, { status, rowCount: null, truncated: false, writtenRows: null, resultJson: null, conditionValue: null, conditionMet: null, durationMs: 1, message: null, notified: false, finishedAt: slotAt + 1 });
+    };
+    await seed("r1", 1_000, "success");
+    await seed("r2", 2_000, "error");
+    await seed("r3", 3_000, "success");
+    await seed("r3-retry", 3_000, "success"); // duplicate slot collapses
+    await seed("r4", 9_000, "success"); // outside the range
+
+    expect(await store.listSuccessfulSlotsBetween(id, 0, 5_000)).toEqual([1_000, 3_000]);
+    expect(await store.listSuccessfulSlotsBetween(id, 3_000, 9_000)).toEqual([3_000, 9_000]);
+    expect(await store.listSuccessfulSlotsBetween(id, 0, 9_000, 2)).toEqual([1_000, 3_000]);
+    expect(await store.listSuccessfulSlotsBetween("missing", 0, 9_000)).toEqual([]);
+  });
+
   it("counts only the requested connection's jobs when a scope is given", async () => {
     await store.createJob(jobInput("job-a", "connection-1"), "owner-1");
     await store.createJob(jobInput("job-b", "connection-2"), "owner-1");

--- a/packages/server/src/services/scheduledQueries/store.ts
+++ b/packages/server/src/services/scheduledQueries/store.ts
@@ -402,6 +402,16 @@ export async function hasSuccessfulRunForSlot(queryId: string, slotAt: number): 
   return rows.length > 0;
 }
 
+/** Distinct successfully-run slots in [fromMs, toMs], ascending (event-promise replays, ADR 0007 D5). */
+export async function listSuccessfulSlotsBetween(queryId: string, fromMs: number, toMs: number, limit = 100): Promise<number[]> {
+  const rows = await all(sql`
+    SELECT DISTINCT slot_at FROM scheduled_query_runs
+    WHERE query_id = ${queryId} AND status = 'success' AND slot_at >= ${fromMs} AND slot_at <= ${toMs}
+    ORDER BY slot_at ASC LIMIT ${limit}
+  `);
+  return rows.map((row) => Number(row.slot_at));
+}
+
 /** The most recent successful run's slot before `beforeSlot` (`{{prev_run_at}}`). */
 export async function getLastSuccessSlot(queryId: string, beforeSlot: number): Promise<number | null> {
   const rows = await all(sql`

--- a/src/api/dataHealth.test.ts
+++ b/src/api/dataHealth.test.ts
@@ -10,6 +10,8 @@ import {
   listDataHealthIncidents,
   listDataHealthPromises,
   previewDataHealthPromise,
+  recoverDataHealthPromise,
+  rerunDataHealthRun,
   runDataHealthPromise,
   snoozeDataHealthIncident,
   backtestDataHealthPromise,
@@ -90,5 +92,19 @@ describe("Data Health API", () => {
     const diagnostic = await diagnoseDataHealthCheck("dh-1", "row_count");
     expect(diagnostic.supported).toBe(true);
     expect(diagnostic.rows).toEqual([{ id: 1 }]);
+  });
+
+  it("reruns a single historical evaluation", async () => {
+    const run = await rerunDataHealthRun("dh-1", "dh-run-9");
+    expect(run?.status).toBe("success");
+    expect(run?.message).toBe("rerun of dh-run-9");
+  });
+
+  it("previews and executes a clear-and-rerun recovery range", async () => {
+    const preview = await recoverDataHealthPromise("dh-1", { from: 1, to: 2 });
+    expect(preview.plan).toEqual([{ slotAt: 1700000000000, hasSamples: true }]);
+    expect(preview.runs).toBeUndefined();
+    const executed = await recoverDataHealthPromise("dh-1", { from: 1, to: 2, execute: true, confirm: true });
+    expect(executed.runs?.[0].status).toBe("success");
   });
 });

--- a/src/api/dataHealth.ts
+++ b/src/api/dataHealth.ts
@@ -152,10 +152,13 @@ export interface DataHealthRun {
   trigger: "scheduled" | "manual" | "event";
   status: "running" | "success" | "failed" | "error";
   slotAt: number;
+  attempt?: number;
   conditionValue: string | null;
   conditionMet: boolean | null;
   durationMs: number | null;
   message: string | null;
+  /** Bounded snapshot: `{ columns, rows, window }` — the observed metrics and substituted window params. */
+  resultJson?: string | null;
   startedAt: number;
   finishedAt: number | null;
 }
@@ -237,6 +240,23 @@ export async function runDataHealthPromise(id: string): Promise<DataHealthRun | 
 
 export function getDataHealthTimeline(id: string): Promise<{ samples: DataHealthSample[]; incidents: DataHealthIncident[]; events: DataHealthIncidentEvent[]; runs: DataHealthRun[] }> {
   return api.get(`/data-health/${id}/timeline`);
+}
+
+export interface DataHealthRecoveryResult {
+  plan: Array<{ slotAt: number; hasSamples: boolean }>;
+  runnable: number;
+  warnings: string[];
+  runs?: DataHealthRun[];
+}
+
+export function recoverDataHealthPromise(id: string, input: { from: number; to: number; execute?: boolean; confirm?: boolean }): Promise<DataHealthRecoveryResult> {
+  return api.post<DataHealthRecoveryResult>(`/data-health/${id}/recovery`, input);
+}
+
+/** Clear & rerun one historical evaluation's slot, replacing its samples. */
+export async function rerunDataHealthRun(promiseId: string, runId: string): Promise<DataHealthRun | null> {
+  const response = await api.post<{ run: DataHealthRun | null }>(`/data-health/${promiseId}/runs/${runId}/rerun`);
+  return response.run;
 }
 
 export async function listDataHealthIncidents(connectionId?: string): Promise<DataHealthIncident[]> {

--- a/src/api/scheduledQueries.test.ts
+++ b/src/api/scheduledQueries.test.ts
@@ -17,6 +17,7 @@ import {
   deleteScheduledQuery,
   getLineage,
   recoverScheduledQuery,
+  rerunScheduledQueryRun,
   type ScheduledQueryInput,
 } from "./scheduledQueries";
 
@@ -132,7 +133,19 @@ describe("Scheduled Queries API", () => {
   it("previews and executes bounded recovery", async () => {
     const preview = await recoverScheduledQuery("sq-1", { from: 1, to: 2 });
     expect(preview.runnable).toBe(1);
+    expect(preview.chainedPromises).toEqual([{ id: "dh-1", name: "Orders ready", enabled: true }]);
     const executed = await recoverScheduledQuery("sq-1", { from: 1, to: 2, execute: true, confirm: true });
     expect(executed.runs?.[0].status).toBe("success");
+  });
+
+  it("passes the chained Data Health opt-in through recovery", async () => {
+    const executed = await recoverScheduledQuery("sq-1", { from: 1, to: 2, execute: true, confirm: true, rerunChainedHealth: true });
+    expect(executed.runs?.[0].message).toBe("chained");
+  });
+
+  it("reruns a single historical run", async () => {
+    const run = await rerunScheduledQueryRun("run-1");
+    expect(run?.status).toBe("success");
+    expect(run?.message).toBe("rerun of run-1");
   });
 });

--- a/src/api/scheduledQueries.ts
+++ b/src/api/scheduledQueries.ts
@@ -216,11 +216,18 @@ export interface ScheduledRecoveryResult {
   plan: Array<{ slotAt: number; alreadySucceeded: boolean }>;
   runnable: number;
   warnings: string[];
+  chainedPromises?: Array<{ id: string; name: string; enabled: boolean }>;
   runs?: ScheduledQueryRun[];
 }
 
-export function recoverScheduledQuery(id: string, input: { from: number; to: number; execute?: boolean; confirm?: boolean; rerunSuccessful?: boolean }): Promise<ScheduledRecoveryResult> {
+export function recoverScheduledQuery(id: string, input: { from: number; to: number; execute?: boolean; confirm?: boolean; rerunSuccessful?: boolean; rerunChainedHealth?: boolean }): Promise<ScheduledRecoveryResult> {
   return api.post<ScheduledRecoveryResult>(`/scheduled-queries/${id}/recovery`, input);
+}
+
+/** Clear & rerun one historical run's slot; chained Data Health promises replay over the same window automatically. */
+export async function rerunScheduledQueryRun(runId: string): Promise<ScheduledQueryRun | null> {
+  const response = await api.post<{ run: ScheduledQueryRun | null }>(`/scheduled-queries/runs/${runId}/rerun`);
+  return response.run;
 }
 
 // --- lineage (observed runtime) ---------------------------------------------

--- a/src/features/data-health/PromiseDetail.tsx
+++ b/src/features/data-health/PromiseDetail.tsx
@@ -1,17 +1,124 @@
 import { useState } from "react";
 import { toast } from "sonner";
-import { ArrowLeft, BookOpen, Clock, Pencil, Play, ShieldCheck, Sparkles, SlidersHorizontal, Network, FlaskConical, Search } from "lucide-react";
+import { ArrowLeft, BookOpen, Clock, Pencil, Play, RotateCcw, ShieldCheck, Sparkles, SlidersHorizontal, Network, FlaskConical, Search } from "lucide-react";
 
-import { backtestDataHealthPromise, diagnoseDataHealthCheck, type DataHealthBacktestResult, type DataHealthDiagnosticResult } from "@/api/dataHealth";
+import { backtestDataHealthPromise, diagnoseDataHealthCheck, recoverDataHealthPromise, rerunDataHealthRun, type DataHealthBacktestResult, type DataHealthDiagnosticResult, type DataHealthRecoveryResult, type DataHealthRun, type DataHealthState } from "@/api/dataHealth";
 import { correlateHealthIncidents, diagnoseHealthIncident, tuneHealthPromise, type DataOpsInvestigation, type HealthIncidentCorrelation, type HealthPromiseTuning } from "@/api/dataOpsAi";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
 import { Skeleton } from "@/components/ui/skeleton";
 import { AiInsightDialog, CorrelationView, InvestigationView, OperationalBriefCard, TuningView } from "@/features/dataops-ai";
 import { useDataOpsModelId } from "@/hooks";
 import { useRbacStore, RBAC_PERMISSIONS } from "@/stores";
 import { useDataHealthPromise, useDataHealthTimeline, useRunDataHealthPromise } from "./hooks";
 import { DH_LABEL, DH_PRIMARY, HealthBadge, formatHealthTime, formatMetric, formatSchedule, isDateOnlyColumnType } from "./lib";
+
+function isHealthState(value: string): value is DataHealthState {
+  return ["healthy", "degraded", "unhealthy", "unknown", "paused"].includes(value);
+}
+
+interface HealthRunSnapshot {
+  columns?: Array<{ name: string; type: string }>;
+  rows?: Array<Record<string, unknown>>;
+  window?: Record<string, string>;
+}
+
+/** "2026-07-17 12:25:00.000" → "2026-07-17 12:25:00". */
+function trimWindowValue(value: string): string {
+  return value.replace(/\.\d{3}$/, "");
+}
+
+/** Compact one-line window: repeats the date on the end only when it differs. */
+function formatWindowRange(start: string, end: string): string {
+  const from = trimWindowValue(start);
+  const to = trimWindowValue(end);
+  const sameDay = from.slice(0, 10) === to.slice(0, 10);
+  return `${from} → ${sameDay ? to.slice(11) : to} UTC`;
+}
+
+/**
+ * The single verdict shown for an evaluation. A run has two dimensions —
+ * whether the monitor EXECUTED and what it FOUND — but showing both reads as a
+ * contradiction ("success" next to "unhealthy"). The data verdict is the one
+ * that matters when the check ran; execution surfaces only when it failed.
+ */
+function RunVerdict({ run }: { run: DataHealthRun }) {
+  if (run.status === "running") return <span className="font-mono text-[10px] uppercase text-paper-muted">running…</span>;
+  if (run.status === "success") {
+    if (run.conditionValue && isHealthState(run.conditionValue)) {
+      return <span title="Data verdict for this slot"><HealthBadge state={run.conditionValue} /></span>;
+    }
+    return <span className="font-mono text-[10px] uppercase text-emerald-500">evaluated</span>;
+  }
+  return (
+    <span title={run.message ?? "The monitor could not execute; data health is unknown for this slot"} className="rounded-xs border border-red-400/40 bg-red-500/10 px-1.5 py-0.5 font-mono text-[9px] uppercase tracking-[0.12em] text-red-500">
+      monitor failed
+    </span>
+  );
+}
+
+/** One evaluation in the run history — expandable to its window, observed metrics, and error. */
+function HealthRunRow({ run, canRun, onRerun }: { run: DataHealthRun; canRun: boolean; onRerun: () => void }) {
+  const [open, setOpen] = useState(false);
+  let snap: HealthRunSnapshot = {};
+  try {
+    snap = run.resultJson ? (JSON.parse(run.resultJson) as HealthRunSnapshot) : {};
+  } catch {
+    snap = {};
+  }
+  const metrics = snap.rows?.[0];
+  const failed = run.status === "error" || run.status === "failed";
+  return (
+    <div className={`rounded-xs border border-ink-500 bg-ink-200/40 ${failed ? "border-l-2 border-l-red-500" : ""}`}>
+      <div className="flex items-center gap-2 px-2.5 py-2">
+        <button type="button" onClick={() => setOpen(!open)} className="flex flex-1 items-center justify-between gap-3 text-left">
+          <div>
+            <p className="font-mono text-[10px] text-paper">slot {formatHealthTime(run.slotAt)}</p>
+            <p className="mt-0.5 text-[10px] text-paper-faint">{run.trigger}{(run.attempt ?? 1) > 1 ? ` · attempt ${run.attempt}` : ""} · ran {formatHealthTime(run.startedAt)}</p>
+          </div>
+          <div className="flex items-center gap-2">
+            <RunVerdict run={run} />
+            <span className="font-mono text-[10px] text-paper-muted">{run.durationMs != null ? `${run.durationMs}ms` : "—"}</span>
+          </div>
+        </button>
+        {canRun && run.status !== "running" && (
+          <button type="button" onClick={onRerun} title="Clear & rerun this evaluation over the same window" className="flex shrink-0 items-center gap-1 rounded-xs border border-ink-500 bg-ink-200 px-1.5 py-0.5 font-mono text-[10px] text-paper-muted hover:border-brand hover:text-paper">
+            <RotateCcw className="h-3 w-3" /> Rerun
+          </button>
+        )}
+      </div>
+      {open && (
+        <div className="space-y-1.5 border-t border-ink-500 px-2.5 py-2">
+          {/* On success the metric chips carry the findings; the summary message would duplicate them. */}
+          {failed && run.message && <p className="text-[11px] text-red-600">{run.message}</p>}
+          {snap.window?.slot_start && snap.window.slot_end && (
+            <p className="font-mono text-[10px] text-paper-muted">
+              window <span className="text-paper">{formatWindowRange(snap.window.slot_start, snap.window.slot_end)}</span>
+              {snap.window.prev_run_at && snap.window.prev_run_at !== snap.window.slot_start && (
+                <> · since last success <span className="text-paper">{trimWindowValue(snap.window.prev_run_at)}</span></>
+              )}
+            </p>
+          )}
+          {metrics && (() => {
+            const entries = Object.entries(metrics);
+            const observed = entries.filter(([, value]) => value != null);
+            const missing = entries.length - observed.length;
+            return (
+              <div className="flex flex-wrap items-center gap-1.5">
+                {observed.map(([name, value]) => (
+                  <span key={name} className="rounded-xs border border-ink-500 bg-ink-200 px-1.5 py-0.5 font-mono text-[10px] text-paper-muted">{name.replace(/_/g, " ")} <span className="text-paper">{String(value)}</span></span>
+                ))}
+                {missing > 0 && <span className="text-[10px] text-paper-faint">{missing} metric{missing > 1 ? "s" : ""} not evaluated</span>}
+              </div>
+            );
+          })()}
+          {!(failed && run.message) && !snap.window && !metrics && <p className="text-[11px] text-paper-muted">No details recorded for this run.</p>}
+        </div>
+      )}
+    </div>
+  );
+}
 
 export function PromiseDetail({ id, onBack, onEdit }: { id: string; onBack: () => void; onEdit: () => void }) {
   const promiseQuery = useDataHealthPromise(id);
@@ -30,6 +137,12 @@ export function PromiseDetail({ id, onBack, onEdit }: { id: string; onBack: () =
   const [correlation, setCorrelation] = useState<HealthIncidentCorrelation>();
   const [backtest, setBacktest] = useState<DataHealthBacktestResult>();
   const [diagnostic, setDiagnostic] = useState<DataHealthDiagnosticResult>();
+  const [rerunOpen, setRerunOpen] = useState(false);
+  const [rerunFrom, setRerunFrom] = useState(() => new Date(Date.now() - 7 * 86_400_000).toISOString().slice(0, 16));
+  const [rerunTo, setRerunTo] = useState(() => new Date().toISOString().slice(0, 16));
+  const [rerunPlan, setRerunPlan] = useState<DataHealthRecoveryResult>();
+  const [rerunError, setRerunError] = useState<string>();
+  const [rerunLoading, setRerunLoading] = useState(false);
   if (promiseQuery.isLoading || !promise) return <div className="space-y-3"><Skeleton className="h-16 rounded-xs" /><Skeleton className="h-80 rounded-xs" /></div>;
 
   const latestByCheck = new Map<string, NonNullable<typeof timelineQuery.data>["samples"][number]>();
@@ -63,6 +176,54 @@ export function PromiseDetail({ id, onBack, onEdit }: { id: string; onBack: () =
     }
   };
 
+  const planRerun = async () => {
+    const from = new Date(rerunFrom).getTime();
+    const to = new Date(rerunTo).getTime();
+    if (!Number.isFinite(from) || !Number.isFinite(to) || from > to) {
+      setRerunError("Choose a valid rerun time range.");
+      return;
+    }
+    setRerunLoading(true);
+    setRerunError(undefined);
+    try {
+      setRerunPlan(await recoverDataHealthPromise(id, { from, to }));
+    } catch (caught) {
+      setRerunError(caught instanceof Error ? caught.message : "Rerun planning failed");
+    } finally {
+      setRerunLoading(false);
+    }
+  };
+
+  const executeRerun = async () => {
+    const from = new Date(rerunFrom).getTime();
+    const to = new Date(rerunTo).getTime();
+    setRerunLoading(true);
+    try {
+      const result = await recoverDataHealthPromise(id, { from, to, execute: true, confirm: true });
+      setRerunPlan(result);
+      const runs = result.runs ?? [];
+      const failed = runs.filter((run) => run.status === "error" || run.status === "failed").length;
+      if (failed > 0) toast.warning(`Re-evaluated ${runs.length} slot(s); ${failed} failed`);
+      else toast.success(`Re-evaluated ${runs.length} slot(s)`);
+      await Promise.all([promiseQuery.refetch(), timelineQuery.refetch()]);
+    } catch (caught) {
+      setRerunError(caught instanceof Error ? caught.message : "Rerun execution failed");
+    } finally {
+      setRerunLoading(false);
+    }
+  };
+
+  const rerunSingleRun = async (runId: string) => {
+    try {
+      const run = await rerunDataHealthRun(id, runId);
+      if (run?.status === "success") toast.success(`Slot re-evaluated: ${run.conditionValue ?? "done"}`);
+      else toast.error(run?.message ?? "Rerun failed");
+      await Promise.all([promiseQuery.refetch(), timelineQuery.refetch()]);
+    } catch (caught) {
+      toast.error(caught instanceof Error ? caught.message : "Rerun failed");
+    }
+  };
+
   const inspectCheck = async (checkKey: string, slotAt?: number) => {
     setDialog("diagnostic");
     setLoading(true);
@@ -83,7 +244,7 @@ export function PromiseDetail({ id, onBack, onEdit }: { id: string; onBack: () =
           <Button variant="ghost" size="icon" className="mt-0.5" onClick={onBack} aria-label="Back to datasets"><ArrowLeft className="h-4 w-4" /></Button>
           <div><div className="flex flex-wrap items-center gap-2"><h2 className="text-[18px] font-semibold text-paper">{promise.name}</h2><HealthBadge state={promise.status} /><span className="font-mono text-[9px] uppercase text-paper-faint">{promise.criticality}</span></div><p className="mt-1 font-mono text-[11px] text-paper-muted">{promise.databaseName && promise.tableName ? `${promise.databaseName}.${promise.tableName}` : "Custom query dataset"}</p>{promise.description && <p className="mt-2 max-w-2xl text-[12px] text-paper-muted">{promise.description}</p>}</div>
         </div>
-        <div className="flex flex-wrap gap-2">{canUseAi && <Button variant="outline" className="h-9 rounded-xs" onClick={() => void runInsight("investigate")}><Sparkles className="mr-2 h-3.5 w-3.5" /> Investigate</Button>}{canUseAi && <Button variant="outline" className="h-9 rounded-xs" onClick={() => void runInsight("tune")}><SlidersHorizontal className="mr-2 h-3.5 w-3.5" /> Tune</Button>}{canUseAi && <Button variant="outline" className="h-9 rounded-xs" onClick={() => void runInsight("correlate")}><Network className="mr-2 h-3.5 w-3.5" /> Correlate</Button>}{canRun && <Button variant="outline" className="h-9 rounded-xs" onClick={() => void runInsight("backtest")}><FlaskConical className="mr-2 h-3.5 w-3.5" /> Backtest</Button>}{canEdit && <Button variant="outline" className="h-9 rounded-xs" onClick={onEdit}><Pencil className="mr-2 h-3.5 w-3.5" /> Edit promise</Button>}{canRun && <Button className={DH_PRIMARY} onClick={() => void runNow()} disabled={runMutation.isPending}><Play className="h-3.5 w-3.5" /> Evaluate now</Button>}</div>
+        <div className="flex flex-wrap gap-2">{canUseAi && <Button variant="outline" className="h-9 rounded-xs" onClick={() => void runInsight("investigate")}><Sparkles className="mr-2 h-3.5 w-3.5" /> Investigate</Button>}{canUseAi && <Button variant="outline" className="h-9 rounded-xs" onClick={() => void runInsight("tune")}><SlidersHorizontal className="mr-2 h-3.5 w-3.5" /> Tune</Button>}{canUseAi && <Button variant="outline" className="h-9 rounded-xs" onClick={() => void runInsight("correlate")}><Network className="mr-2 h-3.5 w-3.5" /> Correlate</Button>}{canRun && <Button variant="outline" className="h-9 rounded-xs" onClick={() => void runInsight("backtest")}><FlaskConical className="mr-2 h-3.5 w-3.5" /> Backtest</Button>}{canRun && <Button variant="outline" className="h-9 rounded-xs" onClick={() => setRerunOpen(true)}><RotateCcw className="mr-2 h-3.5 w-3.5" /> Rerun range</Button>}{canEdit && <Button variant="outline" className="h-9 rounded-xs" onClick={onEdit}><Pencil className="mr-2 h-3.5 w-3.5" /> Edit promise</Button>}{canRun && <Button className={DH_PRIMARY} onClick={() => void runNow()} disabled={runMutation.isPending}><Play className="h-3.5 w-3.5" /> Evaluate now</Button>}</div>
       </div>
 
       <OperationalBriefCard kind="data-health" id={id} />
@@ -98,7 +259,7 @@ export function PromiseDetail({ id, onBack, onEdit }: { id: string; onBack: () =
       <section><div className="mb-3 flex items-center gap-2"><ShieldCheck className="h-4 w-4 text-brand" /><h3 className={DH_LABEL}>Promise checks</h3></div><div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">{promise.checks.map((check) => { const sample = latestByCheck.get(check.checkKey); const diagnosable = ["freshness", "completeness", "uniqueness", "validity"].includes(check.type); return <Card key={check.checkKey} className="rounded-xs border-ink-500 bg-ink-100 p-4"><div className="flex items-start justify-between gap-3"><div><p className="text-[13px] font-medium text-paper">{check.name}</p><p className="mt-0.5 font-mono text-[9px] uppercase text-paper-faint">{check.type.replace("_", " ")} · {check.severity}</p></div>{sample ? <HealthBadge state={sample.outcome} /> : <HealthBadge state="not_evaluated" />}</div><div className="mt-4 flex items-end justify-between"><div><p className={DH_LABEL}>Observed</p><p className="mt-1 text-xl font-semibold tabular-nums text-paper">{formatMetric(sample?.observedValue ?? null, check.type)}</p></div><p className="text-right font-mono text-[10px] text-paper-muted">{sample ? `${formatMetric(sample.expectedLower, check.type)} – ${formatMetric(sample.expectedUpper, check.type)}` : "No sample"}</p></div>{diagnosable && <Button variant="ghost" size="sm" className="mt-3 h-7 rounded-xs" onClick={() => void inspectCheck(check.checkKey, sample?.slotAt)}><Search className="mr-1.5 h-3 w-3" /> Inspect evidence</Button>}</Card>; })}</div></section>
 
       <div className="grid gap-3 lg:grid-cols-2">
-        <Card className="rounded-xs border-ink-500 bg-ink-100 p-4"><div className="flex items-center gap-2"><Clock className="h-4 w-4 text-paper-muted" /><p className={DH_LABEL}>Recent evaluations</p></div><div className="mt-3 divide-y divide-ink-500">{(timelineQuery.data?.runs ?? []).slice(0, 8).map((run) => <div key={run.id} className="flex items-center justify-between gap-3 py-2"><div><p className="font-mono text-[10px] text-paper">{formatHealthTime(run.startedAt)}</p><p className="mt-0.5 text-[10px] text-paper-faint">{run.trigger} · {run.durationMs ?? "—"}ms</p></div><div className="text-right"><span className={`font-mono text-[10px] uppercase ${run.status === "success" ? "text-emerald-500" : "text-red-500"}`}>{run.status}</span>{run.conditionValue && <p className="text-[9px] text-paper-faint">data: {run.conditionValue}</p>}</div></div>)}{(timelineQuery.data?.runs.length ?? 0) === 0 && <p className="py-8 text-center text-[12px] text-paper-muted">No evaluations yet.</p>}</div></Card>
+        <Card className="rounded-xs border-ink-500 bg-ink-100 p-4"><div className="flex items-center gap-2"><Clock className="h-4 w-4 text-paper-muted" /><p className={DH_LABEL}>Run history</p></div><div className="mt-3 space-y-1.5">{(timelineQuery.data?.runs ?? []).slice(0, 10).map((run) => <HealthRunRow key={run.id} run={run} canRun={canRun} onRerun={() => void rerunSingleRun(run.id)} />)}{(timelineQuery.data?.runs.length ?? 0) === 0 && <p className="py-8 text-center text-[12px] text-paper-muted">No evaluations yet.</p>}</div></Card>
         <Card className="rounded-xs border-ink-500 bg-ink-100 p-4"><div className="flex items-center justify-between"><p className={DH_LABEL}>Operational context</p>{promise.runbookUrl && <a href={promise.runbookUrl} target="_blank" rel="noreferrer" className="inline-flex items-center gap-1 text-[11px] text-brand hover:underline"><BookOpen className="h-3.5 w-3.5" /> Open runbook</a>}</div><dl className="mt-4 space-y-3 text-[11px]"><div><dt className="text-paper-faint">Evaluation timezone</dt><dd className="mt-0.5 text-paper">UTC</dd></div><div><dt className="text-paper-faint">Alert policy</dt><dd className="mt-0.5 text-paper">Open after {promise.breachAfter} breach(es), recover after {promise.recoverAfter} pass(es)</dd></div><div><dt className="text-paper-faint">Notification destinations</dt><dd className="mt-0.5 text-paper">{promise.channelIds.length || "None"}</dd></div><div><dt className="text-paper-faint">Retention</dt><dd className="mt-0.5 text-paper">{promise.retentionDays} days</dd></div></dl></Card>
       </div>
       {(timelineQuery.data?.events.length ?? 0) > 0 && <Card className="rounded-xs border-ink-500 bg-ink-100 p-4"><p className={DH_LABEL}>Incident timeline</p><div className="mt-3 divide-y divide-ink-500">{timelineQuery.data?.events.slice(0, 12).map((event) => <div key={event.id} className="flex items-center justify-between gap-3 py-2"><div><p className="text-[11px] capitalize text-paper">{event.type.replace("_", " ")}</p><p className="mt-0.5 font-mono text-[9px] text-paper-faint">incident {event.incidentId.slice(0, 8)}{event.runId ? ` · run ${event.runId.slice(0, 8)}` : ""}</p></div><p className="font-mono text-[10px] text-paper-muted">{formatHealthTime(event.createdAt)}</p></div>)}</div></Card>}
@@ -107,6 +268,30 @@ export function PromiseDetail({ id, onBack, onEdit }: { id: string; onBack: () =
       <AiInsightDialog open={dialog === "tune"} onOpenChange={(open) => !open && setDialog(null)} title="Promise noise tuning" description="Recommendations are advisory and never change the promise automatically." loading={loading} error={error}>{tuning && <TuningView result={tuning} />}</AiInsightDialog>
       <AiInsightDialog open={dialog === "correlate"} onOpenChange={(open) => !open && setDialog(null)} title="Related incident analysis" description="Looks for credible shared timing and execution evidence across visible datasets." loading={loading} error={error}>{correlation && <CorrelationView result={correlation} />}</AiInsightDialog>
       <AiInsightDialog open={dialog === "backtest"} onOpenChange={(open) => !open && setDialog(null)} title="Historical promise backtest" description="Replays metric checks over up to 14 bounded historical windows without opening incidents; structural checks are reported as unknown." loading={loading} error={error}>{backtest && <div className="space-y-3"><div className="grid grid-cols-2 gap-2 sm:grid-cols-5">{Object.entries(backtest.summary).map(([key, value]) => <div key={key} className="rounded-xs border border-ink-500 p-2"><p className="font-mono text-[9px] uppercase text-paper-faint">{key}</p><p className="mt-1 text-[13px] text-paper">{value}</p></div>)}</div><div className="space-y-1">{backtest.slots.map((slot) => <div key={slot.slotAt} className="flex items-center justify-between rounded-xs border border-ink-500 px-3 py-2"><span className="font-mono text-[10px] text-paper-muted">{new Date(slot.slotAt).toLocaleString()}</span><HealthBadge state={slot.state} /></div>)}</div></div>}</AiInsightDialog>
+      <AiInsightDialog open={rerunOpen} onOpenChange={setRerunOpen} title="Clear & rerun a time range" description="Re-evaluates each slot in the range and replaces its recorded samples. Only the newest slot can change current status or incidents; historical slots are corrected silently." loading={rerunLoading} error={rerunError}>
+        <div className="space-y-4">
+          <div className="grid gap-3 sm:grid-cols-2"><div><p className="font-mono text-[9px] uppercase text-paper-faint">From</p><Input type="datetime-local" value={rerunFrom} onChange={(event) => setRerunFrom(event.target.value)} className="mt-1" /></div><div><p className="font-mono text-[9px] uppercase text-paper-faint">To</p><Input type="datetime-local" value={rerunTo} onChange={(event) => setRerunTo(event.target.value)} className="mt-1" /></div></div>
+          <Button variant="outline" className="rounded-xs" onClick={() => void planRerun()}>Preview rerun</Button>
+          {rerunPlan && (
+            <>
+              <div className="rounded-xs border border-ink-500 p-3">
+                <p className="text-[11px] text-paper">{rerunPlan.runnable} slot(s) will be re-evaluated</p>
+                <p className="mt-1 text-[10px] text-paper-muted">{rerunPlan.plan.filter((slot) => slot.hasSamples).length} slot(s) already have samples and will be replaced.</p>
+                {rerunPlan.warnings.map((warning) => <p key={warning} className="mt-1 text-[10px] text-amber-500">{warning}</p>)}
+                {rerunPlan.runnable === 0 && <p className="mt-1 text-[10px] text-paper-muted">No slots to rerun in this range.</p>}
+              </div>
+              {rerunPlan.runs && (() => {
+                const failed = rerunPlan.runs.filter((run) => run.status === "error" || run.status === "failed").length;
+                return failed > 0
+                  ? <p className="text-[11px] text-amber-500">Re-evaluated {rerunPlan.runs.length} slot(s); {failed} failed — see the run timeline for errors.</p>
+                  : <p className="text-[11px] text-emerald-500">Re-evaluated {rerunPlan.runs.length} slot(s).</p>;
+              })()}
+              {rerunPlan.runnable > 0 && rerunPlan.runnable <= 30 && <Button className={DH_PRIMARY} onClick={() => void executeRerun()} disabled={rerunLoading}>Confirm and rerun {rerunPlan.runnable} slot(s)</Button>}
+              {rerunPlan.runnable > 30 && <p className="text-[10px] text-amber-500">At most 30 slots can be executed per request — narrow the range.</p>}
+            </>
+          )}
+        </div>
+      </AiInsightDialog>
       <AiInsightDialog open={dialog === "diagnostic"} onOpenChange={(open) => !open && setDialog(null)} title="Bounded check evidence" description="Rows are queried live under your current access, limited to 50, and are not persisted in the AI result." loading={loading} error={error}>{diagnostic && (diagnostic.supported ? diagnostic.rows.length > 0 ? <div className="overflow-x-auto rounded-xs border border-ink-500"><table className="w-full text-left text-[10px]"><thead><tr>{diagnostic.columns.map((column) => <th key={column.name} className="px-2 py-2 font-mono uppercase text-paper-faint">{column.name}</th>)}</tr></thead><tbody>{diagnostic.rows.map((row, index) => <tr key={index} className="border-t border-ink-500">{diagnostic.columns.map((column) => <td key={column.name} className="max-w-64 truncate px-2 py-2 text-paper">{String(row[column.name] ?? "")}</td>)}</tr>)}</tbody></table></div> : <p className="text-[11px] text-paper-muted">No row-level evidence was found in this evaluation window ({formatHealthTime(diagnostic.slotStart)} – {formatHealthTime(diagnostic.slotEnd)}). Completeness, uniqueness, and validity diagnostics only return violating rows; freshness returns recent rows.</p> : <p className="text-[11px] text-paper-muted">This aggregate check has no meaningful row-level diagnostic. Use its metric history and incident investigation instead.</p>)}</AiInsightDialog>
     </div>
   );

--- a/src/features/scheduled-queries/JobDetail.tsx
+++ b/src/features/scheduled-queries/JobDetail.tsx
@@ -20,6 +20,7 @@ import { assessScheduledQuery, planScheduledRecovery, type RecoveryAssessment, t
 import { recoverScheduledQuery, type ScheduledQuery, type ScheduledRecoveryResult } from "@/api/scheduledQueries";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
+import { Checkbox } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
 import { useDataOpsModelId } from "@/hooks";
 import { formatClickHouseSQL } from "@/lib/formatSql";
@@ -77,6 +78,8 @@ export function JobDetail({ job, jobs, onBack }: JobDetailProps) {
   const [recovery, setRecovery] = useState<{ assessment: RecoveryAssessment; preview: ScheduledRecoveryResult }>();
   const [recoveryError, setRecoveryError] = useState<string>();
   const [recoveryLoading, setRecoveryLoading] = useState(false);
+  const [rerunChainedHealth, setRerunChainedHealth] = useState(true);
+  const [rerunSuccessful, setRerunSuccessful] = useState(false);
 
   const successfulRuns = useMemo(() => runs.filter((run) => run.status === "success").length, [runs]);
   const completedRuns = useMemo(() => runs.filter((run) => run.status !== "running").length, [runs]);
@@ -138,7 +141,7 @@ export function JobDetail({ job, jobs, onBack }: JobDetailProps) {
     try {
       const [assessment, preview] = await Promise.all([
         planScheduledRecovery(job.id, from, to, { modelId }),
-        recoverScheduledQuery(job.id, { from, to }),
+        recoverScheduledQuery(job.id, { from, to, rerunSuccessful }),
       ]);
       setRecovery({ assessment, preview });
     } catch (error) {
@@ -153,7 +156,7 @@ export function JobDetail({ job, jobs, onBack }: JobDetailProps) {
     const to = new Date(recoveryTo).getTime();
     setRecoveryLoading(true);
     try {
-      const result = await recoverScheduledQuery(job.id, { from, to, execute: true, confirm: true });
+      const result = await recoverScheduledQuery(job.id, { from, to, execute: true, confirm: true, rerunSuccessful, rerunChainedHealth });
       setRecovery((current) => current ? { ...current, preview: result } : current);
       toast.success(`Recovery completed ${result.runs?.length ?? 0} run(s)`);
     } catch (error) {
@@ -292,8 +295,25 @@ export function JobDetail({ job, jobs, onBack }: JobDetailProps) {
       <AiInsightDialog open={recoveryOpen} onOpenChange={setRecoveryOpen} title="Historical recovery planner" description="Preview missed deterministic slots before any historical runs execute." loading={recoveryLoading} error={recoveryError}>
         <div className="space-y-4">
           <div className="grid gap-3 sm:grid-cols-2"><div><p className="font-mono text-[9px] uppercase text-paper-faint">From</p><Input type="datetime-local" value={recoveryFrom} onChange={(event) => setRecoveryFrom(event.target.value)} className="mt-1" /></div><div><p className="font-mono text-[9px] uppercase text-paper-faint">To</p><Input type="datetime-local" value={recoveryTo} onChange={(event) => setRecoveryTo(event.target.value)} className="mt-1" /></div></div>
+          <label className="flex items-start gap-2">
+            <Checkbox checked={rerunSuccessful} onCheckedChange={(checked) => { setRerunSuccessful(checked === true); setRecovery(undefined); }} className="mt-0.5" />
+            <span>
+              <span className="block text-[11px] text-paper">Clear &amp; rerun slots that already succeeded</span>
+              <span className="mt-0.5 block text-[10px] text-paper-muted">Re-executes every slot in the range, replacing its output (idempotent per slot). Off = backfill missed slots only.</span>
+            </span>
+          </label>
           <Button variant="outline" className="rounded-xs" onClick={() => void planRecovery()}>Preview recovery</Button>
-          {recovery && <><AssessmentView result={recovery.assessment} /><div className="rounded-xs border border-ink-500 p-3"><p className="text-[11px] text-paper">{recovery.preview.runnable} missing slot(s) ready to run</p><p className="mt-1 text-[10px] text-paper-muted">{recovery.preview.plan.filter((slot) => slot.alreadySucceeded).length} slot(s) already succeeded and will be skipped.</p>{recovery.preview.warnings.map((warning) => <p key={warning} className="mt-1 text-[10px] text-amber-500">{warning}</p>)}</div>{recovery.preview.runnable > 0 && recovery.preview.runnable <= 30 && <Button className={SQ_BTN_PRIMARY} onClick={() => void executeRecovery()}>Confirm and run {recovery.preview.runnable} slot(s)</Button>}</>}
+          {recovery && <><AssessmentView result={recovery.assessment} /><div className="rounded-xs border border-ink-500 p-3"><p className="text-[11px] text-paper">{recovery.preview.runnable} slot(s) ready to run</p><p className="mt-1 text-[10px] text-paper-muted">{recovery.preview.plan.filter((slot) => slot.alreadySucceeded).length} slot(s) already succeeded and will be {rerunSuccessful ? "re-run" : "skipped"}.</p>{recovery.preview.warnings.map((warning) => <p key={warning} className="mt-1 text-[10px] text-amber-500">{warning}</p>)}</div>{(recovery.preview.chainedPromises?.some((promise) => promise.enabled) ?? false) && (
+            <label className="flex items-start gap-2 rounded-xs border border-ink-500 p-3">
+              <Checkbox checked={rerunChainedHealth} onCheckedChange={(checked) => setRerunChainedHealth(checked === true)} className="mt-0.5" />
+              <span>
+                <span className="block text-[11px] text-paper">Also rerun linked Data Health promises over the same windows</span>
+                <span className="mt-1 block text-[10px] text-paper-muted">
+                  {recovery.preview.chainedPromises?.filter((promise) => promise.enabled).map((promise) => promise.name).join(", ")}
+                </span>
+              </span>
+            </label>
+          )}{recovery.preview.runnable > 0 && recovery.preview.runnable <= 30 && <Button className={SQ_BTN_PRIMARY} onClick={() => void executeRecovery()}>Confirm and run {recovery.preview.runnable} slot(s)</Button>}</>}
         </div>
       </AiInsightDialog>
     </div>

--- a/src/features/scheduled-queries/RunsTab.tsx
+++ b/src/features/scheduled-queries/RunsTab.tsx
@@ -7,7 +7,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { toast } from "sonner";
-import { FileSearch, Calendar as CalendarIcon, Trash2, Sparkles } from "lucide-react";
+import { FileSearch, Calendar as CalendarIcon, RotateCcw, Trash2, Sparkles } from "lucide-react";
 import { format, startOfDay, endOfDay, subDays } from "date-fns";
 
 import { Button } from "@/components/ui/button";
@@ -38,7 +38,7 @@ import type { RunQuery, ScheduledQueryRun, SqStatus } from "@/api/scheduledQueri
 import { diagnoseScheduledRun, type DataOpsInvestigation } from "@/api/dataOpsAi";
 import { AiInsightDialog, InvestigationView } from "@/features/dataops-ai";
 import { useDataOpsModelId } from "@/hooks";
-import { useScheduledQueries, useScheduledQueryRuns, useJobOwners, useDeleteRuns } from "./hooks";
+import { useScheduledQueries, useScheduledQueryRuns, useJobOwners, useDeleteRuns, useRerunScheduledQueryRun } from "./hooks";
 import { StatusBadge, formatDuration } from "./lib";
 import { TablePagination } from "./TablePagination";
 import { JobCombobox } from "./JobCombobox";
@@ -110,6 +110,7 @@ export function RunsTab({ selectedJobId, embedded = false }: { selectedJobId?: s
   const canViewLogs = hasPermission(RBAC_PERMISSIONS.LOGS_VIEW);
   const canViewAll = hasPermission(RBAC_PERMISSIONS.SCHEDULED_QUERIES_VIEW_ALL);
   const canDelete = hasPermission(RBAC_PERMISSIONS.SCHEDULED_QUERIES_DELETE);
+  const canRun = hasPermission(RBAC_PERMISSIONS.SCHEDULED_QUERIES_RUN);
   const canUseAi = hasPermission(RBAC_PERMISSIONS.AI_OPTIMIZE);
   const modelId = useDataOpsModelId();
   const openInLogs = (queryId: string) => navigate(`/monitoring/logs?q=${encodeURIComponent(queryId)}`);
@@ -179,6 +180,19 @@ export function RunsTab({ selectedJobId, embedded = false }: { selectedJobId?: s
 
   const total = runs?.length ?? 0;
   const pageRuns = (runs ?? []).slice((page - 1) * pageSize, page * pageSize);
+
+  const rerunMut = useRerunScheduledQueryRun();
+  const rerunRun = async (runId: string) => {
+    try {
+      const run = await rerunMut.mutateAsync(runId);
+      const status = run?.status ?? "running";
+      toast[status === "success" ? "success" : status === "failed" || status === "error" ? "error" : "info"](
+        status === "success" ? "Slot re-ran successfully (linked Data Health re-verified)" : `Rerun finished: ${status}${run?.message ? ` — ${run.message}` : ""}`,
+      );
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Rerun failed");
+    }
+  };
 
   const investigate = async (runId: string) => {
     if (!jobId) return;
@@ -296,6 +310,18 @@ export function RunsTab({ selectedJobId, embedded = false }: { selectedJobId?: s
                       <span>{formatDuration(run.durationMs)}</span>
                     </div>
                   </button>
+                  {canRun && run.status !== "running" && (
+                    <button
+                      type="button"
+                      onClick={(e) => { e.stopPropagation(); void rerunRun(run.id); }}
+                      disabled={rerunMut.isPending}
+                      title="Clear & rerun this slot (replays linked Data Health over the same window)"
+                      className="flex shrink-0 items-center gap-1 rounded-xs border border-ink-500 bg-ink-200 px-1.5 py-0.5 font-mono text-[10px] text-paper-muted hover:border-brand hover:text-paper disabled:opacity-50"
+                    >
+                      <RotateCcw className="h-3 w-3" />
+                      Rerun
+                    </button>
+                  )}
                   {canViewLogs ? (
                     <button
                       type="button"

--- a/src/features/scheduled-queries/hooks.ts
+++ b/src/features/scheduled-queries/hooks.ts
@@ -16,6 +16,7 @@ import {
   getOverview,
   listRuns,
   listScheduledQueries,
+  rerunScheduledQueryRun,
   runScheduledQuery,
   updateScheduledQuery,
   type RunQuery,
@@ -110,6 +111,15 @@ export function useRunScheduledQuery() {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: (id: string) => runScheduledQuery(id),
+    onSuccess: () => void qc.invalidateQueries({ queryKey: sqKeys.all }),
+  });
+}
+
+/** Clear & rerun one historical run's slot (chained Data Health replays automatically). */
+export function useRerunScheduledQueryRun() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (runId: string) => rerunScheduledQueryRun(runId),
     onSuccess: () => void qc.invalidateQueries({ queryKey: sqKeys.all }),
   });
 }

--- a/src/test/mocks/handlers.ts
+++ b/src/test/mocks/handlers.ts
@@ -412,8 +412,20 @@ export const handlers = [
     return HttpResponse.json({ success: true, data: { run: { id: 'run-2', status: 'success', startedAt: 1700000100000 } } });
   }),
   http.post(`${API_BASE}/scheduled-queries/:id/recovery`, async ({ request }) => {
-    const body = await request.json() as { execute?: boolean };
-    return HttpResponse.json({ success: true, data: { plan: [{ slotAt: 1700000000000, alreadySucceeded: false }], runnable: 1, warnings: [], runs: body.execute ? [{ id: 'recovery-1', status: 'success' }] : undefined } });
+    const body = await request.json() as { execute?: boolean; rerunChainedHealth?: boolean };
+    return HttpResponse.json({
+      success: true,
+      data: {
+        plan: [{ slotAt: 1700000000000, alreadySucceeded: false }],
+        runnable: 1,
+        warnings: [],
+        chainedPromises: [{ id: 'dh-1', name: 'Orders ready', enabled: true }],
+        runs: body.execute ? [{ id: 'recovery-1', status: 'success', trigger: 'manual', message: body.rerunChainedHealth ? 'chained' : null }] : undefined,
+      },
+    });
+  }),
+  http.post(`${API_BASE}/scheduled-queries/runs/:runId/rerun`, ({ params }) => {
+    return HttpResponse.json({ success: true, data: { run: { id: 'rerun-1', status: 'success', trigger: 'manual', slotAt: 1700000000000, message: `rerun of ${params.runId as string}` } } });
   }),
   http.get(`${API_BASE}/scheduled-queries/:id/runs`, () => {
     return HttpResponse.json({
@@ -473,6 +485,21 @@ export const handlers = [
   http.delete(`${API_BASE}/data-health/:id`, () => HttpResponse.json({ success: true, data: { success: true } })),
   http.post(`${API_BASE}/data-health/:id/run`, () => HttpResponse.json({ success: true, data: { run: { id: 'dh-run-1', status: 'success', conditionValue: 'healthy', startedAt: 1700000000000 } } })),
   http.post(`${API_BASE}/data-health/:id/backtest`, () => HttpResponse.json({ success: true, data: { slots: [{ slotAt: 1700000000000, state: 'healthy', checks: [] }], summary: { evaluated: 1, healthy: 1, breached: 0, unknown: 0, errors: 0 } } })),
+  http.post(`${API_BASE}/data-health/:id/runs/:runId/rerun`, ({ params }) => {
+    return HttpResponse.json({ success: true, data: { run: { id: 'dh-rerun-1', status: 'success', conditionValue: 'healthy', slotAt: 1700000000000, message: `rerun of ${params.runId as string}` } } });
+  }),
+  http.post(`${API_BASE}/data-health/:id/recovery`, async ({ request }) => {
+    const body = await request.json() as { execute?: boolean };
+    return HttpResponse.json({
+      success: true,
+      data: {
+        plan: [{ slotAt: 1700000000000, hasSamples: true }],
+        runnable: 1,
+        warnings: [],
+        runs: body.execute ? [{ id: 'dh-recovery-1', status: 'success', conditionValue: 'healthy', startedAt: 1700000000000 }] : undefined,
+      },
+    });
+  }),
   http.post(`${API_BASE}/data-health/:id/diagnostics`, () => HttpResponse.json({ success: true, data: { supported: true, rows: [{ id: 1 }], columns: [{ name: 'id', type: 'UInt64' }], slotStart: 1699990000000, slotEnd: 1700000000000 } })),
   http.get(`${API_BASE}/data-health/:id/timeline`, () => HttpResponse.json({ success: true, data: { samples: [], incidents: [], events: [], runs: [] } })),
   http.get(`${API_BASE}/data-health/incidents`, () => HttpResponse.json({ success: true, data: { incidents: [{ id: 'incident-1', promiseId: 'dh-1', status: 'open', severity: 'critical', kind: 'data', summary: 'Rows too low', openedAt: 1700000000000, lastEventAt: 1700000000000 }] } })),


### PR DESCRIPTION
## Description

Adds Airflow-style "clear & rerun" to Scheduled Queries and Data Health, per [ADR 0007](docs/adr/0007-clear-and-rerun-for-scheduled-jobs-and-data-health.md) (Accepted).

Every historical run — in a scheduled job's run history and in a Data Health promise's evaluation history — gets a **Rerun** action that re-executes that run's exact slot over its original window, replacing its recorded output in place (idempotent, not append). Rerunning a materializing job automatically re-verifies any Data Health promises chained to it, over the same window the rerun wrote. Range-based recovery gains the same chained re-verification (default on) plus a "rerun already-succeeded slots" option (the actual "clear"), and Data Health promises get their own range-recovery endpoint/dialog.

Replay safety is the core invariant: only the **newest** evaluated slot for a promise can move current status, open/close incidents, or send notifications. Replaying an older slot silently corrects its recorded samples and nothing else — no user-visible flapping, no re-alerting, no stale-state clobbering.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Related Issue

Closes #

## Changes Made

**Server**
- `dataHealth/store.ts` — sample upsert (`INSERT … ON CONFLICT DO UPDATE`, no schema change needed), `latestLiveSlotAt`, `listLiveSlotsBetween`, `metricHistory` gains a `beforeSlot` bound so replayed anomaly checks can't see future data.
- `scheduledQueries/store.ts` — `listSuccessfulSlotsBetween` (slot derivation for event-triggered promise reruns).
- `dataHealth/execution.ts` — `processDataHealthSuccess` gains `replay` mode: replaces samples, and short-circuits before status/incident/notification when the slot isn't the newest.
- `scheduledQueries/runner.ts` — `ExecuteOptions.replay`/`chainReplay`; chain decision extracted into a pure, unit-tested `chainActionFor`; replay chains bypass the at-most-once slot claim (a confirmed rerun is explicitly re-running an already-claimed slot) and never touch the scheduler lease.
- New endpoints: `POST /scheduled-queries/runs/:runId/rerun`, `POST /data-health/:id/runs/:runId/rerun`, `POST /data-health/:id/recovery`. Existing `POST /scheduled-queries/:id/recovery` gains `rerunSuccessful` and `rerunChainedHealth`.

**Frontend**
- Per-run **Rerun** button in Scheduled Queries' Runs tab and Data Health's promise run history.
- Data Health promise run history rewritten: one verdict per row (was showing a confusing "SUCCESS" execution status next to an "UNHEALTHY" data status side by side), compact expandable window/metrics panel (no duplicated summary text, nulls collapsed to a single note).
- New "Rerun range" dialog for Data Health promises; existing Scheduled Query recovery dialog gains the chained-health and rerun-successful options.

No RBAC migration required — the upsert relies on a unique constraint that already exists in both dialects.

## Testing

- [x] I have tested this locally
- [x] I have added/updated tests
- [x] All existing tests pass

### Test Steps
1. `bun run typecheck` (both packages), `bun run lint`, `bunx vitest run src`, `./scripts/test-isolated-server.sh` (SQLite + PostgreSQL via Docker) — all green.
2. Manually verified live against a real ClickHouse connection: reran individual Data Health evaluations (samples replaced in place, zero incident/outbox side effects for non-newest slots) and scheduled-job runs (chained promise re-verified over the identical window), confirmed via direct DB inspection and network responses.

## Screenshots

N/A (see PR conversation for verification detail; no new visual asset produced for this description)

## Changelog Fragment

- [x] Added `changelogs/unreleased/308-clear-and-rerun.md`

## Checklist

- [x] My code follows the project's code style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have checked for breaking changes and documented them (if applicable) — none; all new fields are additive/optional
- [x] I have tested the changes in the relevant environment (development/production)

## Additional Notes

ADR 0007 is Accepted and included in this PR (`docs/adr/0007-clear-and-rerun-for-scheduled-jobs-and-data-health.md`), documenting the full design and the implementation plan this PR carries out end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)