### PR TITLE
Add production Helm chart with OCI publishing (ADR 0008)

### DIFF
--- a/.github/actions/helm-publish/action.yml
+++ b/.github/actions/helm-publish/action.yml
@@ -1,0 +1,142 @@
+name: Publish Helm chart to GHCR
+description: >-
+  Package, push (OCI), cosign-sign, and smoke-check the chart. Shared by
+  auto-release.yml (app releases) and helm-release.yml (chart-only releases)
+  so the publish logic exists exactly once. Published versions are immutable:
+  when the target version already exists in the registry the action skips the
+  push with a warning instead of overwriting (safe for re-runs of partially
+  failed releases). The calling job needs packages:write (push) and
+  id-token:write (cosign keyless).
+
+inputs:
+  chart-dir:
+    description: Path to the chart
+    default: charts/chouse-ui
+  oci-repo:
+    description: OCI repository to push to, e.g. ghcr.io/<owner>/charts
+    required: true
+  version:
+    description: >-
+      Chart version to publish (e.g. 1.2.0-pre). Empty uses Chart.yaml's
+      version.
+    default: ""
+  allow-overwrite:
+    description: >-
+      Skip the immutability guard (pre-release -pre tags only — the caller
+      deletes the previous tag first).
+    default: "false"
+  token:
+    description: Token with packages:write for the registry login
+    required: true
+
+outputs:
+  version:
+    description: The chart version that was (or would have been) published
+    value: ${{ steps.meta.outputs.version }}
+  digest:
+    description: OCI digest of the pushed chart (empty when skipped)
+    value: ${{ steps.push.outputs.digest }}
+  skipped:
+    description: "true when the version already existed and nothing was pushed"
+    value: ${{ steps.guard.outputs.skipped }}
+
+runs:
+  using: composite
+  steps:
+    - name: Resolve chart metadata
+      id: meta
+      shell: bash
+      run: |
+        NAME=$(awk '/^name:/{print $2; exit}' "${{ inputs.chart-dir }}/Chart.yaml")
+        VERSION="${{ inputs.version }}"
+        if [ -z "$VERSION" ]; then
+          VERSION=$(awk '/^version:/{print $2; exit}' "${{ inputs.chart-dir }}/Chart.yaml")
+        fi
+        echo "name=$NAME" >> "$GITHUB_OUTPUT"
+        echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+        echo "Publishing $NAME version $VERSION to ${{ inputs.oci-repo }}"
+
+    - name: Registry login
+      shell: bash
+      run: |
+        echo "${{ inputs.token }}" | helm registry login "$(echo "${{ inputs.oci-repo }}" | cut -d/ -f1)" \
+          --username "$GITHUB_ACTOR" --password-stdin
+
+    - name: Immutability guard
+      id: guard
+      shell: bash
+      run: |
+        if [ "${{ inputs.allow-overwrite }}" = "true" ]; then
+          echo "skipped=false" >> "$GITHUB_OUTPUT"
+          echo "Overwrite allowed (pre-release tag) — guard bypassed."
+          exit 0
+        fi
+        if helm show chart "oci://${{ inputs.oci-repo }}/${{ steps.meta.outputs.name }}" \
+             --version "${{ steps.meta.outputs.version }}" > /dev/null 2>&1; then
+          echo "skipped=true" >> "$GITHUB_OUTPUT"
+          echo "::warning::Chart ${{ steps.meta.outputs.name }} ${{ steps.meta.outputs.version }} already exists in ${{ inputs.oci-repo }} — published versions are immutable, skipping push. Bump Chart.yaml version to publish new content."
+        else
+          echo "skipped=false" >> "$GITHUB_OUTPUT"
+        fi
+
+    - name: Package chart
+      if: steps.guard.outputs.skipped != 'true'
+      shell: bash
+      run: |
+        helm package "${{ inputs.chart-dir }}" \
+          --version "${{ steps.meta.outputs.version }}" \
+          --destination /tmp/helm-publish
+
+    - name: Push chart
+      id: push
+      if: steps.guard.outputs.skipped != 'true'
+      shell: bash
+      run: |
+        OUT=$(helm push "/tmp/helm-publish/${{ steps.meta.outputs.name }}-${{ steps.meta.outputs.version }}.tgz" \
+          "oci://${{ inputs.oci-repo }}" 2>&1)
+        echo "$OUT"
+        DIGEST=$(echo "$OUT" | awk '/Digest:/{print $2}')
+        if [ -z "$DIGEST" ]; then
+          echo "::error::Could not parse digest from helm push output."
+          exit 1
+        fi
+        echo "digest=$DIGEST" >> "$GITHUB_OUTPUT"
+
+    - name: Install cosign
+      if: steps.guard.outputs.skipped != 'true'
+      uses: sigstore/cosign-installer@v3
+
+    - name: Sign chart (cosign keyless via GitHub OIDC)
+      if: steps.guard.outputs.skipped != 'true'
+      shell: bash
+      run: |
+        cosign sign --yes \
+          "${{ inputs.oci-repo }}/${{ steps.meta.outputs.name }}@${{ steps.push.outputs.digest }}"
+
+    - name: Smoke check (pull + render the published chart)
+      if: steps.guard.outputs.skipped != 'true'
+      shell: bash
+      run: |
+        mkdir -p /tmp/helm-smoke
+        helm pull "oci://${{ inputs.oci-repo }}/${{ steps.meta.outputs.name }}" \
+          --version "${{ steps.meta.outputs.version }}" --destination /tmp/helm-smoke
+        helm template smoke "/tmp/helm-smoke/${{ steps.meta.outputs.name }}-${{ steps.meta.outputs.version }}.tgz" \
+          --values "${{ inputs.chart-dir }}/ci/default-values.yaml" > /dev/null
+        echo "Published chart pulls and renders cleanly."
+
+    - name: Publish summary
+      shell: bash
+      run: |
+        {
+          echo "## Helm chart: ${{ steps.meta.outputs.name }} ${{ steps.meta.outputs.version }}"
+          echo ""
+          if [ "${{ steps.guard.outputs.skipped }}" = "true" ]; then
+            echo "> Skipped — this version already exists (immutable)."
+          else
+            echo "Digest: \`${{ steps.push.outputs.digest }}\` (cosign-signed, keyless)"
+            echo ""
+            echo '```bash'
+            echo "helm install chouse-ui oci://${{ inputs.oci-repo }}/${{ steps.meta.outputs.name }} --version ${{ steps.meta.outputs.version }}"
+            echo '```'
+          fi
+        } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -220,6 +220,39 @@ jobs:
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "Assembled version: $VERSION"
 
+      - name: Setup Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: v4.2.3
+
+      # Keep the chart shipping the app it was released with. The chart
+      # `version` is only auto-bumped (patch) when the current one is already
+      # published — a pending manual bump from a chart PR is respected, never
+      # double-bumped. If the registry check fails, the version is kept and
+      # the publish step later no-ops on the immutability guard (safe).
+      - name: Sync chart appVersion
+        run: |
+          VERSION="${{ steps.release.outputs.version }}"
+          CHART=charts/chouse-ui/Chart.yaml
+          CURRENT=$(awk '/^version:/{print $2; exit}' "$CHART")
+          if helm show chart "oci://ghcr.io/${{ github.repository_owner }}/charts/chouse-ui" --version "$CURRENT" > /dev/null 2>&1; then
+            NEXT=$(echo "$CURRENT" | awk -F. '{printf "%d.%d.%d", $1, $2, $3+1}')
+            sed -i "s/^version: .*/version: $NEXT/" "$CHART"
+            echo "Chart version bumped: $CURRENT -> $NEXT (previous version already published)"
+          else
+            echo "Chart version $CURRENT not published yet — keeping it."
+          fi
+          sed -i "s/^appVersion: .*/appVersion: \"$VERSION\"/" "$CHART"
+          echo "Chart appVersion set to $VERSION"
+
+      # The chart README embeds version/appVersion badges — regenerate so the
+      # helm-docs drift check on the next chart PR stays green.
+      - name: Regenerate chart README
+        run: |
+          curl -fsSL "https://github.com/norwoodj/helm-docs/releases/download/v1.14.2/helm-docs_1.14.2_Linux_x86_64.tar.gz" \
+            | tar -xz -C /usr/local/bin helm-docs
+          helm-docs --chart-search-root charts/chouse-ui
+
       - name: Trim CHANGELOG to latest 10 releases
         run: |
           COUNT_BEFORE=$(grep -c '^## \[v' CHANGELOG.md || true)
@@ -271,6 +304,8 @@ jobs:
             package.json \
             packages/server/package.json \
             docs/portfolio/package.json \
+            charts/chouse-ui/Chart.yaml \
+            charts/chouse-ui/README.md \
             changelogs/unreleased/
           git commit -m "chore: release v$VERSION"
           git push origin HEAD:preview
@@ -445,6 +480,37 @@ jobs:
           cache-to: type=gha,mode=max
           platforms: linux/amd64,linux/arm64
 
+  # ── Step 4 (parallel, after Docker succeeds): publish Helm chart ──────────
+  # No environment gate: `needs: docker` already puts this behind the approved
+  # docker-publish gate, and the image the chart references must exist first.
+  # publish/deploy-docs do NOT depend on this job — a chart publish failure
+  # can never block an app release (re-run via helm-release.yml if it does).
+  helm:
+    name: Publish Helm Chart
+    needs: [docker, assemble]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: main
+
+      - name: Setup Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: v4.2.3
+
+      - name: Publish chart
+        uses: ./.github/actions/helm-publish
+        with:
+          oci-repo: ghcr.io/${{ github.repository_owner }}/charts
+          token: ${{ secrets.GITHUB_TOKEN }}
+
   # ── Step 4 (parallel, after Docker succeeds): publish tag + GitHub Release ─
   publish:
     name: Publish Tag & Release
@@ -537,6 +603,13 @@ jobs:
             echo ""
             echo '```bash'
             echo "docker pull ghcr.io/$REPO:$VERSION"
+            echo '```'
+            echo ""
+            echo "Or on Kubernetes with Helm:"
+            echo ""
+            echo '```bash'
+            CHART_VERSION=$(awk '/^version:/{print $2; exit}' charts/chouse-ui/Chart.yaml)
+            echo "helm install chouse-ui oci://ghcr.io/${REPO%%/*}/charts/chouse-ui --version $CHART_VERSION"
             echo '```'
             echo ""
             echo "## 🔗 Resources"

