### PR TITLE
Fix react-router High CVE and RBAC APP_VERSION mismatch

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -41,7 +41,7 @@
         "dagre": "^0.8.5",
         "date-fns": "^4.1.0",
         "diff": "^8.0.3",
-        "dompurify": "^3.4.11",
+        "dompurify": "^3.4.12",
         "framer-motion": "^12.23.25",
         "highlight.js": "^11.11.1",
         "html-to-image": "^1.11.13",
@@ -55,7 +55,7 @@
         "react-hook-form": "^7.67.0",
         "react-markdown": "^10.1.0",
         "react-resizable-panels": "^3.0.6",
-        "react-router-dom": "^7.15.1",
+        "react-router": "^8.3.0",
         "reactflow": "^11.11.4",
         "recharts": "^3.6.0",
         "remark-gfm": "^4.0.1",
@@ -97,7 +97,7 @@
     },
     "packages/server": {
       "name": "@chouseui/server",
-      "version": "3.7.1",
+      "version": "3.10.0",
       "dependencies": {
         "@clickhouse/client": "^1.16.0",
         "@hono/zod-validator": "^0.7.6",
@@ -144,7 +144,7 @@
     },
   },
   "overrides": {
-    "dompurify": "^3.4.11",
+    "dompurify": "^3.4.12",
     "lodash": "4.18.0",
     "picomatch": "^4.0.4",
     "uuid": "^11.1.1",
@@ -1021,6 +1021,8 @@
 
     "cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
 
+    "cookie-es": ["cookie-es@3.1.1", "", {}, "sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg=="],
+
     "croner": ["croner@10.0.1", "", {}, "sha512-ixNtAJndqh173VQ4KodSdJEI6nuioBWI0V1ITNKhZZsO0pEMoDxz539T4FTTbSZ/xIOSuDnzxLVRqBVSvPNE2g=="],
 
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
@@ -1115,7 +1117,7 @@
 
     "dom-accessibility-api": ["dom-accessibility-api@0.5.16", "", {}, "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg=="],
 
-    "dompurify": ["dompurify@3.4.11", "", { "optionalDependencies": { "@types/trusted-types": "^2.0.7" } }, "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw=="],
+    "dompurify": ["dompurify@3.4.12", "", { "optionalDependencies": { "@types/trusted-types": "^2.0.7" } }, "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg=="],
 
     "drizzle-kit": ["drizzle-kit@0.30.6", "", { "dependencies": { "@drizzle-team/brocli": "^0.10.2", "@esbuild-kit/esm-loader": "^2.5.5", "esbuild": "^0.19.7", "esbuild-register": "^3.5.0", "gel": "^2.0.0" }, "bin": { "drizzle-kit": "bin.cjs" } }, "sha512-U4wWit0fyZuGuP7iNmRleQyK2V8wCuv57vf5l3MnG4z4fzNTjY/U13M8owyQ5RavqvqxBifWORaR3wIUzlN64g=="],
 
@@ -1775,9 +1777,7 @@
 
     "react-resizable-panels": ["react-resizable-panels@3.0.6", "", { "peerDependencies": { "react": "^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc", "react-dom": "^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" } }, "sha512-b3qKHQ3MLqOgSS+FRYKapNkJZf5EQzuf6+RLiq1/IlTHw99YrZ2NJZLk4hQIzTnnIkRg2LUqyVinu6YWWpUYew=="],
 
-    "react-router": ["react-router@7.18.0", "", { "dependencies": { "cookie": "^1.0.1", "set-cookie-parser": "^2.6.0" }, "peerDependencies": { "react": ">=18", "react-dom": ">=18" }, "optionalPeers": ["react-dom"] }, "sha512-pTTGt8J+ji1NOmYnjzT+bAJy/1zD+Jp4ziO6cL7T3ZLvXKtusO7BpFqlRXitqpcPVqllsIXFHRMt+2/k3Xn6HQ=="],
-
-    "react-router-dom": ["react-router-dom@7.18.0", "", { "dependencies": { "react-router": "7.18.0" }, "peerDependencies": { "react": ">=18", "react-dom": ">=18" } }, "sha512-Fi0yY6kgtKae/Th2xibdWK0KSdYZ4B53Gyf6wRtomOKWgpNm7H7+DyfDhncdz9FKbpS+1jmDhg3F4WoGJ+yFOA=="],
+    "react-router": ["react-router@8.3.0", "", { "dependencies": { "cookie-es": "^3.1.1" }, "peerDependencies": { "react": ">=19.2.7", "react-dom": ">=19.2.7" }, "optionalPeers": ["react-dom"] }, "sha512-qyPMvW83jGIct3yiieisxdk9M745anqhpIMKN5m1t6yBMfgVPpt77aHOqs5fUlEJRMCGffg9BaQLH9oPVOL7xQ=="],
 
     "react-style-singleton": ["react-style-singleton@2.2.3", "", { "dependencies": { "get-nonce": "^1.0.0", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ=="],
 
@@ -1848,8 +1848,6 @@
     "secure-json-parse": ["secure-json-parse@4.1.0", "", {}, "sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA=="],
 
     "semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
-
-    "set-cookie-parser": ["set-cookie-parser@2.7.2", "", {}, "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw=="],
 
     "set-function-length": ["set-function-length@1.2.2", "", { "dependencies": { "define-data-property": "^1.1.4", "es-errors": "^1.3.0", "function-bind": "^1.1.2", "get-intrinsic": "^1.2.4", "gopd": "^1.0.1", "has-property-descriptors": "^1.0.2" } }, "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg=="],
 

--- a/changelogs/unreleased/313-security-and-version-fixes.md
+++ b/changelogs/unreleased/313-security-and-version-fixes.md
@@ -1,0 +1,5 @@
+type: patch
+
+### Fixed
+- **Security** — upgraded react-router to v8.3.0, resolving GHSA-qwww-vcr4-c8h2 (High), and bumped dompurify to 3.4.12 (GHSA-c2j3-45gr-mqc4, Low); dependency scans now report no known vulnerabilities.
+- **RBAC version reporting** — servers no longer log a contradictory "current 1.47.0 / target 1.46.0" migration state; the schema version constant now matches the newest migration and is guarded by a test.

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "dagre": "^0.8.5",
     "date-fns": "^4.1.0",
     "diff": "^8.0.3",
-    "dompurify": "^3.4.11",
+    "dompurify": "^3.4.12",
     "framer-motion": "^12.23.25",
     "highlight.js": "^11.11.1",
     "html-to-image": "^1.11.13",
@@ -77,7 +77,7 @@
     "react-hook-form": "^7.67.0",
     "react-markdown": "^10.1.0",
     "react-resizable-panels": "^3.0.6",
-    "react-router-dom": "^7.15.1",
+    "react-router": "^8.3.0",
     "reactflow": "^11.11.4",
     "recharts": "^3.6.0",
     "remark-gfm": "^4.0.1",
@@ -123,7 +123,7 @@
   ],
   "overrides": {
     "lodash": "4.18.0",
-    "dompurify": "^3.4.11",
+    "dompurify": "^3.4.12",
     "picomatch": "^4.0.4",
     "ws": "^8.21.0",
     "uuid": "^11.1.1"

--- a/packages/server/src/rbac/db/migrations.test.ts
+++ b/packages/server/src/rbac/db/migrations.test.ts
@@ -15,7 +15,7 @@ import { describe, it, expect, beforeAll, afterAll } from "bun:test";
 import { sql } from "drizzle-orm";
 import { randomUUID } from "crypto";
 import { closeDatabase, getDatabaseType } from "./index";
-import { runMigrations, MIGRATIONS } from "./migrations";
+import { runMigrations, MIGRATIONS, APP_VERSION } from "./migrations";
 import * as h from "./migrationTestHarness";
 
 const DIALECTS: h.Dialect[] = ["sqlite", "postgres"];
@@ -337,6 +337,15 @@ async function userRoleIds(userId: string): Promise<string[]> {
 // ---------------------------------------------------------------------------
 // Per-dialect suites.
 // ---------------------------------------------------------------------------
+// APP_VERSION is what "current schema version" reports (logs, /api/rbac/status)
+// and what fresh installs are stamped with — a migration added without bumping
+// it makes every server log a nonsense "current > target" state.
+describe("migrations · version bookkeeping", () => {
+  it("APP_VERSION matches the newest migration", () => {
+    expect(APP_VERSION).toBe(MIGRATIONS[MIGRATIONS.length - 1].version);
+  });
+});
+
 for (const dialect of DIALECTS) {
   describe(`migrations · fresh install [${dialect}]`, () => {
     beforeAll(async () => {

--- a/packages/server/src/rbac/db/migrations.ts
+++ b/packages/server/src/rbac/db/migrations.ts
@@ -45,7 +45,7 @@ export interface MigrationResult {
 // Current App Version
 // ============================================
 
-export const APP_VERSION = '1.46.0';
+export const APP_VERSION = '1.47.0';
 
 // ============================================
 // Error Helpers

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react";
-import { BrowserRouter as Router, Routes, Route, Outlet, Navigate } from "react-router-dom";
+import { BrowserRouter as Router, Routes, Route, Outlet, Navigate } from "react-router";
 import FloatingDock from "@/components/common/FloatingDock";
 import AiChatBubble from "@/components/common/AiChatBubble";
 import CommandPalette from "@/components/common/CommandPalette";

--- a/src/components/common/AppInit.tsx
+++ b/src/components/common/AppInit.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState, ReactNode } from "react";
 import { MultiStepLoader as Loader } from "@/components/ui/multi-step-loader";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 import { useRbacStore } from "@/stores";
 import { toast } from "sonner";
 import { listenForUserChanges } from "@/utils/sessionCleanup";

--- a/src/components/common/CommandPalette.tsx
+++ b/src/components/common/CommandPalette.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 import {
   Database,
   BookOpen,

--- a/src/components/common/DefaultRedirect.tsx
+++ b/src/components/common/DefaultRedirect.tsx
@@ -1,4 +1,4 @@
-import { Navigate } from "react-router-dom";
+import { Navigate } from "react-router";
 import { useRbacStore, RBAC_PERMISSIONS } from "@/stores";
 import { ADMIN_ACCESS_PERMISSIONS, EXPLORER_ACCESS_PERMISSIONS } from "@/lib/navAccess";
 import { Loader2 } from "lucide-react";

--- a/src/components/common/FloatingDock.test.tsx
+++ b/src/components/common/FloatingDock.test.tsx
@@ -1,5 +1,5 @@
 import { act, render, screen, waitFor } from "@testing-library/react";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter } from "react-router";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import FloatingDock, { loadDockPreferencesFromLocal } from "./FloatingDock";

--- a/src/components/common/FloatingDock.tsx
+++ b/src/components/common/FloatingDock.tsx
@@ -1,5 +1,5 @@
 import { useState, useRef, useEffect, useCallback } from "react";
-import { Link, useLocation } from "react-router-dom";
+import { Link, useLocation } from "react-router";
 import {
   Globe2,
   LayoutDashboard,

--- a/src/components/common/NoPermission.tsx
+++ b/src/components/common/NoPermission.tsx
@@ -7,7 +7,7 @@
  */
 
 import { ShieldOff, ArrowLeft } from "lucide-react";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 
 interface NoPermissionProps {
   /** Human-readable feature / tab name the user tried to reach. */

--- a/src/components/common/PageTitleUpdater.tsx
+++ b/src/components/common/PageTitleUpdater.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from "react";
-import { useLocation } from "react-router-dom";
+import { useLocation } from "react-router";
 
 /**
  * Mapping of route paths to page titles.

--- a/src/components/common/RestrictedRoute.tsx
+++ b/src/components/common/RestrictedRoute.tsx
@@ -1,4 +1,4 @@
-import { Navigate, useLocation } from "react-router-dom";
+import { Navigate, useLocation } from "react-router";
 import { useRbacStore, RBAC_PERMISSIONS } from "@/stores";
 import { Loader2 } from "lucide-react";
 

--- a/src/components/common/privateRoute.tsx
+++ b/src/components/common/privateRoute.tsx
@@ -1,4 +1,4 @@
-import { Navigate, useLocation } from "react-router-dom";
+import { Navigate, useLocation } from "react-router";
 import { useRbacStore } from "@/stores";
 import { Loader2 } from "lucide-react";
 

--- a/src/components/sidebar/UserMenu.tsx
+++ b/src/components/sidebar/UserMenu.tsx
@@ -8,7 +8,7 @@ import {
 } from "@/components/ui/tooltip";
 import { LogOut } from "lucide-react";
 import { useRbacStore } from "@/stores";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 import { getSessionId, clearSession } from "@/api/client";
 import { rbacConnectionsApi } from "@/api/rbac";
 import ConfirmationDialog from "@/components/common/ConfirmationDialog";

--- a/src/features/admin/components/CreateUser/index.tsx
+++ b/src/features/admin/components/CreateUser/index.tsx
@@ -18,7 +18,7 @@ import {
   AlertCircle,
   Sparkles,
 } from "lucide-react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 import { toast } from "sonner";
 import { log } from "@/lib/log";
 import { Button } from "@/components/ui/button";

--- a/src/features/admin/components/EditUser/index.tsx
+++ b/src/features/admin/components/EditUser/index.tsx
@@ -27,7 +27,7 @@ import {
   Database,
   Unlink,
 } from "lucide-react";
-import { useNavigate, useParams } from "react-router-dom";
+import { useNavigate, useParams } from "react-router";
 import { toast } from "sonner";
 import { cn } from "@/lib/utils";
 import { log } from "@/lib/log";

--- a/src/features/admin/components/UserManagement/index.tsx
+++ b/src/features/admin/components/UserManagement/index.tsx
@@ -68,7 +68,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 import { toast } from "sonner";
 import { rbacUsersApi, rbacRolesApi, type RbacUser, type RbacRole } from "@/api/rbac";
 import { useRbacStore, RBAC_PERMISSIONS } from "@/stores";

--- a/src/features/admin/routes/adminRoute.tsx
+++ b/src/features/admin/routes/adminRoute.tsx
@@ -1,4 +1,4 @@
-import { Navigate, useLocation } from "react-router-dom";
+import { Navigate, useLocation } from "react-router";
 import { useRbacStore, RBAC_PERMISSIONS } from "@/stores";
 import { Loader2 } from "lucide-react";
 import NoPermission from "@/components/common/NoPermission";

--- a/src/features/explorer/components/DataExplorer.tsx
+++ b/src/features/explorer/components/DataExplorer.tsx
@@ -28,7 +28,7 @@ import {
   CircleX,
   Ban,
 } from "lucide-react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 import { toast } from "sonner";
 import { useExplorerStore, useWorkspaceStore, genTabId, useAuthStore, RBAC_PERMISSIONS, useRbacStore } from "@/stores";
 import { useDatabases, useSavedQueries, useSavedQueriesConnectionNames, useDebounce, useDeleteSavedQuery } from "@/hooks";

--- a/src/features/explorer/components/ImportWizard/ImportWizard.tsx
+++ b/src/features/explorer/components/ImportWizard/ImportWizard.tsx
@@ -20,7 +20,7 @@ import { cn } from '@/lib/utils';
 import { motion } from 'framer-motion';
 import { useDatabases } from '@/hooks';
 import { useWorkspaceStore, genTabId } from '@/stores/workspace';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 
 interface ImportWizardProps {
     isOpen: boolean;

--- a/src/features/explorer/components/TreeNode.tsx
+++ b/src/features/explorer/components/TreeNode.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useMemo } from "react";
 import { ChevronRight, ChevronDown, MoreVertical, Database, Table2, FilePlus, Info, FileUp, Trash2, TerminalIcon, FileType, Settings2, Eye, Star } from "lucide-react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 import { motion, AnimatePresence } from "framer-motion";
 import { Button } from "@/components/ui/button";
 import {

--- a/src/features/onboarding/Coachmark.test.tsx
+++ b/src/features/onboarding/Coachmark.test.tsx
@@ -1,5 +1,5 @@
 import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { MemoryRouter, useLocation } from "react-router-dom";
+import { MemoryRouter, useLocation } from "react-router";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { calculateCoachmarkPosition, Coachmark, isOnboardingRouteActive } from "./Coachmark";
@@ -21,8 +21,8 @@ vi.mock("@/lib/onboardingSurfaces", () => ({
   waitForOnboardingSurfacesToSettle: surfaceMocks.waitForSettle,
 }));
 
-vi.mock("react-router-dom", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("react-router-dom")>();
+vi.mock("react-router", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react-router")>();
   return {
     ...actual,
     useNavigate: () => {

--- a/src/features/onboarding/Coachmark.tsx
+++ b/src/features/onboarding/Coachmark.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useLayoutEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { ArrowLeft, ArrowRight, Check, X } from "lucide-react";
-import { useLocation, useNavigate } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router";
 
 import { Button } from "@/components/ui/button";
 import {

--- a/src/features/onboarding/GettingStartedHub.test.tsx
+++ b/src/features/onboarding/GettingStartedHub.test.tsx
@@ -1,5 +1,5 @@
 import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter } from "react-router";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { GettingStartedHub } from "./GettingStartedHub";

--- a/src/features/onboarding/GettingStartedHub.tsx
+++ b/src/features/onboarding/GettingStartedHub.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState } from "react";
 import { Check, ChevronRight, Circle, KeyRound, LockKeyhole, Plug, RotateCcw, ShieldCheck } from "lucide-react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 import { toast } from "sonner";
 
 import { rbacAuthApi } from "@/api";

--- a/src/features/onboarding/OnboardingProvider.test.tsx
+++ b/src/features/onboarding/OnboardingProvider.test.tsx
@@ -1,5 +1,5 @@
 import { act, render, screen, waitFor } from "@testing-library/react";
-import { MemoryRouter, useLocation } from "react-router-dom";
+import { MemoryRouter, useLocation } from "react-router";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { RBAC_PERMISSIONS } from "@/stores";

--- a/src/features/onboarding/OnboardingProvider.tsx
+++ b/src/features/onboarding/OnboardingProvider.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef } from "react";
-import { useLocation, useNavigate } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router";
 
 import { RBAC_PERMISSIONS, useAuthStore, useRbacStore } from "@/stores";
 

--- a/src/features/scheduled-queries/RunsTab.tsx
+++ b/src/features/scheduled-queries/RunsTab.tsx
@@ -5,7 +5,7 @@
  */
 
 import { useEffect, useMemo, useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 import { toast } from "sonner";
 import { FileSearch, Calendar as CalendarIcon, RotateCcw, Trash2, Sparkles } from "lucide-react";
 import { format, startOfDay, endOfDay, subDays } from "date-fns";

--- a/src/features/workspace/components/WorkspaceTabs.tsx
+++ b/src/features/workspace/components/WorkspaceTabs.tsx
@@ -43,7 +43,7 @@ import {
   ContextMenuSeparator,
   ContextMenuTrigger,
 } from "@/components/ui/context-menu";
-import { useSearchParams } from "react-router-dom";
+import { useSearchParams } from "react-router";
 import { cn } from "@/lib/utils";
 
 interface SortableTabProps {

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -7,7 +7,7 @@
  */
 
 import { useEffect, useCallback } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { useRbacStore } from '@/stores';
 import { log } from '@/lib/log';
 

--- a/src/pages/Admin.tsx
+++ b/src/pages/Admin.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react";
-import { useParams, useNavigate } from "react-router-dom";
+import { useParams, useNavigate } from "react-router";
 import { Button } from "@/components/ui/button";
 import UserTable from "@/features/admin/components/UserManagement/index";
 import InfoDialog from "@/components/common/InfoDialog";

--- a/src/pages/DataOps.tsx
+++ b/src/pages/DataOps.tsx
@@ -6,7 +6,7 @@
  */
 
 import { useEffect } from "react";
-import { useNavigate, useParams } from "react-router-dom";
+import { useNavigate, useParams } from "react-router";
 import { CalendarClock, HeartPulse, Workflow } from "lucide-react";
 
 import { cn } from "@/lib/utils";

--- a/src/pages/Doctor.test.tsx
+++ b/src/pages/Doctor.test.tsx
@@ -1,6 +1,6 @@
 import { act, cleanup, render, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { MemoryRouter, Route, Routes } from "react-router";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import Doctor from "./Doctor";

--- a/src/pages/Doctor.tsx
+++ b/src/pages/Doctor.tsx
@@ -9,7 +9,7 @@
  */
 
 import { useEffect, useState } from "react";
-import { useLocation, useParams, useNavigate } from "react-router-dom";
+import { useLocation, useParams, useNavigate } from "react-router";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { Stethoscope, Loader2, Sparkles, AlertCircle, Server, Check, ChevronDown, Trash2, ListChecks, X, CalendarClock, ShieldOff } from "lucide-react";
 import { toast } from "sonner";

--- a/src/pages/Explorer.tsx
+++ b/src/pages/Explorer.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState, useRef, useCallback } from "react";
-import { useSearchParams, useNavigate } from "react-router-dom";
+import { useSearchParams, useNavigate } from "react-router";
 import { ChevronRight, Database, Layers, PanelLeftClose, PanelLeftOpen, Table2 } from "lucide-react";
 import DatabaseExplorer from "@/features/explorer/components/DataExplorer";
 import WorkspaceTabs from "@/features/workspace/components/WorkspaceTabs";

--- a/src/pages/Fleet.test.tsx
+++ b/src/pages/Fleet.test.tsx
@@ -1,5 +1,5 @@
 import { render } from "@testing-library/react";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter } from "react-router";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import FleetPage from "./Fleet";

--- a/src/pages/Fleet.tsx
+++ b/src/pages/Fleet.tsx
@@ -10,7 +10,7 @@
  */
 
 import { useMemo, useState } from "react";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 import { AlertTriangle, Globe2, InfoIcon, Plug, RefreshCw, Search, X } from "lucide-react";
 import { useQueries } from "@tanstack/react-query";
 import { Button } from "@/components/ui/button";

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -28,7 +28,7 @@ import {
   type LucideIcon,
 } from "lucide-react";
 import { toast } from "sonner";
-import { Link, useNavigate } from "react-router-dom";
+import { Link, useNavigate } from "react-router";
 import { useQueryClient } from "@tanstack/react-query";
 import { useRecentQueries, useSavedQueries, useSystemStats, useDatabases } from "@/hooks";
 import { useAuthStore } from "@/stores/auth";

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -11,7 +11,7 @@ import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import * as z from "zod";
 import { ArrowUpRight, ChevronDown, Eye, EyeOff, Loader2, Lock, ShieldCheck, User } from "lucide-react";
-import { useNavigate, useSearchParams } from "react-router-dom";
+import { useNavigate, useSearchParams } from "react-router";
 import { useRbacStore } from "@/stores";
 import { ssoApi, authConfigApi } from "@/api/rbac";
 import { SsoProviderIcon } from "@/features/auth/SsoProviderIcon";

--- a/src/pages/Logs.tsx
+++ b/src/pages/Logs.tsx
@@ -61,7 +61,7 @@ import {
 } from "@/hooks/useMonitoringTimeline";
 import { QueryHistogramChart } from "@/components/monitoring/QueryHistogramChart";
 import { useRbacStore, RBAC_PERMISSIONS, useWorkspaceStore, genTabId } from "@/stores";
-import { useNavigate, useSearchParams } from "react-router-dom";
+import { useNavigate, useSearchParams } from "react-router";
 import { cn, formatCompactNumber } from "@/lib/utils";
 import { DataControls } from "@/components/common/DataControls";
 import {

--- a/src/pages/Monitoring.tsx
+++ b/src/pages/Monitoring.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react";
-import { useParams, useNavigate, useSearchParams } from "react-router-dom";
+import { useParams, useNavigate, useSearchParams } from "react-router";
 import {
   InfoIcon,
   Activity,

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -7,7 +7,7 @@
  * the app so the page doesn't feel orphaned from the rest of the design.
  */
 
-import { Link, useNavigate } from "react-router-dom";
+import { Link, useNavigate } from "react-router";
 import { ArrowLeft, ArrowUpRight, Globe2, Signpost } from "lucide-react";
 import { cn } from "@/lib/utils";
 

--- a/src/pages/Preferences.tsx
+++ b/src/pages/Preferences.tsx
@@ -27,7 +27,7 @@ import { Button } from "@/components/ui/button";
 import { useAuthStore, useRbacStore, usePreferencesStore } from "@/stores";
 import { RESULT_ROWS_MIN, RESULT_ROWS_MAX, RESULT_ROWS_DEFAULT } from "@/stores/preferences";
 import { useAppPreferences } from "@/hooks/useAppPreferences";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 import { cn } from "@/lib/utils";
 import { rbacAuthApi, rbacConnectionsApi } from "@/api/rbac";
 import { getSessionId } from "@/api/client";

--- a/src/pages/SsoCallback.test.tsx
+++ b/src/pages/SsoCallback.test.tsx
@@ -5,7 +5,7 @@
 import React from "react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
-import { MemoryRouter, Route, Routes, useLocation } from "react-router-dom";
+import { MemoryRouter, Route, Routes, useLocation } from "react-router";
 // --- mock the rbac store module ---
 const mockCompleteSsoLogin = vi.fn();
 

--- a/src/pages/SsoCallback.tsx
+++ b/src/pages/SsoCallback.tsx
@@ -9,7 +9,7 @@
  */
 
 import { useEffect, useRef, useState } from "react";
-import { Link, useNavigate, useSearchParams } from "react-router-dom";
+import { Link, useNavigate, useSearchParams } from "react-router";
 import { Loader2 } from "lucide-react";
 import { useRbacStore } from "@/stores";
 import { log } from "@/lib/log";

--- a/src/pages/SsoComplete.test.tsx
+++ b/src/pages/SsoComplete.test.tsx
@@ -5,7 +5,7 @@
 import React from "react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
-import { MemoryRouter, Route, Routes, useLocation } from "react-router-dom";
+import { MemoryRouter, Route, Routes, useLocation } from "react-router";
 
 // --- mock the rbac store module ---
 const mockCompleteSamlLogin = vi.fn();

--- a/src/pages/SsoComplete.tsx
+++ b/src/pages/SsoComplete.tsx
@@ -9,7 +9,7 @@
  */
 
 import { useEffect, useRef, useState } from "react";
-import { Link, useNavigate, useSearchParams } from "react-router-dom";
+import { Link, useNavigate, useSearchParams } from "react-router";
 import { Loader2 } from "lucide-react";
 import { useRbacStore } from "@/stores";
 import { log } from "@/lib/log";

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,7 @@
     "strict": true,
     "forceConsistentCasingInFileNames": true,
     "module": "ESNext",
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,


### PR DESCRIPTION
## Description

Two fixes that unblock CI and release hygiene: the Grype Security Scan has failed on every PR since GHSA-qwww-vcr4-c8h2 (High) was published against react-router 7.x, and every server logs a nonsense "current 1.47.0 / target 1.46.0" migration state because `APP_VERSION` wasn't bumped with migration 1.47.0. These are also the app-code changes that let the next release run end-to-end (fast-forwarding `main` and publishing the Helm chart from PR #312).

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Other (please describe):

## Related Issue

Closes #

## Changes Made

- **react-router 7.18.0 → 8.3.0** (GHSA-qwww-vcr4-c8h2, High — RSC-mode CSRF bypass; this SPA doesn't use RSC mode, but the advisory gates CI). v8 folds `react-router-dom` into the core package: dependency swapped, all `src/` imports rewritten to `"react-router"`. The app uses only the declarative API (`BrowserRouter`/`Routes`/hooks), which is unchanged in v8 — zero call-site changes beyond import paths.
- **`tsconfig.json` `moduleResolution: Node → bundler`** — v8 ships types via package `exports`, invisible to legacy node10 resolution; `bundler` is the standard setting for Vite apps. Full typecheck passes with no other fallout.
- **dompurify override `^3.4.11 → ^3.4.12`** — clears the remaining Low advisory (GHSA-c2j3-45gr-mqc4), including the nested copy under `@types/dompurify`.
- **`APP_VERSION` `1.46.0 → 1.47.0`** in `packages/server/src/rbac/db/migrations.ts`, plus a bookkeeping test asserting `APP_VERSION` always equals the newest migration's version so it can't drift again.

## Testing

- [x] I have tested this locally
- [x] I have added/updated tests
- [x] All existing tests pass

### Test Steps

- `bun run typecheck` (frontend) and server `typecheck` — clean.
- `bun run lint` — clean (`--max-warnings 0`).
- Frontend suite: **529/529 tests pass** (includes every router-mocking component test).
- `bun run build:web` — production build succeeds.
- `./scripts/test-migrations.sh` — **156 pass, 0 fail** on both SQLite and PostgreSQL (mandatory for the `migrations.ts` change; includes the new APP_VERSION sync test).
- Grype on a clean tree (as the CI job runs it): **"No vulnerabilities found"**.

## Screenshots

N/A.

## Changelog Fragment

- [x] Added `changelogs/unreleased/<pr-number>-<slug>.md` *(added as a follow-up commit with the real PR number)*

## Checklist

- [x] My code follows the project's code style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have checked for breaking changes and documented them (if applicable)
- [x] I have tested the changes in the relevant environment (development/production)

## Additional Notes

The advisory's vulnerable range is `>= 7.12.0, < 8.3.0` with no 7.x patch, and `react-router-dom` has no v8 — the package merge is the upstream-intended upgrade path. After this merges, dispatching **Release** (with "Use workflow from: `preview`") will cut the next version, fast-forward `main`, and publish the first Helm chart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)