--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -1,0 +1,147 @@
+name: Helm Release
+
+# Chart-only releases: template fixes and values additions that shouldn't
+# wait for (or trigger) an app release. App releases publish the chart
+# automatically via the helm job in auto-release.yml — use this workflow only
+# when the chart changed and the app didn't.
+#
+# Runs from 'preview' by default (like auto-release): PRs merge to preview,
+# and main only advances when an app release is cut, so a chart-only fix
+# would otherwise be stuck until the next app release.
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Package and render only — push nothing."
+        type: boolean
+        default: false
+      prerelease:
+        description: "Publish as <version>-pre for cluster testing (replaces the previous -pre tag; no git tag)."
+        type: boolean
+        default: false
+      branch:
+        description: "Branch to release the chart from. Leave empty for 'preview'."
+        required: false
+        default: ""
+
+env:
+  CHART_DIR: charts/chouse-ui
+  HELM_VERSION: v4.2.3
+
+jobs:
+  # ── Step 1: package + render, always. This IS the dry-run; the publish job
+  # below is skipped when dry_run is set. ─────────────────────────────────────
+  plan:
+    name: Package & Render
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      branch: ${{ steps.target.outputs.branch }}
+
+    steps:
+      - name: Resolve target branch
+        id: target
+        run: |
+          BRANCH="${{ inputs.branch }}"
+          if [ -z "$BRANCH" ]; then
+            BRANCH="preview"
+          fi
+          echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
+          echo "Releasing chart from '$BRANCH'"
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.target.outputs.branch }}
+
+      - name: Setup Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: ${{ env.HELM_VERSION }}
+
+      - name: Compute version
+        id: version
+        run: |
+          VERSION=$(awk '/^version:/{print $2; exit}' "$CHART_DIR/Chart.yaml")
+          if [ "${{ inputs.prerelease }}" = "true" ]; then
+            VERSION="$VERSION-pre"
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Target chart version: $VERSION"
+
+      - name: Package and render
+        run: |
+          helm package "$CHART_DIR" --version "${{ steps.version.outputs.version }}" --destination /tmp/plan
+          helm template plan "/tmp/plan/chouse-ui-${{ steps.version.outputs.version }}.tgz" \
+            --values "$CHART_DIR/ci/default-values.yaml" > /dev/null
+          echo "Chart packages and renders cleanly."
+
+      - name: Dry-run summary
+        if: inputs.dry_run
+        run: |
+          {
+            echo "## Dry run — nothing published"
+            echo ""
+            echo "Would publish \`chouse-ui ${{ steps.version.outputs.version }}\` from \`${{ steps.target.outputs.branch }}\` to \`oci://ghcr.io/${{ github.repository_owner }}/charts\`."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  # ── Step 2: approval-gated publish ─────────────────────────────────────────
+  publish:
+    name: Publish to GHCR
+    needs: plan
+    if: ${{ !inputs.dry_run }}
+    runs-on: ubuntu-latest
+    environment: helm-publish
+    permissions:
+      contents: write
+      packages: write
+      id-token: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.plan.outputs.branch }}
+
+      - name: Setup Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: ${{ env.HELM_VERSION }}
+
+      # Re-running with the same version overwrites the -pre tag; delete the
+      # previous one first so its bytes don't linger as orphaned versions
+      # (same pattern as the pre-release image in auto-release.yml).
+      - name: Delete previous pre-release chart
+        if: inputs.prerelease
+        uses: dataaxiom/ghcr-cleanup-action@d52806a0dc70b430571a37da1fde39733ffd640f
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          package: charts/chouse-ui
+          delete-tags: ${{ needs.plan.outputs.version }}
+
+      - name: Publish chart
+        id: publish
+        uses: ./.github/actions/helm-publish
+        with:
+          chart-dir: ${{ env.CHART_DIR }}
+          oci-repo: ghcr.io/${{ github.repository_owner }}/charts
+          version: ${{ needs.plan.outputs.version }}
+          allow-overwrite: ${{ inputs.prerelease && 'true' || 'false' }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Tag chart release
+        if: ${{ !inputs.prerelease && steps.publish.outputs.skipped != 'true' }}
+        run: |
+          TAG="chart-v${{ needs.plan.outputs.version }}"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          if git ls-remote --tags origin "$TAG" | grep -q "refs/tags/$TAG"; then
+            echo "Tag $TAG already exists — skipping."
+            exit 0
+          fi
+          git tag -a "$TAG" -m "Helm chart $TAG"
+          git push origin "$TAG"
+          echo "Tag $TAG created."

--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -1,0 +1,204 @@
+name: Helm Chart
+
+on:
+  pull_request:
+    branches:
+      - preview
+    paths:
+      - "charts/**"
+      - ".github/workflows/helm.yml"
+      - ".github/workflows/helm-release.yml"
+      - ".github/actions/helm-publish/**"
+
+# Cancel in-progress runs when a new commit is pushed to the same branch/PR
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CHART_DIR: charts/chouse-ui
+  HELM_VERSION: v4.2.3
+  UNITTEST_PLUGIN_VERSION: 1.1.2
+  KUBECONFORM_VERSION: v0.8.0
+  HELM_DOCS_VERSION: 1.14.2
+
+jobs:
+  # Any change under charts/ must bump Chart.yaml `version` — a chart change
+  # without a new version could never be published (released versions are
+  # immutable).
+  version-guard:
+    name: Chart Version Bump Guard
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Require a version bump when the chart changes
+        run: |
+          BASE="${{ github.event.pull_request.base.sha }}"
+          CHANGED=$(git diff --name-only "$BASE"...HEAD -- "$CHART_DIR" || true)
+          if [ -z "$CHANGED" ]; then
+            echo "No chart files changed — guard not applicable."
+            exit 0
+          fi
+          OLD=$(git show "$BASE:$CHART_DIR/Chart.yaml" 2>/dev/null | awk '/^version:/{print $2}' || true)
+          NEW=$(awk '/^version:/{print $2}' "$CHART_DIR/Chart.yaml")
+          if [ -z "$OLD" ]; then
+            echo "Chart.yaml is new in this PR (version $NEW) — guard satisfied."
+            exit 0
+          fi
+          if [ "$OLD" = "$NEW" ]; then
+            echo "::error::Chart files changed but Chart.yaml version is still $OLD. Bump the chart 'version' (semver — breaking values changes bump major) so the change can be published. See .rules/HELM_CHART.md."
+            exit 1
+          fi
+          echo "Chart version bumped: $OLD -> $NEW"
+
+  lint-test:
+    name: Lint, Unit Tests & Schema
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: ${{ env.HELM_VERSION }}
+
+      - name: Install helm-unittest plugin
+        run: helm plugin install --verify=false https://github.com/helm-unittest/helm-unittest --version "$UNITTEST_PLUGIN_VERSION"
+
+      - name: Install kubeconform and helm-docs
+        run: |
+          curl -fsSL "https://github.com/yannh/kubeconform/releases/download/${KUBECONFORM_VERSION}/kubeconform-linux-amd64.tar.gz" \
+            | tar -xz -C /usr/local/bin kubeconform
+          curl -fsSL "https://github.com/norwoodj/helm-docs/releases/download/v${HELM_DOCS_VERSION}/helm-docs_${HELM_DOCS_VERSION}_Linux_x86_64.tar.gz" \
+            | tar -xz -C /usr/local/bin helm-docs
+
+      - name: Helm lint (all ci values)
+        run: |
+          for values in "$CHART_DIR"/ci/*-values.yaml; do
+            echo "=== lint with $values"
+            helm lint "$CHART_DIR" --strict --values "$values"
+          done
+
+      - name: Helm unit tests
+        run: helm unittest "$CHART_DIR"
+
+      - name: Kubeconform (rendered manifests, pinned K8s versions)
+        run: |
+          for k8s in 1.29.0 1.31.0 1.33.0; do
+            for values in "$CHART_DIR"/ci/*-values.yaml; do
+              echo "=== kubeconform k8s=$k8s values=$values"
+              helm template chouse-ui "$CHART_DIR" --values "$values" \
+                | kubeconform -strict -summary -kubernetes-version "$k8s"
+            done
+          done
+
+      - name: helm-docs is up to date
+        run: |
+          helm-docs --chart-search-root "$CHART_DIR"
+          if ! git diff --exit-code -- "$CHART_DIR/README.md"; then
+            echo "::error::charts/chouse-ui/README.md is stale. Run helm-docs and commit the result (the README is generated from README.md.gotmpl + values.yaml comments)."
+            exit 1
+          fi
+
+  kind-install:
+    name: Install on kind (${{ matrix.scenario }})
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        scenario: [default, ha-postgres]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: ${{ env.HELM_VERSION }}
+
+      - name: Create kind cluster
+        uses: helm/kind-action@v1
+        with:
+          cluster_name: chart-ci
+
+      - name: Deploy throwaway PostgreSQL
+        if: matrix.scenario == 'ha-postgres'
+        run: |
+          kubectl apply -f - <<'EOF'
+          apiVersion: apps/v1
+          kind: Deployment
+          metadata:
+            name: postgres-ci
+          spec:
+            replicas: 1
+            selector:
+              matchLabels: { app: postgres-ci }
+            template:
+              metadata:
+                labels: { app: postgres-ci }
+              spec:
+                containers:
+                  - name: postgres
+                    image: postgres:16-alpine
+                    env:
+                      - { name: POSTGRES_USER, value: chouse }
+                      - { name: POSTGRES_PASSWORD, value: chouse-ci }
+                      - { name: POSTGRES_DB, value: chouse }
+                    ports:
+                      - containerPort: 5432
+                    readinessProbe:
+                      exec:
+                        command: ["pg_isready", "-U", "chouse"]
+                      periodSeconds: 2
+          ---
+          apiVersion: v1
+          kind: Service
+          metadata:
+            name: postgres-ci
+          spec:
+            selector: { app: postgres-ci }
+            ports:
+              - port: 5432
+          EOF
+          kubectl rollout status deployment/postgres-ci --timeout=120s
+
+      - name: Install chart
+        run: |
+          helm install chouse-ui "$CHART_DIR" \
+            --values "$CHART_DIR/ci/${{ matrix.scenario }}-values.yaml" \
+            --wait --timeout 5m
+
+      - name: Helm test
+        run: helm test chouse-ui --logs
+
+      # Release-to-release upgrade coverage starts once a chart version is
+      # published; until then this exercises the upgrade machinery (checksum
+      # rollout + Recreate/RollingUpdate paths) with the PR chart itself.
+      - name: Upgrade in place (config change rolls pods)
+        run: |
+          helm upgrade chouse-ui "$CHART_DIR" \
+            --values "$CHART_DIR/ci/${{ matrix.scenario }}-values.yaml" \
+            --set-string config.log_level=info \
+            --wait --timeout 5m
+          helm test chouse-ui --logs
+
+      - name: Diagnostics on failure
+        if: failure()
+        run: |
+          kubectl get pods -A -o wide || true
+          kubectl describe pods -l app.kubernetes.io/name=chouse-ui || true
+          kubectl logs -l app.kubernetes.io/name=chouse-ui --all-containers --tail=200 || true

--- a/.rules/HELM_CHART.md
+++ b/.rules/HELM_CHART.md
@@ -1,0 +1,71 @@
+# Helm Chart Rules
+
+When and how to update `charts/chouse-ui/` — the production Helm chart
+(ADR 0008). The chart is a public, versioned artifact on
+`oci://ghcr.io/daun-gatal/charts/chouse-ui`; published versions are immutable.
+
+---
+
+## When a code change requires a chart change (same PR)
+
+If your change touches any of these, the chart **must** be updated in the same
+PR — the chart is how Kubernetes users consume the change:
+
+| Code change | Chart impact |
+|---|---|
+| New / renamed / removed env var or config key (you touched `.env.example` or `.config.example.yaml`) | `values.yaml` (+ comment), `values.schema.json`, env wiring in `templates/_helpers.tpl` or deployment templates if chart-managed; README regen. If the key is app-level and flows through `config:`, usually only docs — but check the managed-keys guard in `templates/_validate.tpl`. |
+| Server port, health endpoint paths, or startup/readiness semantics (`packages/server/src/index.ts`, `packages/server/src/routes/index.ts`) | `probes` defaults, Service `targetPort`, helm test (`templates/tests/test-connection.yaml`). |
+| New background service, scheduler, or lease | Assess HA: does it lease correctly across pods on PostgreSQL? Update `CHOUSE_HA` handling, `_validate.tpl` guards, or the dedicated-scheduler split. |
+| New required production secret, or changed validation in `validateEnvironmentVariables()` | `secrets.*` values, `templates/secret.yaml`, matching render-time checks in `_validate.tpl` (chart guards mirror server guards). |
+| `Dockerfile` changes: user/uid, port, `/app/data` layout, writable paths | `podSecurityContext` (uid/fsGroup), PVC mount, `readOnlyRootFilesystem` + `/tmp` emptyDir assumptions. |
+| SQLite/PostgreSQL behavior or migration-locking changes | Topology guards in `_validate.tpl`, `Recreate`/`RollingUpdate` switch, startup probe budget. |
+
+Not chart-relevant: pure frontend changes, refactors, anything that doesn't
+alter the container's runtime contract.
+
+## How to ship a chart change
+
+1. **Bump `version` in `Chart.yaml`** — always, in the same PR (CI's
+   version-guard blocks the merge otherwise). Semver: breaking values changes
+   (renamed/removed keys, changed defaults that alter behavior) bump
+   **major**; new values/features bump **minor**; fixes bump **patch**.
+2. **Never edit `appVersion`** — `auto-release.yml` owns it.
+3. **Never edit `charts/chouse-ui/README.md` directly** — it is generated.
+   Edit `README.md.gotmpl` or the `# --` comments in `values.yaml`, then run
+   `helm-docs --chart-search-root charts/chouse-ui`.
+4. **Keep `values.schema.json` in sync** with any values change.
+5. **Add/adjust a helm-unittest case** (`charts/chouse-ui/tests/`) for any
+   template logic with branches — guards, mode switches, secret wiring. Run:
+   `helm unittest charts/chouse-ui`.
+6. New topology or mode? Add a `ci/<scenario>-values.yaml` and extend the
+   kind matrix in `.github/workflows/helm.yml`.
+7. Verify locally before pushing:
+   `helm lint charts/chouse-ui --strict --values charts/chouse-ui/ci/default-values.yaml`
+   and `helm unittest charts/chouse-ui`.
+
+## Publishing (for context — you don't do this in a PR)
+
+- App releases publish the chart automatically (`helm` job in
+  `auto-release.yml`; `assemble` syncs `appVersion` and auto-bumps the chart
+  patch version only when the current version is already published).
+- Chart-only fixes ship via the `Helm Release` workflow
+  (`helm-release.yml`, workflow_dispatch from `preview`; supports `dry_run`
+  and `prerelease`).
+- Publish logic lives once, in `.github/actions/helm-publish/action.yml`.
+
+## Hard don'ts
+
+- **Never auto-generate secrets** in templates (no `lookup`/`randAlphaNum`
+  for `JWT_SECRET` / `RBAC_ENCRYPTION_KEY` / `RBAC_ENCRYPTION_SALT`) — a
+  regenerated encryption key makes every stored ClickHouse password
+  unrecoverable. Render-time `fail` with generation instructions is the
+  policy.
+- **Never weaken the topology guards** in `_validate.tpl` (sqlite ×
+  replicas>1 / HPA / dedicated scheduler) — they exist because the server
+  only warns at runtime while data silently diverges per pod.
+- **No bundled database subcharts** (PostgreSQL, ClickHouse) — ADR 0008
+  non-goal.
+- **Don't add anything to `selectorLabels`** — selectors are immutable on
+  Deployments; changing them breaks every existing install's upgrade.
+- A chart change is user-visible: add a `changelogs/unreleased/` fragment
+  like any other feature/fix.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,7 @@ CHouse UI is a web interface for ClickHouse with built-in RBAC, fleet monitoring
 - `src/` — Frontend (React 19 + Vite 7 SPA)
 - `packages/server/` — Backend (Bun + Hono v4 API server)
 - `docs/portfolio/` — Marketing/docs website (separate Vite app)
+- `charts/chouse-ui/` — Production Helm chart (published to `oci://ghcr.io/daun-gatal/charts/chouse-ui`; see [.rules/HELM_CHART.md](.rules/HELM_CHART.md))
 
 ## Quick Reference
 
@@ -174,6 +175,12 @@ When a PR containing a fragment merges to `main`, `auto-release.yml` fires autom
 
 Manual override (emergency use only): `bun run release 2.20.0`
 
+**Helm chart versioning is separate:** `charts/chouse-ui/Chart.yaml` `version`
+is bumped **manually** in every PR that changes the chart (CI enforces this),
+while `appVersion` is synced automatically by `auto-release.yml` — never edit
+`appVersion` or the generated chart `README.md` by hand. Chart-only releases
+ship via the `Helm Release` workflow. See [.rules/HELM_CHART.md](.rules/HELM_CHART.md).
+
 ## Architecture Decision Records (ADR)
 
 For **big, multi-component** changes, capture the proposal as an ADR in
@@ -201,3 +208,4 @@ data flow, deployment topology, anything spanning RBAC + ClickHouse + UI), and
 | Proactively scanning the codebase for cleanup | **[.rules/DEAD_CODE.md](.rules/DEAD_CODE.md)** — full scan process including dependency and barrel-export checks |
 | A change is user-visible (new feature, bug fix, removal) | Drop a fragment in `changelogs/unreleased/<pr-number>-<slug>.md` — never edit `CHANGELOG.md` directly |
 | Touching `rbac/db/migrations.ts` (add or edit a migration) | **MANDATORY** — add/update `migrations.test.ts` (per-version `VERSION_CHECKS` + data-migration cases) and run `./scripts/test-migrations.sh` (SQLite + PostgreSQL/Docker). See [Database Migrations](#database-migrations--testing-is-mandatory). |
+| Changing env vars / config keys, server port or health endpoints, required secrets, the Dockerfile, background services/leases, or anything under `charts/` | **[.rules/HELM_CHART.md](.rules/HELM_CHART.md)** — whether the Helm chart must change in the same PR, how to version it (bump `Chart.yaml` `version`; never `appVersion`), and what to regenerate/test. |

--- a/README.md
+++ b/README.md
@@ -178,6 +178,24 @@ Access at http://localhost:5521
 
 For production, we recommend using an external highly-available PostgreSQL database for RBAC storage. See the [Configuration](#configuration) section for details on how to configure `RBAC_POSTGRES_URL`.
 
+### Deployment (Kubernetes / Helm)
+
+The production Helm chart is published to GHCR as a signed OCI artifact:
+
+```bash
+helm install chouse-ui oci://ghcr.io/daun-gatal/charts/chouse-ui \
+  --set secrets.jwtSecret="$(openssl rand -base64 32)" \
+  --set secrets.encryptionKey="$(openssl rand -hex 32)" \
+  --set secrets.encryptionSalt="$(openssl rand -hex 32)"
+```
+
+The default install is single-replica SQLite on a PersistentVolumeClaim. For
+HA, point the chart at PostgreSQL (`database.type=postgres`) and scale
+`replicaCount` — the chart enforces the topology rules (SQLite cannot span
+pods) at render time and sets `CHOUSE_HA` for you. See
+[`charts/chouse-ui/README.md`](charts/chouse-ui/README.md) for all values,
+the topology guide, SSO/config examples, and ingress notes.
+
 ---
 
 ## Configuration

--- a/changelogs/unreleased/312-helm-chart.md
+++ b/changelogs/unreleased/312-helm-chart.md
@@ -1,0 +1,4 @@
+type: minor
+
+### Added
+- **Production Helm chart** — official Kubernetes deployment via `helm install chouse-ui oci://ghcr.io/daun-gatal/charts/chouse-ui`: SQLite (single replica + PVC) and PostgreSQL/HA topologies with render-time guard rails, automatic `CHOUSE_HA` wiring, optional dedicated scheduled-queries pod, hardened security defaults, and cosign-signed chart releases published automatically alongside app releases (ADR 0008).

--- a/charts/chouse-ui/Chart.yaml
+++ b/charts/chouse-ui/Chart.yaml
@@ -1,0 +1,25 @@
+apiVersion: v2
+name: chouse-ui
+description: >-
+  A modern web interface for ClickHouse with built-in RBAC, fleet monitoring,
+  scheduled queries, data health checks, and an AI SRE.
+type: application
+# Chart version — bump manually in every PR that changes the chart
+# (see .rules/HELM_CHART.md). Breaking values changes bump major.
+version: 1.0.0
+# App version — owned by auto-release.yml; never edit by hand.
+appVersion: "3.9.0"
+kubeVersion: ">=1.25.0-0"
+home: https://github.com/daun-gatal/chouse-ui
+sources:
+  - https://github.com/daun-gatal/chouse-ui
+keywords:
+  - clickhouse
+  - database
+  - sql
+  - rbac
+  - monitoring
+  - ai
+maintainers:
+  - name: daun-gatal
+    url: https://github.com/daun-gatal

--- a/charts/chouse-ui/Chart.yaml
+++ b/charts/chouse-ui/Chart.yaml
@@ -8,7 +8,7 @@ type: application
 # (see .rules/HELM_CHART.md). Breaking values changes bump major.
 version: 1.0.0
 # App version — owned by auto-release.yml; never edit by hand.
-appVersion: "3.9.0"
+appVersion: "3.10.0"
 kubeVersion: ">=1.25.0-0"
 home: https://github.com/daun-gatal/chouse-ui
 sources:

--- a/charts/chouse-ui/README.md
+++ b/charts/chouse-ui/README.md
@@ -1,0 +1,192 @@
+# chouse-ui
+
+![Version: 1.0.0](https://img.shields.io/badge/Version-1.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.9.0](https://img.shields.io/badge/AppVersion-3.9.0-informational?style=flat-square)
+
+A modern web interface for ClickHouse with built-in RBAC, fleet monitoring, scheduled queries, data health checks, and an AI SRE.
+
+The chart deploys the single CHouse UI container (API + SPA on port 5521) and
+wires the topology rules the app expects — so a broken layout fails at
+`helm install` instead of corrupting data at runtime.
+
+## Quickstart
+
+```bash
+helm install chouse-ui oci://ghcr.io/daun-gatal/charts/chouse-ui \
+  --set secrets.jwtSecret="$(openssl rand -base64 32)" \
+  --set secrets.encryptionKey="$(openssl rand -hex 32)" \
+  --set secrets.encryptionSalt="$(openssl rand -hex 32)"
+
+kubectl port-forward svc/chouse-ui 5521:80
+```
+
+Log in at http://localhost:5521 with `admin@localhost` / `admin123!` — and
+change that password immediately.
+
+> **Keep those three secrets safe.** `encryptionKey`/`encryptionSalt` protect
+> every stored ClickHouse connection password; if they change, those stored
+> credentials are unrecoverable. For real installs put them in a Secret and
+> pass `secrets.existingSecret` (keys `JWT_SECRET`, `RBAC_ENCRYPTION_KEY`,
+> `RBAC_ENCRYPTION_SALT`).
+
+## Choosing a topology
+
+| | SQLite (default) | PostgreSQL |
+|---|---|---|
+| Replicas | exactly 1 (enforced) | any — the chart sets `CHOUSE_HA=true` when >1 |
+| State | PVC at `/app/data` (kept on uninstall) | external database, stateless pods |
+| Rollouts | `Recreate` (brief downtime) | `RollingUpdate`, HPA, PDB, spread constraints |
+| Good for | single-team installs, evaluation | production, HA |
+
+```yaml
+# HA example
+replicaCount: 3
+database:
+  type: postgres
+  postgres:
+    existingSecret: chouse-postgres      # key RBAC_POSTGRES_URL
+secrets:
+  existingSecret: chouse-secrets
+pdb:
+  enabled: true
+```
+
+The chart deliberately bundles **no** PostgreSQL or ClickHouse — bring your
+own (CloudNativePG or a managed Postgres work well). Migrations run at pod
+start and are safe under concurrent replica boot (Postgres advisory lock).
+
+## App configuration
+
+Everything the app reads from its config file — SSO, fleet poller, AI doctor,
+admin seeding, CORS, log level — goes under the freeform `config:` block,
+which the chart renders into a Secret-mounted `config.yaml` (schema:
+[`.config.example.yaml`](../../.config.example.yaml)):
+
+```yaml
+config:
+  cors_origin: "https://chouse.example.com"
+  fleet:
+    poller_enabled: true
+  auth:
+    sso:
+      enabled: true
+      base_url: https://chouse.example.com
+      providers:
+        okta:
+          type: oidc
+          display_name: "Okta"
+          issuer: https://corp.okta.com
+          client_id: "..."
+          client_secret: "${OKTA_CLIENT_SECRET}"   # via extraEnv from a Secret
+extraEnv:
+  - name: OKTA_CLIENT_SECRET
+    valueFrom:
+      secretKeyRef:
+        name: okta-oidc
+        key: client_secret
+```
+
+Keys the chart already manages (`port`, `rbac.db_type`, `jwt.secret`, …) are
+rejected at render time to avoid silent conflicts — use the chart values for
+those.
+
+## Ingress notes
+
+- AI chat streams over **SSE**: raise the proxy read timeout (nginx:
+  `nginx.ingress.kubernetes.io/proxy-read-timeout: "300"`) and disable
+  response buffering (`nginx.ingress.kubernetes.io/proxy-buffering: "off"`).
+- Login rate limiting keys on **`X-Forwarded-For`** — the ingress must
+  overwrite it with the real client IP (nginx: `use-forwarded-headers`
+  configured correctly), or all users share one rate-limit bucket and
+  spoofed headers bypass it.
+
+## Migrating from docker-compose
+
+Move to PostgreSQL *before* moving to Kubernetes, or copy your existing
+`data/` directory into the release's PVC — the one-time legacy import of
+`alert-config.json` / `doctor-schedule.json` and your SQLite database both
+live there.
+
+## Requirements
+
+Kubernetes: `>=1.25.0-0`
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| affinity | object | `{}` | Affinity for all pods. |
+| autoscaling.enabled | bool | `false` | Horizontal pod autoscaling for the web pods. Requires `database.type: postgres` (render fails on sqlite). Implies `CHOUSE_HA=true` regardless of `replicaCount`. |
+| autoscaling.maxReplicas | int | `5` |  |
+| autoscaling.minReplicas | int | `2` |  |
+| autoscaling.targetCPUUtilizationPercentage | int | `80` | Target average CPU utilization (percent). |
+| autoscaling.targetMemoryUtilizationPercentage | string | `""` | Target average memory utilization (percent). Empty disables the memory metric. |
+| commonLabels | object | `{}` | Labels added to every rendered resource. |
+| config | object | `{}` | Freeform CHouse UI configuration, rendered to a Secret-mounted `config.yaml` (see `.config.example.yaml` in the repo for the full schema: SSO, fleet poller, AI doctor, admin seeding, CORS, log level, ...). Do NOT set keys the chart already manages (`port`, `node_env`, `static_path`, `rbac.db_type`, `rbac.sqlite_path`, `rbac.postgres_url`, `rbac.encryption`, `jwt.secret`, `scheduled_queries`) — the chart refuses to render if you do, because config.yaml values override the pod environment. |
+| containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true}` | Container security context. The root filesystem is read-only; the chart mounts an emptyDir on `/tmp`. |
+| database.postgres.existingSecret | string | `""` | Name of an existing Secret holding the connection URL. |
+| database.postgres.existingSecretKey | string | `"RBAC_POSTGRES_URL"` | Key inside `existingSecret` that holds the URL. |
+| database.postgres.poolSize | int | `10` | Connection pool size per pod. |
+| database.postgres.url | string | `""` | Full PostgreSQL connection URL (`postgres://user:pass@host:5432/dbname`). Stored in a chart-managed Secret. Prefer `existingSecret` so the URL never lands in values files. |
+| database.sqlite.persistence.accessModes | list | `["ReadWriteOnce"]` | PVC access modes. |
+| database.sqlite.persistence.annotations | object | `{}` | Extra annotations for the PVC (e.g. to keep it on helm uninstall). |
+| database.sqlite.persistence.enabled | bool | `true` | Persist the SQLite database (`/app/data`) on a PVC. Disabling this loses all users, connections, and settings on every pod restart — only do it for throwaway installs. |
+| database.sqlite.persistence.existingClaim | string | `""` | Use a pre-created PVC instead of chart-managed one. |
+| database.sqlite.persistence.size | string | `"1Gi"` | PVC size. |
+| database.sqlite.persistence.storageClass | string | `""` | StorageClass. Empty string uses the cluster default. |
+| database.type | string | `"sqlite"` | RBAC database backend: `sqlite` (single replica + PVC) or `postgres` (external PostgreSQL; required for HA / more than one replica). |
+| dedicatedScheduler.enabled | bool | `false` | Run the scheduled-queries scheduler on a dedicated single-replica Deployment instead of the web pods. Requires `database.type: postgres`. |
+| dedicatedScheduler.resources | object | `{}` | Resources for the scheduler pod. |
+| extraEnv | list | `[]` | Extra environment variables for the web pods (list of EnvVar). Useful for referencing SSO client secrets from Secrets via `valueFrom`. |
+| extraEnvFrom | list | `[]` | Extra `envFrom` sources (ConfigMap/Secret refs) for the web pods. |
+| extraVolumeMounts | list | `[]` | Extra volume mounts for the web container. |
+| extraVolumes | list | `[]` | Extra volumes for the web pods. |
+| fullnameOverride | string | `""` | Override the fully qualified release name. |
+| image.pullPolicy | string | `"IfNotPresent"` | Image pull policy. |
+| image.repository | string | `"ghcr.io/daun-gatal/chouse-ui"` | Container image repository. |
+| image.tag | string | `""` | Image tag. Defaults to `v<Chart.appVersion>`. |
+| imagePullSecrets | list | `[]` | Secrets for pulling the image from a private registry. |
+| ingress.annotations | object | `{}` | Ingress annotations. Two matter operationally: AI chat streams over SSE, so raise the proxy read timeout (nginx: `nginx.ingress.kubernetes.io/proxy-read-timeout: "300"`) and disable buffering (`nginx.ingress.kubernetes.io/proxy-buffering: "off"`); and login rate limiting keys on X-Forwarded-For, so the ingress must overwrite it with the real client IP. |
+| ingress.className | string | `""` | IngressClass name. |
+| ingress.enabled | bool | `false` | Expose the UI through an Ingress. |
+| ingress.hosts[0].host | string | `"chouse-ui.local"` |  |
+| ingress.hosts[0].paths[0].path | string | `"/"` |  |
+| ingress.hosts[0].paths[0].pathType | string | `"Prefix"` |  |
+| ingress.tls | list | `[]` | TLS configuration. |
+| initContainers | list | `[]` | Extra init containers for the web pods. |
+| nameOverride | string | `""` | Override the chart name. |
+| networkPolicy.egressTo | list | `[]` | Extra egress rules (full NetworkPolicyEgressRule objects) applied when `restrictEgress` is true. |
+| networkPolicy.enabled | bool | `false` | Create a NetworkPolicy for the pods. |
+| networkPolicy.ingressFrom | list | `[]` | Extra `from` peers allowed to reach the pods on the app port (in addition to same-namespace pods). Use this to admit your ingress controller's namespace. |
+| networkPolicy.restrictEgress | bool | `false` | Restrict egress. When true, only DNS plus `egressTo` are allowed — list your ClickHouse hosts, PostgreSQL, IdP, SMTP, and AI provider endpoints there. When false, all egress is allowed. |
+| nodeSelector | object | `{}` | Node selector for all pods. |
+| pdb.enabled | bool | `false` | PodDisruptionBudget for the web pods. Only meaningful with more than one replica. |
+| pdb.maxUnavailable | string | `""` | Maximum pods that may be unavailable. Set `minAvailable` to "" when using this. |
+| pdb.minAvailable | int | `1` | Minimum pods that must stay available. Mutually exclusive with `maxUnavailable`. |
+| podAnnotations | object | `{}` | Extra annotations for the pods. |
+| podLabels | object | `{}` | Extra labels for the pods. |
+| podSecurityContext | object | `{"fsGroup":1001,"runAsGroup":1001,"runAsNonRoot":true,"runAsUser":1001,"seccompProfile":{"type":"RuntimeDefault"}}` | Pod security context. The image runs as uid/gid 1001; `fsGroup` makes the SQLite PVC writable. |
+| priorityClassName | string | `""` | Priority class for all pods. |
+| probes.liveness | object | `{"failureThreshold":3,"httpGet":{"path":"/api/health","port":"http"},"periodSeconds":20,"timeoutSeconds":5}` | Liveness probe — dependency-free endpoint. |
+| probes.readiness | object | `{"failureThreshold":3,"httpGet":{"path":"/api/rbac/health","port":"http"},"periodSeconds":10,"timeoutSeconds":5}` | Readiness probe — 503 until the RBAC database is healthy and migrations have applied. |
+| probes.startup | object | `{"failureThreshold":60,"httpGet":{"path":"/api/rbac/health","port":"http"},"periodSeconds":5,"timeoutSeconds":5}` | Startup probe — generous budget (5 min) so long upgrade migrations don't get the pod killed. |
+| replicaCount | int | `1` | Number of web pods. Must be 1 when `database.type` is `sqlite` (the chart refuses to render otherwise). When >1, the chart sets `CHOUSE_HA=true` on the pods automatically. |
+| resources.limits.memory | string | `"1Gi"` |  |
+| resources.requests.cpu | string | `"250m"` |  |
+| resources.requests.memory | string | `"256Mi"` |  |
+| scheduledQueries.enabled | bool | `true` | Run the in-process scheduled-queries scheduler on the web pods. Redundant ticks across pods are harmless (per-job atomic lease on PostgreSQL). Ignored (forced off on web pods) when `dedicatedScheduler.enabled` is true. |
+| secrets.encryptionKey | string | `""` | AES-256 key for stored connection passwords, 64 hex chars. Generate: `openssl rand -hex 32`. |
+| secrets.encryptionSalt | string | `""` | Key-derivation salt, exactly 64 hex chars. Generate: `openssl rand -hex 32`. |
+| secrets.existingSecret | string | `""` | Name of an existing Secret with keys `JWT_SECRET`, `RBAC_ENCRYPTION_KEY`, and `RBAC_ENCRYPTION_SALT` (recommended). When empty, the three inline values below are required and rendered into a chart-managed Secret. The chart never auto-generates these: the encryption key/salt protect stored ClickHouse passwords, and a regenerated key makes them unrecoverable. |
+| secrets.jwtSecret | string | `""` | JWT signing secret, min 32 chars. Generate: `openssl rand -base64 32`. |
+| service.annotations | object | `{}` | Extra annotations for the Service. |
+| service.port | int | `80` | Service port (targets the fixed container port 5521). |
+| service.type | string | `"ClusterIP"` | Service type. |
+| serviceAccount.annotations | object | `{}` | Annotations for the ServiceAccount. |
+| serviceAccount.create | bool | `true` | Create a ServiceAccount for the pods. |
+| serviceAccount.name | string | `""` | ServiceAccount name override. |
+| terminationGracePeriodSeconds | int | `60` | Grace period so the SIGTERM handler can release poller leases and drain scheduled-query slots. |
+| tolerations | list | `[]` | Tolerations for all pods. |
+| topologySpreadConstraints | list | `[]` | Topology spread constraints for the web pods (postgres/HA installs). |
+
+----------------------------------------------
+Autogenerated from chart metadata using [helm-docs v1.14.2](https://github.com/norwoodj/helm-docs/releases/v1.14.2)

--- a/charts/chouse-ui/README.md
+++ b/charts/chouse-ui/README.md
@@ -1,6 +1,6 @@
 # chouse-ui
 
-![Version: 1.0.0](https://img.shields.io/badge/Version-1.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.9.0](https://img.shields.io/badge/AppVersion-3.9.0-informational?style=flat-square)
+![Version: 1.0.0](https://img.shields.io/badge/Version-1.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.10.0](https://img.shields.io/badge/AppVersion-3.10.0-informational?style=flat-square)
 
 A modern web interface for ClickHouse with built-in RBAC, fleet monitoring, scheduled queries, data health checks, and an AI SRE.
 

--- a/charts/chouse-ui/README.md
+++ b/charts/chouse-ui/README.md
@@ -165,6 +165,7 @@ Kubernetes: `>=1.25.0-0`
 | podAnnotations | object | `{}` | Extra annotations for the pods. |
 | podLabels | object | `{}` | Extra labels for the pods. |
 | podSecurityContext | object | `{"fsGroup":1001,"runAsGroup":1001,"runAsNonRoot":true,"runAsUser":1001,"seccompProfile":{"type":"RuntimeDefault"}}` | Pod security context. The image runs as uid/gid 1001; `fsGroup` makes the SQLite PVC writable. |
+| preStopSleepSeconds | int | `5` | Seconds the web container keeps serving after Kubernetes starts terminating it (preStop sleep). Endpoint removal reaches kube-proxy asynchronously; without this, connections routed to a terminating pod during a rolling update can hang. Set to 0 to disable. Applies to web pods only (the scheduler receives no Service traffic). |
 | priorityClassName | string | `""` | Priority class for all pods. |
 | probes.liveness | object | `{"failureThreshold":3,"httpGet":{"path":"/api/health","port":"http"},"periodSeconds":20,"timeoutSeconds":5}` | Liveness probe — dependency-free endpoint. |
 | probes.readiness | object | `{"failureThreshold":3,"httpGet":{"path":"/api/rbac/health","port":"http"},"periodSeconds":10,"timeoutSeconds":5}` | Readiness probe — 503 until the RBAC database is healthy and migrations have applied. |

--- a/charts/chouse-ui/README.md.gotmpl
+++ b/charts/chouse-ui/README.md.gotmpl
@@ -1,0 +1,115 @@
+{{ template "chart.header" . }}
+
+{{ template "chart.deprecationWarning" . }}
+
+{{ template "chart.badgesSection" . }}
+
+{{ template "chart.description" . }}
+
+The chart deploys the single CHouse UI container (API + SPA on port 5521) and
+wires the topology rules the app expects — so a broken layout fails at
+`helm install` instead of corrupting data at runtime.
+
+## Quickstart
+
+```bash
+helm install chouse-ui oci://ghcr.io/daun-gatal/charts/chouse-ui \
+  --set secrets.jwtSecret="$(openssl rand -base64 32)" \
+  --set secrets.encryptionKey="$(openssl rand -hex 32)" \
+  --set secrets.encryptionSalt="$(openssl rand -hex 32)"
+
+kubectl port-forward svc/chouse-ui 5521:80
+```
+
+Log in at http://localhost:5521 with `admin@localhost` / `admin123!` — and
+change that password immediately.
+
+> **Keep those three secrets safe.** `encryptionKey`/`encryptionSalt` protect
+> every stored ClickHouse connection password; if they change, those stored
+> credentials are unrecoverable. For real installs put them in a Secret and
+> pass `secrets.existingSecret` (keys `JWT_SECRET`, `RBAC_ENCRYPTION_KEY`,
+> `RBAC_ENCRYPTION_SALT`).
+
+## Choosing a topology
+
+| | SQLite (default) | PostgreSQL |
+|---|---|---|
+| Replicas | exactly 1 (enforced) | any — the chart sets `CHOUSE_HA=true` when >1 |
+| State | PVC at `/app/data` (kept on uninstall) | external database, stateless pods |
+| Rollouts | `Recreate` (brief downtime) | `RollingUpdate`, HPA, PDB, spread constraints |
+| Good for | single-team installs, evaluation | production, HA |
+
+```yaml
+# HA example
+replicaCount: 3
+database:
+  type: postgres
+  postgres:
+    existingSecret: chouse-postgres      # key RBAC_POSTGRES_URL
+secrets:
+  existingSecret: chouse-secrets
+pdb:
+  enabled: true
+```
+
+The chart deliberately bundles **no** PostgreSQL or ClickHouse — bring your
+own (CloudNativePG or a managed Postgres work well). Migrations run at pod
+start and are safe under concurrent replica boot (Postgres advisory lock).
+
+## App configuration
+
+Everything the app reads from its config file — SSO, fleet poller, AI doctor,
+admin seeding, CORS, log level — goes under the freeform `config:` block,
+which the chart renders into a Secret-mounted `config.yaml` (schema:
+[`.config.example.yaml`](../../.config.example.yaml)):
+
+```yaml
+config:
+  cors_origin: "https://chouse.example.com"
+  fleet:
+    poller_enabled: true
+  auth:
+    sso:
+      enabled: true
+      base_url: https://chouse.example.com
+      providers:
+        okta:
+          type: oidc
+          display_name: "Okta"
+          issuer: https://corp.okta.com
+          client_id: "..."
+          client_secret: "${OKTA_CLIENT_SECRET}"   # via extraEnv from a Secret
+extraEnv:
+  - name: OKTA_CLIENT_SECRET
+    valueFrom:
+      secretKeyRef:
+        name: okta-oidc
+        key: client_secret
+```
+
+Keys the chart already manages (`port`, `rbac.db_type`, `jwt.secret`, …) are
+rejected at render time to avoid silent conflicts — use the chart values for
+those.
+
+## Ingress notes
+
+- AI chat streams over **SSE**: raise the proxy read timeout (nginx:
+  `nginx.ingress.kubernetes.io/proxy-read-timeout: "300"`) and disable
+  response buffering (`nginx.ingress.kubernetes.io/proxy-buffering: "off"`).
+- Login rate limiting keys on **`X-Forwarded-For`** — the ingress must
+  overwrite it with the real client IP (nginx: `use-forwarded-headers`
+  configured correctly), or all users share one rate-limit bucket and
+  spoofed headers bypass it.
+
+## Migrating from docker-compose
+
+Move to PostgreSQL *before* moving to Kubernetes, or copy your existing
+`data/` directory into the release's PVC — the one-time legacy import of
+`alert-config.json` / `doctor-schedule.json` and your SQLite database both
+live there.
+
+{{ template "chart.requirementsSection" . }}
+
+{{ template "chart.valuesSection" . }}
+
+{{ template "helm-docs.versionFooter" . }}

--- a/charts/chouse-ui/ci/default-values.yaml
+++ b/charts/chouse-ui/ci/default-values.yaml
@@ -1,0 +1,8 @@
+# chart-testing: default SQLite topology on kind.
+# CI-only throwaway secrets — never reuse outside ephemeral test clusters.
+secrets:
+  jwtSecret: "ci-only-jwt-secret-0123456789-0123456789"
+  encryptionKey: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  encryptionSalt: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+config:
+  log_level: debug

--- a/charts/chouse-ui/ci/ha-postgres-values.yaml
+++ b/charts/chouse-ui/ci/ha-postgres-values.yaml
@@ -1,0 +1,18 @@
+# chart-testing: HA topology on kind against the throwaway PostgreSQL the
+# workflow deploys as `postgres-ci` in the same namespace.
+# CI-only throwaway secrets — never reuse outside ephemeral test clusters.
+replicaCount: 2
+database:
+  type: postgres
+  postgres:
+    url: "postgres://chouse:chouse-ci@postgres-ci:5432/chouse"
+secrets:
+  jwtSecret: "ci-only-jwt-secret-0123456789-0123456789"
+  encryptionKey: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  encryptionSalt: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+dedicatedScheduler:
+  enabled: true
+pdb:
+  enabled: true
+config:
+  log_level: debug

--- a/charts/chouse-ui/templates/NOTES.txt
+++ b/charts/chouse-ui/templates/NOTES.txt
@@ -1,0 +1,50 @@
+CHouse UI {{ .Values.image.tag | default (printf "v%s" .Chart.AppVersion) }} deployed.
+
+  Mode:     {{ .Values.database.type }}{{ if gt (int .Values.replicaCount) 1 }} (HA — CHOUSE_HA=true set on {{ .Values.replicaCount }} replicas){{ end }}
+  Service:  {{ include "chouse-ui.fullname" . }}:{{ .Values.service.port }} (namespace {{ .Release.Namespace }})
+
+Reach the UI:
+{{- if .Values.ingress }}
+{{- if .Values.ingress.enabled }}
+{{- range .Values.ingress.hosts }}
+
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ .host }}
+{{- end }}
+{{- else }}
+
+  kubectl -n {{ .Release.Namespace }} port-forward svc/{{ include "chouse-ui.fullname" . }} 5521:{{ .Values.service.port }}
+  open http://localhost:5521
+{{- end }}
+{{- else }}
+
+  kubectl -n {{ .Release.Namespace }} port-forward svc/{{ include "chouse-ui.fullname" . }} 5521:{{ .Values.service.port }}
+  open http://localhost:5521
+{{- end }}
+
+First login (unless overridden via config.rbac.admin):
+
+  email/username: admin@localhost / admin
+  password:       admin123!
+
+  >>> Change this password immediately. <<<
+
+{{- if eq .Values.database.type "sqlite" }}
+{{- if not .Values.database.sqlite.persistence.enabled }}
+
+WARNING: persistence is disabled — all users, connections, and settings are
+lost on every pod restart. Enable database.sqlite.persistence for anything
+beyond a throwaway install.
+{{- end }}
+
+Note: SQLite mode is limited to a single replica. For HA, point the chart at
+PostgreSQL (database.type=postgres) and scale replicaCount.
+{{- end }}
+{{- if .Values.ingress }}{{- if .Values.ingress.enabled }}
+
+Ingress reminders:
+  - AI chat streams over SSE; raise the proxy read timeout (nginx:
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "300") and disable
+    response buffering for smooth streaming.
+  - Login rate limiting keys on X-Forwarded-For — make sure your ingress
+    overwrites it with the real client IP.
+{{- end }}{{- end }}

--- a/charts/chouse-ui/templates/_helpers.tpl
+++ b/charts/chouse-ui/templates/_helpers.tpl
@@ -1,0 +1,146 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "chouse-ui.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name, truncated at 63 chars (DNS limit).
+*/}}
+{{- define "chouse-ui.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Chart name and version for the chart label.
+*/}}
+{{- define "chouse-ui.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels.
+*/}}
+{{- define "chouse-ui.labels" -}}
+helm.sh/chart: {{ include "chouse-ui.chart" . }}
+{{ include "chouse-ui.selectorLabels" . }}
+app.kubernetes.io/version: {{ .Values.image.tag | default (printf "v%s" .Chart.AppVersion) | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- with .Values.commonLabels }}
+{{ toYaml . }}
+{{- end }}
+{{- end }}
+
+{{/*
+Selector labels (immutable — never add anything that changes across upgrades).
+*/}}
+{{- define "chouse-ui.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "chouse-ui.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+ServiceAccount name.
+*/}}
+{{- define "chouse-ui.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "chouse-ui.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Full image reference. The release pipeline tags images v<semver>.
+*/}}
+{{- define "chouse-ui.image" -}}
+{{- printf "%s:%s" .Values.image.repository (.Values.image.tag | default (printf "v%s" .Chart.AppVersion)) }}
+{{- end }}
+
+{{/*
+Name of the Secret holding JWT_SECRET / RBAC_ENCRYPTION_KEY / RBAC_ENCRYPTION_SALT.
+*/}}
+{{- define "chouse-ui.secretName" -}}
+{{- .Values.secrets.existingSecret | default (printf "%s-secrets" (include "chouse-ui.fullname" .)) }}
+{{- end }}
+
+{{/*
+Name of the Secret holding the PostgreSQL connection URL, and its key.
+*/}}
+{{- define "chouse-ui.postgresSecretName" -}}
+{{- .Values.database.postgres.existingSecret | default (printf "%s-postgres" (include "chouse-ui.fullname" .)) }}
+{{- end }}
+
+{{- define "chouse-ui.postgresSecretKey" -}}
+{{- if .Values.database.postgres.existingSecret }}
+{{- .Values.database.postgres.existingSecretKey }}
+{{- else }}
+{{- "RBAC_POSTGRES_URL" }}
+{{- end }}
+{{- end }}
+
+{{/*
+Where the rendered config.yaml is mounted inside the container.
+*/}}
+{{- define "chouse-ui.configMountPath" -}}
+/etc/chouse
+{{- end }}
+
+{{/*
+Shared environment for every chouse-ui container (web and dedicated
+scheduler). Scheduler enablement is per-workload, so it is NOT set here.
+*/}}
+{{- define "chouse-ui.env" -}}
+- name: NODE_ENV
+  value: production
+- name: RBAC_DB_TYPE
+  value: {{ .Values.database.type | quote }}
+{{- if eq .Values.database.type "sqlite" }}
+- name: RBAC_SQLITE_PATH
+  value: /app/data/rbac.db
+{{- else }}
+- name: RBAC_POSTGRES_URL
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "chouse-ui.postgresSecretName" . }}
+      key: {{ include "chouse-ui.postgresSecretKey" . }}
+- name: RBAC_POSTGRES_POOL_SIZE
+  value: {{ .Values.database.postgres.poolSize | quote }}
+{{- end }}
+- name: JWT_SECRET
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "chouse-ui.secretName" . }}
+      key: JWT_SECRET
+- name: RBAC_ENCRYPTION_KEY
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "chouse-ui.secretName" . }}
+      key: RBAC_ENCRYPTION_KEY
+- name: RBAC_ENCRYPTION_SALT
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "chouse-ui.secretName" . }}
+      key: RBAC_ENCRYPTION_SALT
+{{- if gt (int .Values.replicaCount) 1 }}
+- name: CHOUSE_HA
+  value: "true"
+{{- end }}
+{{- if .Values.config }}
+- name: CHOUSE_CONFIG_PATH
+  value: {{ include "chouse-ui.configMountPath" . }}/config.yaml
+{{- end }}
+{{- with .Values.extraEnv }}
+{{ toYaml . }}
+{{- end }}
+{{- end }}

--- a/charts/chouse-ui/templates/_helpers.tpl
+++ b/charts/chouse-ui/templates/_helpers.tpl
@@ -132,7 +132,7 @@ scheduler). Scheduler enablement is per-workload, so it is NOT set here.
     secretKeyRef:
       name: {{ include "chouse-ui.secretName" . }}
       key: RBAC_ENCRYPTION_SALT
-{{- if gt (int .Values.replicaCount) 1 }}
+{{- if or (gt (int .Values.replicaCount) 1) .Values.autoscaling.enabled }}
 - name: CHOUSE_HA
   value: "true"
 {{- end }}

--- a/charts/chouse-ui/templates/_validate.tpl
+++ b/charts/chouse-ui/templates/_validate.tpl
@@ -1,0 +1,58 @@
+{{/*
+Render-time validation. Included from deployment.yaml so every
+template/install/upgrade path runs it. Broken topologies fail here, loudly,
+instead of becoming silent duplicate jobs or per-pod databases at runtime.
+*/}}
+{{- define "chouse-ui.validate" -}}
+
+{{- if not (has .Values.database.type (list "sqlite" "postgres")) }}
+{{- fail (printf "database.type must be 'sqlite' or 'postgres', got '%s'" .Values.database.type) }}
+{{- end }}
+
+{{- if eq .Values.database.type "sqlite" }}
+{{- if gt (int .Values.replicaCount) 1 }}
+{{- fail (printf "replicaCount=%d with database.type=sqlite: SQLite cannot span pods — every replica would get its own database (separate users/settings) and every scheduler lease would be per-pod (duplicate scheduled runs and notifications). Set database.type=postgres for HA, or keep replicaCount=1." (int .Values.replicaCount)) }}
+{{- end }}
+{{- if .Values.autoscaling.enabled }}
+{{- fail "autoscaling.enabled=true with database.type=sqlite: SQLite cannot span pods. Set database.type=postgres for HA." }}
+{{- end }}
+{{- if .Values.dedicatedScheduler.enabled }}
+{{- fail "dedicatedScheduler.enabled=true with database.type=sqlite: the scheduler pod would get its own empty database and schedule nothing. Set database.type=postgres." }}
+{{- end }}
+{{- end }}
+
+{{/* Secrets: match the server's own production validation so a bad value
+     fails at render instead of as a CrashLoopBackOff. Only checked for the
+     chart-managed Secret — an existingSecret's contents are the user's own. */}}
+{{- if not .Values.secrets.existingSecret }}
+{{- $gen := "Generate with: JWT_SECRET: openssl rand -base64 32 | RBAC_ENCRYPTION_KEY: openssl rand -hex 32 | RBAC_ENCRYPTION_SALT: openssl rand -hex 32" }}
+{{- if and .Values.secrets.jwtSecret (lt (len .Values.secrets.jwtSecret) 32) }}
+{{- fail (printf "secrets.jwtSecret must be at least 32 characters (got %d). %s" (len .Values.secrets.jwtSecret) $gen) }}
+{{- end }}
+{{- if and .Values.secrets.encryptionKey (lt (len .Values.secrets.encryptionKey) 32) }}
+{{- fail (printf "secrets.encryptionKey must be at least 32 characters (got %d). %s" (len .Values.secrets.encryptionKey) $gen) }}
+{{- end }}
+{{- if and .Values.secrets.encryptionSalt (ne (len .Values.secrets.encryptionSalt) 64) }}
+{{- fail (printf "secrets.encryptionSalt must be exactly 64 characters (got %d). %s" (len .Values.secrets.encryptionSalt) $gen) }}
+{{- end }}
+{{- end }}
+
+{{/* config.yaml values override the pod environment (the server injects them
+     into process.env last), so a config key the chart also manages would
+     silently win over the chart's wiring. Refuse the ambiguity. */}}
+{{- range $key := list "port" "node_env" "static_path" "chouse" "scheduled_queries" }}
+{{- if hasKey $.Values.config $key }}
+{{- fail (printf "config.%s conflicts with chart-managed settings — remove it from `config` and use the chart values instead (config.yaml overrides the pod environment)" $key) }}
+{{- end }}
+{{- end }}
+{{- $rbac := .Values.config.rbac | default dict }}
+{{- range $key := list "db_type" "sqlite_path" "postgres_url" "postgres_pool_size" "encryption" }}
+{{- if hasKey $rbac $key }}
+{{- fail (printf "config.rbac.%s conflicts with chart-managed settings — use the chart's `database`/`secrets` values instead (config.yaml overrides the pod environment)" $key) }}
+{{- end }}
+{{- end }}
+{{- if hasKey (.Values.config.jwt | default dict) "secret" }}
+{{- fail "config.jwt.secret conflicts with chart-managed settings — use secrets.jwtSecret or secrets.existingSecret instead (config.yaml overrides the pod environment)" }}
+{{- end }}
+
+{{- end }}

--- a/charts/chouse-ui/templates/config-secret.yaml
+++ b/charts/chouse-ui/templates/config-secret.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.config }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "chouse-ui.fullname" . }}-config
+  labels:
+    {{- include "chouse-ui.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  config.yaml: |
+    {{- toYaml .Values.config | nindent 4 }}
+{{- end }}

--- a/charts/chouse-ui/templates/deployment.yaml
+++ b/charts/chouse-ui/templates/deployment.yaml
@@ -1,0 +1,129 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "chouse-ui.fullname" . }}
+  labels:
+    {{- include "chouse-ui.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  {{- if eq .Values.database.type "sqlite" }}
+  # Two pods must never share the SQLite file, even transiently mid-rollout.
+  strategy:
+    type: Recreate
+  {{- else }}
+  strategy:
+    type: RollingUpdate
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "chouse-ui.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: web
+  template:
+    metadata:
+      labels:
+        {{- include "chouse-ui.labels" . | nindent 8 }}
+        app.kubernetes.io/component: web
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/config-secret.yaml") . | sha256sum }}
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "chouse-ui.serviceAccountName" . }}
+      automountServiceAccountToken: false
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      {{- with .Values.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- with .Values.initContainers }}
+      initContainers:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: chouse-ui
+          image: {{ include "chouse-ui.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          securityContext:
+            {{- toYaml .Values.containerSecurityContext | nindent 12 }}
+          ports:
+            - name: http
+              containerPort: 5521
+              protocol: TCP
+          env:
+            {{- include "chouse-ui.env" . | nindent 12 }}
+            {{- if .Values.dedicatedScheduler.enabled }}
+            - name: SCHEDULED_QUERIES_ENABLED
+              value: "false"
+            {{- else }}
+            - name: SCHEDULED_QUERIES_ENABLED
+              value: {{ .Values.scheduledQueries.enabled | quote }}
+            {{- end }}
+          {{- with .Values.extraEnvFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          livenessProbe:
+            {{- toYaml .Values.probes.liveness | nindent 12 }}
+          readinessProbe:
+            {{- toYaml .Values.probes.readiness | nindent 12 }}
+          startupProbe:
+            {{- toYaml .Values.probes.startup | nindent 12 }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+            {{- if eq .Values.database.type "sqlite" }}
+            - name: data
+              mountPath: /app/data
+            {{- end }}
+            {{- if .Values.config }}
+            - name: config
+              mountPath: {{ include "chouse-ui.configMountPath" . }}
+              readOnly: true
+            {{- end }}
+            {{- with .Values.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+      volumes:
+        - name: tmp
+          emptyDir: {}
+        {{- if eq .Values.database.type "sqlite" }}
+        - name: data
+          {{- if .Values.database.sqlite.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.database.sqlite.persistence.existingClaim | default (printf "%s-data" (include "chouse-ui.fullname" .)) }}
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+        {{- end }}
+        {{- if .Values.config }}
+        - name: config
+          secret:
+            secretName: {{ include "chouse-ui.fullname" . }}-config
+        {{- end }}
+        {{- with .Values.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/chouse-ui/templates/deployment.yaml
+++ b/charts/chouse-ui/templates/deployment.yaml
@@ -58,6 +58,15 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           securityContext:
             {{- toYaml .Values.containerSecurityContext | nindent 12 }}
+          {{- if .Values.preStopSleepSeconds }}
+          # Endpoint removal propagates to kube-proxy asynchronously; keep
+          # accepting connections briefly so in-flight DNAT to this pod
+          # doesn't blackhole during rolling updates.
+          lifecycle:
+            preStop:
+              exec:
+                command: ["sleep", "{{ .Values.preStopSleepSeconds }}"]
+          {{- end }}
           ports:
             - name: http
               containerPort: 5521

--- a/charts/chouse-ui/templates/hpa.yaml
+++ b/charts/chouse-ui/templates/hpa.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "chouse-ui.fullname" . }}
+  labels:
+    {{- include "chouse-ui.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "chouse-ui.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- with .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ . }}
+    {{- end }}
+    {{- with .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ . }}
+    {{- end }}
+{{- end }}

--- a/charts/chouse-ui/templates/ingress.yaml
+++ b/charts/chouse-ui/templates/ingress.yaml
@@ -1,0 +1,35 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "chouse-ui.fullname" . }}
+  labels:
+    {{- include "chouse-ui.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.ingress.className }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  {{- with .Values.ingress.tls }}
+  tls:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "chouse-ui.fullname" $ }}
+                port:
+                  name: http
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/chouse-ui/templates/networkpolicy.yaml
+++ b/charts/chouse-ui/templates/networkpolicy.yaml
@@ -1,0 +1,38 @@
+{{- if .Values.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "chouse-ui.fullname" . }}
+  labels:
+    {{- include "chouse-ui.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "chouse-ui.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+    {{- if .Values.networkPolicy.restrictEgress }}
+    - Egress
+    {{- end }}
+  ingress:
+    - from:
+        - podSelector: {}
+        {{- with .Values.networkPolicy.ingressFrom }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      ports:
+        - port: 5521
+          protocol: TCP
+  {{- if .Values.networkPolicy.restrictEgress }}
+  egress:
+    # DNS
+    - ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+    {{- with .Values.networkPolicy.egressTo }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/chouse-ui/templates/pdb.yaml
+++ b/charts/chouse-ui/templates/pdb.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.pdb.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "chouse-ui.fullname" . }}
+  labels:
+    {{- include "chouse-ui.labels" . | nindent 4 }}
+spec:
+  {{- with .Values.pdb.minAvailable }}
+  minAvailable: {{ . }}
+  {{- end }}
+  {{- with .Values.pdb.maxUnavailable }}
+  maxUnavailable: {{ . }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "chouse-ui.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: web
+{{- end }}

--- a/charts/chouse-ui/templates/pvc.yaml
+++ b/charts/chouse-ui/templates/pvc.yaml
@@ -1,0 +1,24 @@
+{{- if and (eq .Values.database.type "sqlite") .Values.database.sqlite.persistence.enabled (not .Values.database.sqlite.persistence.existingClaim) }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "chouse-ui.fullname" . }}-data
+  labels:
+    {{- include "chouse-ui.labels" . | nindent 4 }}
+  annotations:
+    # Survive `helm uninstall` — this PVC holds every user, connection, and
+    # setting of the install. Delete it manually if you really mean it.
+    helm.sh/resource-policy: keep
+    {{- with .Values.database.sqlite.persistence.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  accessModes:
+    {{- toYaml .Values.database.sqlite.persistence.accessModes | nindent 4 }}
+  resources:
+    requests:
+      storage: {{ .Values.database.sqlite.persistence.size }}
+  {{- with .Values.database.sqlite.persistence.storageClass }}
+  storageClassName: {{ . }}
+  {{- end }}
+{{- end }}

--- a/charts/chouse-ui/templates/scheduler-deployment.yaml
+++ b/charts/chouse-ui/templates/scheduler-deployment.yaml
@@ -1,31 +1,31 @@
-{{- include "chouse-ui.validate" . -}}
+{{- if .Values.dedicatedScheduler.enabled }}
+{{/*
+Dedicated scheduled-queries runner: one replica with the scheduler on, while
+the web pods run with SCHEDULED_QUERIES_ENABLED=false. Correctness does not
+depend on this being a singleton (per-job leases in PostgreSQL make redundant
+ticks harmless) — it exists to keep scheduled work off the request-serving
+pods. Recreate keeps the singleton clean across upgrades.
+*/}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "chouse-ui.fullname" . }}
+  name: {{ include "chouse-ui.fullname" . }}-scheduler
   labels:
     {{- include "chouse-ui.labels" . | nindent 4 }}
+    app.kubernetes.io/component: scheduler
 spec:
-  {{- if not .Values.autoscaling.enabled }}
-  replicas: {{ .Values.replicaCount }}
-  {{- end }}
-  {{- if eq .Values.database.type "sqlite" }}
-  # Two pods must never share the SQLite file, even transiently mid-rollout.
+  replicas: 1
   strategy:
     type: Recreate
-  {{- else }}
-  strategy:
-    type: RollingUpdate
-  {{- end }}
   selector:
     matchLabels:
       {{- include "chouse-ui.selectorLabels" . | nindent 6 }}
-      app.kubernetes.io/component: web
+      app.kubernetes.io/component: scheduler
   template:
     metadata:
       labels:
         {{- include "chouse-ui.labels" . | nindent 8 }}
-        app.kubernetes.io/component: web
+        app.kubernetes.io/component: scheduler
         {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
@@ -48,12 +48,8 @@ spec:
       {{- end }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
-      {{- with .Values.initContainers }}
-      initContainers:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
       containers:
-        - name: chouse-ui
+        - name: chouse-ui-scheduler
           image: {{ include "chouse-ui.image" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           securityContext:
@@ -64,13 +60,8 @@ spec:
               protocol: TCP
           env:
             {{- include "chouse-ui.env" . | nindent 12 }}
-            {{- if .Values.dedicatedScheduler.enabled }}
             - name: SCHEDULED_QUERIES_ENABLED
-              value: "false"
-            {{- else }}
-            - name: SCHEDULED_QUERIES_ENABLED
-              value: {{ .Values.scheduledQueries.enabled | quote }}
-            {{- end }}
+              value: "true"
           {{- with .Values.extraEnvFrom }}
           envFrom:
             {{- toYaml . | nindent 12 }}
@@ -82,14 +73,14 @@ spec:
           startupProbe:
             {{- toYaml .Values.probes.startup | nindent 12 }}
           resources:
+            {{- if .Values.dedicatedScheduler.resources }}
+            {{- toYaml .Values.dedicatedScheduler.resources | nindent 12 }}
+            {{- else }}
             {{- toYaml .Values.resources | nindent 12 }}
+            {{- end }}
           volumeMounts:
             - name: tmp
               mountPath: /tmp
-            {{- if eq .Values.database.type "sqlite" }}
-            - name: data
-              mountPath: /app/data
-            {{- end }}
             {{- if .Values.config }}
             - name: config
               mountPath: {{ include "chouse-ui.configMountPath" . }}
@@ -101,15 +92,6 @@ spec:
       volumes:
         - name: tmp
           emptyDir: {}
-        {{- if eq .Values.database.type "sqlite" }}
-        - name: data
-          {{- if .Values.database.sqlite.persistence.enabled }}
-          persistentVolumeClaim:
-            claimName: {{ .Values.database.sqlite.persistence.existingClaim | default (printf "%s-data" (include "chouse-ui.fullname" .)) }}
-          {{- else }}
-          emptyDir: {}
-          {{- end }}
-        {{- end }}
         {{- if .Values.config }}
         - name: config
           secret:
@@ -130,7 +112,4 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.topologySpreadConstraints }}
-      topologySpreadConstraints:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+{{- end }}

--- a/charts/chouse-ui/templates/secret.yaml
+++ b/charts/chouse-ui/templates/secret.yaml
@@ -1,0 +1,25 @@
+{{- if not .Values.secrets.existingSecret }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "chouse-ui.fullname" . }}-secrets
+  labels:
+    {{- include "chouse-ui.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  JWT_SECRET: {{ required "secrets.jwtSecret is required (or set secrets.existingSecret)" .Values.secrets.jwtSecret | quote }}
+  RBAC_ENCRYPTION_KEY: {{ required "secrets.encryptionKey is required (or set secrets.existingSecret)" .Values.secrets.encryptionKey | quote }}
+  RBAC_ENCRYPTION_SALT: {{ required "secrets.encryptionSalt is required (or set secrets.existingSecret)" .Values.secrets.encryptionSalt | quote }}
+{{- end }}
+{{- if and (eq .Values.database.type "postgres") (not .Values.database.postgres.existingSecret) }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "chouse-ui.fullname" . }}-postgres
+  labels:
+    {{- include "chouse-ui.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  RBAC_POSTGRES_URL: {{ required "database.postgres.url is required when database.type=postgres (or set database.postgres.existingSecret)" .Values.database.postgres.url | quote }}
+{{- end }}

--- a/charts/chouse-ui/templates/service.yaml
+++ b/charts/chouse-ui/templates/service.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "chouse-ui.fullname" . }}
+  labels:
+    {{- include "chouse-ui.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "chouse-ui.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: web

--- a/charts/chouse-ui/templates/serviceaccount.yaml
+++ b/charts/chouse-ui/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "chouse-ui.serviceAccountName" . }}
+  labels:
+    {{- include "chouse-ui.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: false
+{{- end }}

--- a/charts/chouse-ui/templates/tests/test-connection.yaml
+++ b/charts/chouse-ui/templates/tests/test-connection.yaml
@@ -1,0 +1,33 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: {{ include "chouse-ui.fullname" . }}-test-connection
+  labels:
+    {{- include "chouse-ui.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/hook: test
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+spec:
+  restartPolicy: Never
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 65534
+    seccompProfile:
+      type: RuntimeDefault
+  containers:
+    - name: probe
+      image: curlimages/curl:8.14.1
+      securityContext:
+        allowPrivilegeEscalation: false
+        readOnlyRootFilesystem: true
+        capabilities:
+          drop:
+            - ALL
+      command:
+        - sh
+        - -ec
+        # /api/health proves the server is up; /api/rbac/health proves the
+        # RBAC database is reachable and migrated (503 otherwise).
+        - |
+          curl -fsS "http://{{ include "chouse-ui.fullname" . }}:{{ .Values.service.port }}/api/health"
+          curl -fsS "http://{{ include "chouse-ui.fullname" . }}:{{ .Values.service.port }}/api/rbac/health"

--- a/charts/chouse-ui/templates/tests/test-connection.yaml
+++ b/charts/chouse-ui/templates/tests/test-connection.yaml
@@ -28,6 +28,12 @@ spec:
         - -ec
         # /api/health proves the server is up; /api/rbac/health proves the
         # RBAC database is reachable and migrated (503 otherwise).
+        # --connect-timeout + --retry: a test run right after an upgrade can
+        # race endpoint propagation — a fresh connection per retry re-rolls
+        # the DNAT instead of hanging on a conntrack entry pinned to a
+        # terminated pod.
         - |
-          curl -fsS "http://{{ include "chouse-ui.fullname" . }}:{{ .Values.service.port }}/api/health"
-          curl -fsS "http://{{ include "chouse-ui.fullname" . }}:{{ .Values.service.port }}/api/rbac/health"
+          curl -fsS --connect-timeout 5 --retry 8 --retry-delay 2 --retry-all-errors \
+            "http://{{ include "chouse-ui.fullname" . }}:{{ .Values.service.port }}/api/health"
+          curl -fsS --connect-timeout 5 --retry 8 --retry-delay 2 --retry-all-errors \
+            "http://{{ include "chouse-ui.fullname" . }}:{{ .Values.service.port }}/api/rbac/health"

--- a/charts/chouse-ui/tests/deployment_test.yaml
+++ b/charts/chouse-ui/tests/deployment_test.yaml
@@ -1,0 +1,126 @@
+suite: web deployment topology
+templates:
+  - deployment.yaml
+  # referenced by checksum annotations — loaded, not asserted
+  - config-secret.yaml
+  - secret.yaml
+tests:
+  - it: sqlite default uses Recreate, a PVC, and no CHOUSE_HA
+    template: deployment.yaml
+    set:
+      secrets.existingSecret: s
+    asserts:
+      - equal:
+          path: spec.strategy.type
+          value: Recreate
+      - equal:
+          path: spec.replicas
+          value: 1
+      - equal:
+          path: spec.template.spec.volumes[1].persistentVolumeClaim.claimName
+          value: RELEASE-NAME-chouse-ui-data
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: CHOUSE_HA
+            value: "true"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: RBAC_DB_TYPE
+            value: sqlite
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SCHEDULED_QUERIES_ENABLED
+            value: "true"
+
+  - it: postgres HA uses RollingUpdate, CHOUSE_HA, and secret-backed URL
+    template: deployment.yaml
+    set:
+      secrets.existingSecret: s
+      database.type: postgres
+      database.postgres.existingSecret: pg
+      database.postgres.existingSecretKey: DATABASE_URL
+      replicaCount: 3
+    asserts:
+      - equal:
+          path: spec.strategy.type
+          value: RollingUpdate
+      - equal:
+          path: spec.replicas
+          value: 3
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: CHOUSE_HA
+            value: "true"
+      - equal:
+          path: spec.template.spec.containers[0].env[2].valueFrom.secretKeyRef.name
+          value: pg
+      - equal:
+          path: spec.template.spec.containers[0].env[2].valueFrom.secretKeyRef.key
+          value: DATABASE_URL
+      - notContains:
+          path: spec.template.spec.volumes
+          content:
+            name: data
+
+  - it: autoscaling omits replicas and still sets CHOUSE_HA at replicaCount=1
+    template: deployment.yaml
+    set:
+      secrets.existingSecret: s
+      database.type: postgres
+      database.postgres.existingSecret: pg
+      replicaCount: 1
+      autoscaling.enabled: true
+    asserts:
+      - notExists:
+          path: spec.replicas
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: CHOUSE_HA
+            value: "true"
+
+  - it: dedicated scheduler turns the web scheduler off
+    template: deployment.yaml
+    set:
+      secrets.existingSecret: s
+      database.type: postgres
+      database.postgres.existingSecret: pg
+      dedicatedScheduler.enabled: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SCHEDULED_QUERIES_ENABLED
+            value: "false"
+
+  - it: config block mounts config.yaml and sets CHOUSE_CONFIG_PATH
+    template: deployment.yaml
+    set:
+      secrets.existingSecret: s
+      config:
+        log_level: debug
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: CHOUSE_CONFIG_PATH
+            value: /etc/chouse/config.yaml
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: config
+            mountPath: /etc/chouse
+            readOnly: true
+
+  - it: image tag defaults to v<appVersion>
+    template: deployment.yaml
+    set:
+      secrets.existingSecret: s
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].image
+          pattern: ^ghcr\.io/daun-gatal/chouse-ui:v\d+\.\d+\.\d+$

--- a/charts/chouse-ui/tests/deployment_test.yaml
+++ b/charts/chouse-ui/tests/deployment_test.yaml
@@ -116,6 +116,24 @@ tests:
             mountPath: /etc/chouse
             readOnly: true
 
+  - it: preStop drain sleep is on by default and removable
+    template: deployment.yaml
+    set:
+      secrets.existingSecret: s
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].lifecycle.preStop.exec.command
+          value: ["sleep", "5"]
+
+  - it: preStopSleepSeconds 0 removes the lifecycle hook
+    template: deployment.yaml
+    set:
+      secrets.existingSecret: s
+      preStopSleepSeconds: 0
+    asserts:
+      - notExists:
+          path: spec.template.spec.containers[0].lifecycle
+
   - it: image tag defaults to v<appVersion>
     template: deployment.yaml
     set:

--- a/charts/chouse-ui/tests/scheduler_test.yaml
+++ b/charts/chouse-ui/tests/scheduler_test.yaml
@@ -1,0 +1,39 @@
+suite: dedicated scheduler deployment
+templates:
+  - scheduler-deployment.yaml
+  # referenced by checksum annotations — loaded, not asserted
+  - config-secret.yaml
+  - secret.yaml
+tests:
+  - it: renders nothing by default
+    template: scheduler-deployment.yaml
+    set:
+      secrets.existingSecret: s
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders a singleton with the scheduler enabled
+    template: scheduler-deployment.yaml
+    set:
+      secrets.existingSecret: s
+      database.type: postgres
+      database.postgres.existingSecret: pg
+      dedicatedScheduler.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.replicas
+          value: 1
+      - equal:
+          path: spec.strategy.type
+          value: Recreate
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SCHEDULED_QUERIES_ENABLED
+            value: "true"
+      - equal:
+          path: spec.template.metadata.labels["app.kubernetes.io/component"]
+          value: scheduler

--- a/charts/chouse-ui/tests/secrets_test.yaml
+++ b/charts/chouse-ui/tests/secrets_test.yaml
@@ -1,0 +1,48 @@
+suite: secret rendering
+templates:
+  - secret.yaml
+tests:
+  - it: renders no Secret when existingSecret is set (sqlite)
+    set:
+      secrets.existingSecret: s
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders the app Secret from inline values
+    set:
+      secrets.jwtSecret: "0123456789012345678901234567890123456789"
+      secrets.encryptionKey: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      secrets.encryptionSalt: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: stringData.RBAC_ENCRYPTION_SALT
+          value: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+
+  - it: fails loudly when inline secrets are missing
+    asserts:
+      - failedTemplate:
+          errorPattern: secrets.jwtSecret is required
+
+  - it: renders a postgres Secret only for an inline URL
+    set:
+      secrets.existingSecret: s
+      database.type: postgres
+      database.postgres.url: "postgres://u:p@h:5432/db"
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: stringData.RBAC_POSTGRES_URL
+          value: "postgres://u:p@h:5432/db"
+
+  - it: renders no postgres Secret with an existingSecret
+    set:
+      secrets.existingSecret: s
+      database.type: postgres
+      database.postgres.existingSecret: pg
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/charts/chouse-ui/tests/validation_test.yaml
+++ b/charts/chouse-ui/tests/validation_test.yaml
@@ -1,0 +1,74 @@
+suite: render-time topology guards
+templates:
+  - deployment.yaml
+  # referenced by checksum annotations — loaded, not asserted
+  - config-secret.yaml
+  - secret.yaml
+tests:
+  - it: refuses sqlite with more than one replica
+    template: deployment.yaml
+    set:
+      secrets.existingSecret: s
+      replicaCount: 3
+    asserts:
+      - failedTemplate:
+          errorPattern: SQLite cannot span pods
+
+  - it: refuses sqlite with autoscaling
+    template: deployment.yaml
+    set:
+      secrets.existingSecret: s
+      autoscaling.enabled: true
+    asserts:
+      - failedTemplate:
+          errorPattern: SQLite cannot span pods
+
+  - it: refuses sqlite with a dedicated scheduler
+    template: deployment.yaml
+    set:
+      secrets.existingSecret: s
+      dedicatedScheduler.enabled: true
+    asserts:
+      - failedTemplate:
+          errorPattern: dedicatedScheduler.enabled=true with database.type=sqlite
+
+  - it: refuses an unknown database type (values.schema.json fires first)
+    template: deployment.yaml
+    set:
+      secrets.existingSecret: s
+      database.type: mysql
+    asserts:
+      - failedTemplate:
+          errorPattern: must be one of 'sqlite', 'postgres'
+
+  - it: refuses chart-managed keys inside config
+    template: deployment.yaml
+    set:
+      secrets.existingSecret: s
+      config:
+        rbac:
+          db_type: postgres
+    asserts:
+      - failedTemplate:
+          errorPattern: config\.rbac\.db_type conflicts with chart-managed settings
+
+  - it: refuses a jwt secret inside config
+    template: deployment.yaml
+    set:
+      secrets.existingSecret: s
+      config:
+        jwt:
+          secret: something
+    asserts:
+      - failedTemplate:
+          errorPattern: config\.jwt\.secret conflicts
+
+  - it: refuses a short inline salt
+    template: deployment.yaml
+    set:
+      secrets.jwtSecret: "0123456789012345678901234567890123456789"
+      secrets.encryptionKey: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      secrets.encryptionSalt: "too-short"
+    asserts:
+      - failedTemplate:
+          errorPattern: secrets.encryptionSalt must be exactly 64 characters

--- a/charts/chouse-ui/values.schema.json
+++ b/charts/chouse-ui/values.schema.json
@@ -1,0 +1,175 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "title": "chouse-ui values",
+  "type": "object",
+  "properties": {
+    "replicaCount": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "image": {
+      "type": "object",
+      "properties": {
+        "repository": { "type": "string", "minLength": 1 },
+        "tag": { "type": "string" },
+        "pullPolicy": { "enum": ["Always", "IfNotPresent", "Never"] }
+      },
+      "additionalProperties": false
+    },
+    "imagePullSecrets": { "type": "array" },
+    "nameOverride": { "type": "string" },
+    "fullnameOverride": { "type": "string" },
+    "database": {
+      "type": "object",
+      "properties": {
+        "type": { "enum": ["sqlite", "postgres"] },
+        "sqlite": {
+          "type": "object",
+          "properties": {
+            "persistence": {
+              "type": "object",
+              "properties": {
+                "enabled": { "type": "boolean" },
+                "size": { "type": "string", "minLength": 1 },
+                "storageClass": { "type": "string" },
+                "existingClaim": { "type": "string" },
+                "accessModes": {
+                  "type": "array",
+                  "items": { "type": "string" },
+                  "minItems": 1
+                },
+                "annotations": { "type": "object" }
+              },
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        },
+        "postgres": {
+          "type": "object",
+          "properties": {
+            "url": { "type": "string" },
+            "existingSecret": { "type": "string" },
+            "existingSecretKey": { "type": "string", "minLength": 1 },
+            "poolSize": { "type": "integer", "minimum": 1 }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "secrets": {
+      "type": "object",
+      "properties": {
+        "existingSecret": { "type": "string" },
+        "jwtSecret": { "type": "string" },
+        "encryptionKey": { "type": "string" },
+        "encryptionSalt": { "type": "string" }
+      },
+      "additionalProperties": false
+    },
+    "config": { "type": "object" },
+    "extraEnv": { "type": "array" },
+    "extraEnvFrom": { "type": "array" },
+    "scheduledQueries": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" }
+      },
+      "additionalProperties": false
+    },
+    "dedicatedScheduler": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "resources": { "type": "object" }
+      },
+      "additionalProperties": false
+    },
+    "service": {
+      "type": "object",
+      "properties": {
+        "type": { "enum": ["ClusterIP", "NodePort", "LoadBalancer"] },
+        "port": { "type": "integer", "minimum": 1, "maximum": 65535 },
+        "annotations": { "type": "object" }
+      },
+      "additionalProperties": false
+    },
+    "ingress": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "className": { "type": "string" },
+        "annotations": { "type": "object" },
+        "hosts": { "type": "array" },
+        "tls": { "type": "array" }
+      },
+      "additionalProperties": false
+    },
+    "networkPolicy": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "ingressFrom": { "type": "array" },
+        "restrictEgress": { "type": "boolean" },
+        "egressTo": { "type": "array" }
+      },
+      "additionalProperties": false
+    },
+    "serviceAccount": {
+      "type": "object",
+      "properties": {
+        "create": { "type": "boolean" },
+        "annotations": { "type": "object" },
+        "name": { "type": "string" }
+      },
+      "additionalProperties": false
+    },
+    "podAnnotations": { "type": "object" },
+    "podLabels": { "type": "object" },
+    "commonLabels": { "type": "object" },
+    "podSecurityContext": { "type": "object" },
+    "containerSecurityContext": { "type": "object" },
+    "resources": { "type": "object" },
+    "probes": {
+      "type": "object",
+      "properties": {
+        "liveness": { "type": "object" },
+        "readiness": { "type": "object" },
+        "startup": { "type": "object" }
+      },
+      "additionalProperties": false
+    },
+    "terminationGracePeriodSeconds": { "type": "integer", "minimum": 0 },
+    "autoscaling": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "minReplicas": { "type": "integer", "minimum": 1 },
+        "maxReplicas": { "type": "integer", "minimum": 1 },
+        "targetCPUUtilizationPercentage": { "type": ["integer", "string"] },
+        "targetMemoryUtilizationPercentage": { "type": ["integer", "string"] }
+      },
+      "additionalProperties": false
+    },
+    "pdb": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "minAvailable": { "type": ["integer", "string"] },
+        "maxUnavailable": { "type": ["integer", "string"] }
+      },
+      "additionalProperties": false
+    },
+    "topologySpreadConstraints": { "type": "array" },
+    "nodeSelector": { "type": "object" },
+    "tolerations": { "type": "array" },
+    "affinity": { "type": "object" },
+    "priorityClassName": { "type": "string" },
+    "initContainers": { "type": "array" },
+    "extraVolumes": { "type": "array" },
+    "extraVolumeMounts": { "type": "array" },
+    "global": { "type": "object" }
+  },
+  "additionalProperties": false
+}

--- a/charts/chouse-ui/values.schema.json
+++ b/charts/chouse-ui/values.schema.json
@@ -141,6 +141,7 @@
       "additionalProperties": false
     },
     "terminationGracePeriodSeconds": { "type": "integer", "minimum": 0 },
+    "preStopSleepSeconds": { "type": "integer", "minimum": 0 },
     "autoscaling": {
       "type": "object",
       "properties": {

--- a/charts/chouse-ui/values.yaml
+++ b/charts/chouse-ui/values.yaml
@@ -114,6 +114,41 @@ service:
   # -- Extra annotations for the Service.
   annotations: {}
 
+ingress:
+  # -- Expose the UI through an Ingress.
+  enabled: false
+  # -- IngressClass name.
+  className: ""
+  # -- Ingress annotations. Two matter operationally: AI chat streams over
+  # SSE, so raise the proxy read timeout (nginx:
+  # `nginx.ingress.kubernetes.io/proxy-read-timeout: "300"`) and disable
+  # buffering (`nginx.ingress.kubernetes.io/proxy-buffering: "off"`); and
+  # login rate limiting keys on X-Forwarded-For, so the ingress must
+  # overwrite it with the real client IP.
+  annotations: {}
+  hosts:
+    - host: chouse-ui.local
+      paths:
+        - path: /
+          pathType: Prefix
+  # -- TLS configuration.
+  tls: []
+
+networkPolicy:
+  # -- Create a NetworkPolicy for the pods.
+  enabled: false
+  # -- Extra `from` peers allowed to reach the pods on the app port (in
+  # addition to same-namespace pods). Use this to admit your ingress
+  # controller's namespace.
+  ingressFrom: []
+  # -- Restrict egress. When true, only DNS plus `egressTo` are allowed —
+  # list your ClickHouse hosts, PostgreSQL, IdP, SMTP, and AI provider
+  # endpoints there. When false, all egress is allowed.
+  restrictEgress: false
+  # -- Extra egress rules (full NetworkPolicyEgressRule objects) applied when
+  # `restrictEgress` is true.
+  egressTo: []
+
 serviceAccount:
   # -- Create a ServiceAccount for the pods.
   create: true

--- a/charts/chouse-ui/values.yaml
+++ b/charts/chouse-ui/values.yaml
@@ -1,0 +1,204 @@
+# Default values for chouse-ui.
+#
+# The app itself is configured through the freeform `config:` block (rendered
+# to a config.yaml the server loads via CHOUSE_CONFIG_PATH). Only values that
+# shape the Kubernetes deployment are first-class here.
+
+# -- Number of web pods. Must be 1 when `database.type` is `sqlite` (the chart
+# refuses to render otherwise). When >1, the chart sets `CHOUSE_HA=true` on the
+# pods automatically.
+replicaCount: 1
+
+image:
+  # -- Container image repository.
+  repository: ghcr.io/daun-gatal/chouse-ui
+  # -- Image tag. Defaults to `v<Chart.appVersion>`.
+  tag: ""
+  # -- Image pull policy.
+  pullPolicy: IfNotPresent
+
+# -- Secrets for pulling the image from a private registry.
+imagePullSecrets: []
+
+# -- Override the chart name.
+nameOverride: ""
+# -- Override the fully qualified release name.
+fullnameOverride: ""
+
+database:
+  # -- RBAC database backend: `sqlite` (single replica + PVC) or `postgres`
+  # (external PostgreSQL; required for HA / more than one replica).
+  type: sqlite
+
+  sqlite:
+    persistence:
+      # -- Persist the SQLite database (`/app/data`) on a PVC. Disabling this
+      # loses all users, connections, and settings on every pod restart —
+      # only do it for throwaway installs.
+      enabled: true
+      # -- PVC size.
+      size: 1Gi
+      # -- StorageClass. Empty string uses the cluster default.
+      storageClass: ""
+      # -- Use a pre-created PVC instead of chart-managed one.
+      existingClaim: ""
+      # -- PVC access modes.
+      accessModes:
+        - ReadWriteOnce
+      # -- Extra annotations for the PVC (e.g. to keep it on helm uninstall).
+      annotations: {}
+
+  postgres:
+    # -- Full PostgreSQL connection URL
+    # (`postgres://user:pass@host:5432/dbname`). Stored in a chart-managed
+    # Secret. Prefer `existingSecret` so the URL never lands in values files.
+    url: ""
+    # -- Name of an existing Secret holding the connection URL.
+    existingSecret: ""
+    # -- Key inside `existingSecret` that holds the URL.
+    existingSecretKey: RBAC_POSTGRES_URL
+    # -- Connection pool size per pod.
+    poolSize: 10
+
+secrets:
+  # -- Name of an existing Secret with keys `JWT_SECRET`,
+  # `RBAC_ENCRYPTION_KEY`, and `RBAC_ENCRYPTION_SALT` (recommended). When
+  # empty, the three inline values below are required and rendered into a
+  # chart-managed Secret. The chart never auto-generates these: the encryption
+  # key/salt protect stored ClickHouse passwords, and a regenerated key makes
+  # them unrecoverable.
+  existingSecret: ""
+  # -- JWT signing secret, min 32 chars. Generate: `openssl rand -base64 32`.
+  jwtSecret: ""
+  # -- AES-256 key for stored connection passwords, 64 hex chars.
+  # Generate: `openssl rand -hex 32`.
+  encryptionKey: ""
+  # -- Key-derivation salt, exactly 64 hex chars. Generate: `openssl rand -hex 32`.
+  encryptionSalt: ""
+
+# -- Freeform CHouse UI configuration, rendered to a Secret-mounted
+# `config.yaml` (see `.config.example.yaml` in the repo for the full schema:
+# SSO, fleet poller, AI doctor, admin seeding, CORS, log level, ...). Do NOT
+# set keys the chart already manages (`port`, `node_env`, `static_path`,
+# `rbac.db_type`, `rbac.sqlite_path`, `rbac.postgres_url`, `rbac.encryption`,
+# `jwt.secret`, `scheduled_queries`) — the chart refuses to render if you do,
+# because config.yaml values override the pod environment.
+config: {}
+
+# -- Extra environment variables for the web pods (list of EnvVar). Useful for
+# referencing SSO client secrets from Secrets via `valueFrom`.
+extraEnv: []
+
+# -- Extra `envFrom` sources (ConfigMap/Secret refs) for the web pods.
+extraEnvFrom: []
+
+scheduledQueries:
+  # -- Run the in-process scheduled-queries scheduler on the web pods.
+  # Redundant ticks across pods are harmless (per-job atomic lease on
+  # PostgreSQL). Ignored (forced off on web pods) when
+  # `dedicatedScheduler.enabled` is true.
+  enabled: true
+
+dedicatedScheduler:
+  # -- Run the scheduled-queries scheduler on a dedicated single-replica
+  # Deployment instead of the web pods. Requires `database.type: postgres`.
+  enabled: false
+  # -- Resources for the scheduler pod.
+  resources: {}
+
+service:
+  # -- Service type.
+  type: ClusterIP
+  # -- Service port (targets the fixed container port 5521).
+  port: 80
+  # -- Extra annotations for the Service.
+  annotations: {}
+
+serviceAccount:
+  # -- Create a ServiceAccount for the pods.
+  create: true
+  # -- Annotations for the ServiceAccount.
+  annotations: {}
+  # -- ServiceAccount name override.
+  name: ""
+
+# -- Extra annotations for the pods.
+podAnnotations: {}
+# -- Extra labels for the pods.
+podLabels: {}
+# -- Labels added to every rendered resource.
+commonLabels: {}
+
+# -- Pod security context. The image runs as uid/gid 1001; `fsGroup` makes the
+# SQLite PVC writable.
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 1001
+  runAsGroup: 1001
+  fsGroup: 1001
+  seccompProfile:
+    type: RuntimeDefault
+
+# -- Container security context. The root filesystem is read-only; the chart
+# mounts an emptyDir on `/tmp`.
+containerSecurityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop:
+      - ALL
+
+resources:
+  requests:
+    cpu: 250m
+    memory: 256Mi
+  limits:
+    memory: 1Gi
+
+probes:
+  # -- Liveness probe — dependency-free endpoint.
+  liveness:
+    httpGet:
+      path: /api/health
+      port: http
+    periodSeconds: 20
+    timeoutSeconds: 5
+    failureThreshold: 3
+  # -- Readiness probe — 503 until the RBAC database is healthy and
+  # migrations have applied.
+  readiness:
+    httpGet:
+      path: /api/rbac/health
+      port: http
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 3
+  # -- Startup probe — generous budget (5 min) so long upgrade migrations
+  # don't get the pod killed.
+  startup:
+    httpGet:
+      path: /api/rbac/health
+      port: http
+    periodSeconds: 5
+    timeoutSeconds: 5
+    failureThreshold: 60
+
+# -- Grace period so the SIGTERM handler can release poller leases and drain
+# scheduled-query slots.
+terminationGracePeriodSeconds: 60
+
+# -- Node selector for all pods.
+nodeSelector: {}
+# -- Tolerations for all pods.
+tolerations: []
+# -- Affinity for all pods.
+affinity: {}
+# -- Priority class for all pods.
+priorityClassName: ""
+
+# -- Extra init containers for the web pods.
+initContainers: []
+# -- Extra volumes for the web pods.
+extraVolumes: []
+# -- Extra volume mounts for the web container.
+extraVolumeMounts: []

--- a/charts/chouse-ui/values.yaml
+++ b/charts/chouse-ui/values.yaml
@@ -187,6 +187,33 @@ probes:
 # scheduled-query slots.
 terminationGracePeriodSeconds: 60
 
+autoscaling:
+  # -- Horizontal pod autoscaling for the web pods. Requires
+  # `database.type: postgres` (render fails on sqlite). Implies
+  # `CHOUSE_HA=true` regardless of `replicaCount`.
+  enabled: false
+  minReplicas: 2
+  maxReplicas: 5
+  # -- Target average CPU utilization (percent).
+  targetCPUUtilizationPercentage: 80
+  # -- Target average memory utilization (percent). Empty disables the
+  # memory metric.
+  targetMemoryUtilizationPercentage: ""
+
+pdb:
+  # -- PodDisruptionBudget for the web pods. Only meaningful with more than
+  # one replica.
+  enabled: false
+  # -- Minimum pods that must stay available. Mutually exclusive with
+  # `maxUnavailable`.
+  minAvailable: 1
+  # -- Maximum pods that may be unavailable. Set `minAvailable` to "" when
+  # using this.
+  maxUnavailable: ""
+
+# -- Topology spread constraints for the web pods (postgres/HA installs).
+topologySpreadConstraints: []
+
 # -- Node selector for all pods.
 nodeSelector: {}
 # -- Tolerations for all pods.

--- a/charts/chouse-ui/values.yaml
+++ b/charts/chouse-ui/values.yaml
@@ -222,6 +222,13 @@ probes:
 # scheduled-query slots.
 terminationGracePeriodSeconds: 60
 
+# -- Seconds the web container keeps serving after Kubernetes starts
+# terminating it (preStop sleep). Endpoint removal reaches kube-proxy
+# asynchronously; without this, connections routed to a terminating pod
+# during a rolling update can hang. Set to 0 to disable. Applies to web pods
+# only (the scheduler receives no Service traffic).
+preStopSleepSeconds: 5
+
 autoscaling:
   # -- Horizontal pod autoscaling for the web pods. Requires
   # `database.type: postgres` (render fails on sqlite). Implies

--- a/docs/adr/0008-helm-chart-and-oci-distribution.md
+++ b/docs/adr/0008-helm-chart-and-oci-distribution.md
@@ -1,0 +1,181 @@
+# 0008 — Production Helm Chart and OCI Distribution
+
+- **Status:** Accepted
+- **Date:** 2026-07-30
+- **Implementation:** same PR as this ADR (deliberate deviation from the usual
+  two-PR flow — the chart is additive and touches no application code, so the
+  spec and its implementation are reviewed together)
+
+## Context
+
+CHouse UI ships as a single container image (`ghcr.io/daun-gatal/chouse-ui`,
+multi-arch, published by `auto-release.yml`), but the repo offers no supported
+path onto Kubernetes: the only manifest in-tree deploys the marketing site, and
+users hand-roll Deployments against an app whose topology rules are non-obvious
+and easy to get wrong:
+
+- **Two persistence modes.** RBAC state lives in SQLite (default,
+  `/app/data/rbac.db`) or external PostgreSQL (`RBAC_POSTGRES_URL`). SQLite
+  cannot span pods — every HA mechanism in the server (fleet-poller lease,
+  scheduled-query per-job leases, DB-backed login rate limits) assumes a
+  *shared* database. The server only logs an error for the broken
+  SQLite-multi-replica combination; it does not refuse to start.
+- **`CHOUSE_HA=true` is a chart contract.** `.env.example` and ADRs 0001/0002
+  explicitly reserve this env var for "the Helm chart sets it when
+  `replicas > 1`". Nothing sets it today.
+- **Production hard-fails without three secrets** (`JWT_SECRET` ≥ 32 chars,
+  `RBAC_ENCRYPTION_KEY` ≥ 32 chars, `RBAC_ENCRYPTION_SALT` exactly 64 hex
+  chars). `RBAC_ENCRYPTION_KEY`/`SALT` protect stored ClickHouse connection
+  passwords — losing them is unrecoverable data loss.
+- **Health endpoints are already probe-shaped**: `/api/health` is
+  dependency-free; `/api/rbac/health` returns 503 until the RBAC DB is healthy
+  and migrations have applied (the server listens before RBAC init completes,
+  so readiness on this endpoint correctly gates traffic during migrations).
+  On PostgreSQL, boot-time migrations are serialized with `pg_advisory_lock`,
+  so concurrent replica startup is safe.
+- **Config is env vars or one YAML file** (`CHOUSE_CONFIG_PATH` → flattened
+  into env by `configLoader.ts`), which a chart can exploit to avoid
+  per-feature template sprawl.
+- Operational sharp edges a chart must document or absorb: login rate limiting
+  keys on `X-Forwarded-For` (ingress must overwrite it), AI chat uses
+  long-lived SSE (default nginx-ingress 60s read timeout kills it), SSO needs
+  the public base URL, and migrations 1.36/1.37 import legacy JSON files from
+  `/app/data` exactly once.
+
+We also want the chart distributed from the same place as the image, with the
+same release ergonomics as the existing fragment-driven, approval-gated
+`auto-release.yml` pipeline — and without introducing external services
+(ArtifactHub, dedicated chart hosting) to operate.
+
+## Decision
+
+### One chart, `charts/chouse-ui/`, distributed as an OCI artifact on GHCR
+
+`helm install chouse-ui oci://ghcr.io/daun-gatal/charts/chouse-ui --version <v>`.
+No GitHub Pages Helm repo, no `index.yaml`, no ArtifactHub. Charts are pushed
+signed (cosign keyless via GitHub OIDC) to the same registry namespace as the
+app image. One one-time manual step after the first publish: set the
+`charts/chouse-ui` GHCR package public and link it to the repo.
+
+### Two topologies, enforced at render time
+
+| | `database.type: sqlite` (default) | `database.type: postgres` |
+|---|---|---|
+| Replicas | exactly 1 (render **fails** if >1) | any; `CHOUSE_HA=true` injected when >1 |
+| Storage | PVC at `/app/data`, `fsGroup: 1001` | none (stateless pods) |
+| Strategy | `Recreate` | `RollingUpdate` |
+| HPA / topologySpread | render fails / n.a. | allowed |
+
+Failing the render is deliberate: the server's own runtime warning for
+SQLite-multi-replica is easy to miss, and the resulting duplicate scheduled-job
+runs and per-pod user databases are silent data corruption from the operator's
+point of view.
+
+### Secrets are never auto-generated
+
+`JWT_SECRET`, `RBAC_ENCRYPTION_KEY`, `RBAC_ENCRYPTION_SALT` come from
+`secrets.existingSecret` (recommended) or inline values; if absent, render
+fails with the `openssl rand` generation commands in the error message. A
+`lookup`-based auto-generate was rejected: silently minting the encryption key
+that protects stored ClickHouse passwords turns a `helm uninstall`/reinstall
+into unrecoverable loss of every stored connection credential.
+
+### App config flows through one rendered YAML
+
+A freeform `config:` values block renders into a Secret mounted at
+`/etc/chouse/config.yaml` with `CHOUSE_CONFIG_PATH` pointing at it, riding the
+existing config loader. SSO, fleet poller, doctor, admin seeding, CORS — all
+express as values under `config:` without dedicated templates.
+`extraEnv`/`extraEnvFrom` cover secret interpolation (e.g. SSO client
+secrets). The chart renders this into a Secret (not a ConfigMap) because the
+block routinely carries credentials.
+
+### Probes and lifecycle
+
+Liveness `GET /api/health`; readiness **and** startup `GET /api/rbac/health`
+(startup probe with generous `failureThreshold` to absorb long upgrade
+migrations); `terminationGracePeriodSeconds: 60` so the SIGTERM handler can
+release poller leases and drain scheduled-query slots.
+
+### Security defaults on
+
+`runAsNonRoot` uid/gid 1001, seccomp `RuntimeDefault`, all capabilities
+dropped, `readOnlyRootFilesystem: true` with an `emptyDir` on `/tmp`.
+
+### Optional dedicated scheduler
+
+`dedicatedScheduler.enabled` (postgres mode only) adds a 1-replica Deployment
+with `SCHEDULED_QUERIES_ENABLED=true` while web pods get `false` — the exact
+split `.env.example` describes.
+
+### Non-goals
+
+- No bundled PostgreSQL or ClickHouse subcharts. Operators bring their own
+  (CloudNativePG / managed Postgres; Altinity or ClickHouse operator).
+  Bundled-DB subcharts are a maintenance liability and contradict the README's
+  own "external HA PostgreSQL" guidance.
+- No ServiceMonitor — the app exposes no Prometheus endpoint today.
+
+### CI: validation on PR, publishing on release — one implementation
+
+- **`helm.yml` (PR gate):** `helm lint`, kubeconform against pinned K8s
+  versions, helm-unittest for the guard/wiring logic, chart-testing installs
+  on kind (SQLite default + HA-Postgres values), upgrade-from-latest-release
+  test, `helm-docs --validate`, and a **chart-version-bump guard** (chart
+  changes cannot merge without bumping `Chart.yaml` `version`).
+- **Composite action `.github/actions/helm-publish`:** immutability guard
+  (a published chart version is never overwritten; re-runs no-op when digests
+  match), `helm package` + `helm push`, cosign keyless sign, pull-and-render
+  smoke check, step summary.
+- **`auto-release.yml` (primary path):** during `assemble`, `Chart.yaml`
+  `appVersion` is synced to the new app version and the chart `version` patch
+  is bumped *only if* the current chart version is already published (a
+  pending manual bump is respected, never double-bumped). A new `helm` job
+  runs after `docker` (image must exist before the chart referencing it),
+  reuses the existing `docker-publish` environment gate, and publishes via the
+  composite action. The release announcement gains a `helm install` snippet.
+  The `helm` job is additive — `docker`/`publish` do not depend on it, so its
+  failure cannot break an app release.
+- **`helm-release.yml` (chart-only path):** `workflow_dispatch` from `main`
+  with `dry_run` and `prerelease` (`<version>-pre` tag, previous `-pre`
+  cleaned up) inputs, gated by a `helm-publish` environment, version read from
+  `Chart.yaml` (the merged PR already declared it), finished with a
+  `chart-v<version>` git tag.
+
+### Versioning
+
+Chart `version` is its own semver, bumped manually in the PR that changes the
+chart (breaking values changes = major). `appVersion` is owned by
+`auto-release.yml` and never edited by hand. `image.tag` defaults to
+`v{{ .Chart.AppVersion }}`.
+
+## Consequences
+
+**Easier:** supported one-command Kubernetes install; broken topologies caught
+at render time instead of as silent duplicate jobs; chart freshness guaranteed
+by riding the app release train; agents know when to touch the chart via
+`.rules/HELM_CHART.md`.
+
+**Accepted costs:** chart maintenance is coupled to config-surface changes
+(every new env var / config key is a chart PR too — enforced by rules + CI);
+kind-based CI adds minutes to PRs touching `charts/**`; `auto-release.yml`
+gains one step and one job in a live pipeline (mitigated by the additive
+design and a post-merge dry-run dispatch); Helm 3.8+ is required of users
+(OCI support).
+
+## Alternatives considered
+
+- **ArtifactHub + GitHub Pages Helm repo (chart-releaser):** more
+  discoverability, but adds a `gh-pages` publishing branch, an external
+  service to claim/maintain, and a second index to keep consistent. GHCR OCI
+  reuses infrastructure the project already operates. Revisitable later —
+  ArtifactHub can index an OCI repo without changing this design.
+- **StatefulSet for SQLite mode:** semantically "stateful", but a
+  single-replica Deployment with `Recreate` + PVC has identical behaviour with
+  less machinery; volumeClaimTemplates only pay off at >1 replica, which
+  SQLite forbids anyway.
+- **Auto-generated secrets via `lookup`:** rejected (data-loss trap, see
+  Decision).
+- **Bundled Postgres subchart:** rejected (see Non-goals).
+- **Raw manifests / Kustomize in-repo:** no values validation, no render-time
+  guards, no versioned distribution — the guard rails are the point.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -32,6 +32,7 @@ We use a lightweight [MADR](https://adr.github.io/madr/)-style template:
 | [0005](0005-unified-first-install-onboarding.md) | Unified first-install and product onboarding | Accepted |
 | [0006](0006-event-triggered-data-health.md) | Event-triggered Data Health (pipeline-chained promises) | Accepted |
 | [0007](0007-clear-and-rerun-for-scheduled-jobs-and-data-health.md) | Clear & Rerun for Scheduled Jobs and Data Health | Accepted |
+| [0008](0008-helm-chart-and-oci-distribution.md) | Production Helm Chart and OCI Distribution | Accepted |
 
 ## Conventions
 


### PR DESCRIPTION
## Description

Adds the production Helm chart for CHouse UI (`charts/chouse-ui/`), published as a signed OCI artifact to `oci://ghcr.io/daun-gatal/charts/chouse-ui`, plus the CI to validate it on PRs and publish it from the existing release pipeline. Spec captured in ADR 0008 (included, Accepted — implementation rides this PR since the change is purely additive).

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Other (please describe):

## Related Issue

Closes #

## Changes Made

- **ADR 0008** — chart design, topology rules, OCI distribution, versioning policy.
- **`charts/chouse-ui/`** — Deployment (Recreate on SQLite / RollingUpdate on Postgres), Service, Ingress, PVC (`helm.sh/resource-policy: keep`), app/postgres/config Secrets, HPA, PDB, NetworkPolicy, optional dedicated scheduled-queries Deployment, helm test pod.
  - Render-time guards: SQLite × (replicas>1 / HPA / dedicated scheduler) fails; secret-format checks mirror the server's production validation; `config:` keys that conflict with chart-managed settings are rejected.
  - `CHOUSE_HA=true` is injected when replicas>1 or HPA is on — the contract reserved for the chart by `.env.example` and ADRs 0001/0002.
  - Secrets are never auto-generated (a regenerated encryption key would make stored ClickHouse passwords unrecoverable); render fails with `openssl rand` instructions instead.
  - `values.schema.json`, helm-docs-generated README, 20 helm-unittest cases, two chart-testing scenarios in `ci/`.
- **`.github/workflows/helm.yml`** — PR gate: chart-version bump guard, strict lint, unit tests, kubeconform (3 pinned K8s versions), helm-docs drift check, kind install/test/upgrade matrix (SQLite + HA Postgres with a throwaway DB).
- **`.github/actions/helm-publish/`** — single publish implementation: immutability guard (released versions never overwritten; re-runs skip safely), package + OCI push, cosign keyless signing, pull+render smoke check.
- **`.github/workflows/helm-release.yml`** — chart-only releases from `preview` (dispatch; `dry_run` / `prerelease` inputs, `helm-publish` environment gate, `chart-v<version>` tag).
- **`auto-release.yml`** (additive only) — `assemble` syncs `appVersion` + auto-bumps chart patch only when the current version is already published and regenerates the chart README; a new `helm` job publishes after `docker` behind the existing gate; `publish`/`deploy-docs` do **not** depend on it, so a chart failure can never block an app release; announcement gains the `helm install` snippet.
- **`.rules/HELM_CHART.md` + CLAUDE.md** — when a code change requires a chart change in the same PR, versioning rules, hard don'ts.
- Root README Kubernetes section.

## Testing

- [x] I have tested this locally
- [x] I have added/updated tests
- [x] All existing tests pass

### Test Steps

- `helm lint --strict` clean on both ci values files; `helm unittest charts/chouse-ui` — 20/20 pass.
- `helm template` renders validated with kubeconform (`-strict`) for sqlite-default, postgres-HA (3 replicas + HPA + PDB + dedicated scheduler), ingress+NetworkPolicy scenarios.
- All six render-time guards verified to fail with actionable messages.
- helm-docs regenerated and committed (drift check green).
- kind install/upgrade runs in the new `helm.yml` workflow on this PR.

## Screenshots

N/A (infrastructure).

## Changelog Fragment

- [x] Added `changelogs/unreleased/<pr-number>-<slug>.md` *(added as a follow-up commit with the real PR number)*

## Checklist

- [x] My code follows the project's code style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have checked for breaking changes and documented them (if applicable)
- [x] I have tested the changes in the relevant environment (development/production)

## Additional Notes

**Post-merge, one-time:** after the first chart publish, set the `charts/chouse-ui` GHCR package to public and link it to the repo; optionally create the `helm-publish` environment (with reviewers) used by `helm-release.yml`. A `dry_run` dispatch of `Helm Release` is a safe end-to-end check of the publish path. The `helm.yml` kind jobs pull the released app image (`v<appVersion>`), so no image build happens on chart PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)