### PR TITLE
Harden chart sync in the release pipeline

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -220,7 +220,14 @@ jobs:
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "Assembled version: $VERSION"
 
+      # Chart sync is a convenience, never a reason to fail a release: the app
+      # is what's shipping. Every step below is non-fatal — if Helm can't be
+      # installed or the registry is unreachable, the chart keeps its current
+      # appVersion and the chart publish later no-ops on the immutability
+      # guard (or is re-run via the Helm Release workflow).
       - name: Setup Helm
+        id: setup_helm
+        continue-on-error: true
         uses: azure/setup-helm@v4
         with:
           version: v4.2.3
@@ -228,33 +235,77 @@ jobs:
       # Keep the chart shipping the app it was released with. The chart
       # `version` is only auto-bumped (patch) when the current one is already
       # published — a pending manual bump from a chart PR is respected, never
-      # double-bumped. If the registry check fails, the version is kept and
-      # the publish step later no-ops on the immutability guard (safe).
+      # double-bumped.
       - name: Sync chart appVersion
+        id: chart_sync
+        continue-on-error: true
         run: |
           VERSION="${{ steps.release.outputs.version }}"
           CHART=charts/chouse-ui/Chart.yaml
+
+          # `^version:` deliberately excludes the `appVersion:` line.
           CURRENT=$(awk '/^version:/{print $2; exit}' "$CHART")
+
+          # A published version is immutable, so it must be bumped. An
+          # unpublished one came from a chart PR that also wrote its own
+          # release notes — leave both alone.
+          AUTO_BUMPED=false
           if helm show chart "oci://ghcr.io/${{ github.repository_owner }}/charts/chouse-ui" --version "$CURRENT" > /dev/null 2>&1; then
             NEXT=$(echo "$CURRENT" | awk -F. '{printf "%d.%d.%d", $1, $2, $3+1}')
             sed -i "s/^version: .*/version: $NEXT/" "$CHART"
+            AUTO_BUMPED=true
             echo "Chart version bumped: $CURRENT -> $NEXT (previous version already published)"
           else
-            echo "Chart version $CURRENT not published yet — keeping it."
+            echo "Chart version $CURRENT not published yet — keeping it (and its release notes)."
           fi
+
           sed -i "s/^appVersion: .*/appVersion: \"$VERSION\"/" "$CHART"
           # Keep the artifacthub.io/images annotation pointing at the same
           # release the chart installs by default.
           sed -i "s|image: ghcr.io/daun-gatal/chouse-ui:v[0-9][0-9.]*|image: ghcr.io/daun-gatal/chouse-ui:v$VERSION|" "$CHART"
           echo "Chart appVersion set to $VERSION"
 
+          # An auto-bumped version has no human-written notes of its own. Without
+          # this it would inherit the previous chart PR's artifacthub.io/changes
+          # and advertise that feature again under a version that didn't add it.
+          if [ "$AUTO_BUMPED" = "true" ]; then
+            python3 - "$CHART" "$VERSION" <<'PY'
+          import re, sys
+          path, version = sys.argv[1], sys.argv[2]
+          with open(path) as f:
+              content = f.read()
+          replacement = (
+              "  artifacthub.io/changes: |\n"
+              "    - kind: changed\n"
+              f"      description: Updated to CHouse UI v{version}\n"
+          )
+          # Replace the whole block literal, up to the next annotation key or EOF.
+          pattern = re.compile(
+              r"^  artifacthub\.io/changes: \|\n(?:^(?:    .*)?\n)*",
+              re.MULTILINE,
+          )
+          content, count = pattern.subn(replacement, content, count=1)
+          if count != 1:
+              sys.exit("artifacthub.io/changes block not found — refusing to guess")
+          with open(path, "w") as f:
+              f.write(content)
+          print(f"artifacthub.io/changes reset for auto-bumped chart version (app v{version})")
+          PY
+          fi
+
       # The chart README embeds version/appVersion badges — regenerate so the
       # helm-docs drift check on the next chart PR stays green.
       - name: Regenerate chart README
+        continue-on-error: true
         run: |
           curl -fsSL "https://github.com/norwoodj/helm-docs/releases/download/v1.14.2/helm-docs_1.14.2_Linux_x86_64.tar.gz" \
             | tar -xz -C /usr/local/bin helm-docs
           helm-docs --chart-search-root charts/chouse-ui
+
+      - name: Warn if chart sync was skipped
+        if: steps.setup_helm.outcome != 'success' || steps.chart_sync.outcome != 'success'
+        run: |
+          echo "::warning::Chart sync did not complete (setup-helm=${{ steps.setup_helm.outcome }}, sync=${{ steps.chart_sync.outcome }}). The app release is unaffected; re-run the Helm Release workflow afterwards to publish an updated chart."
 
       - name: Trim CHANGELOG to latest 10 releases
         run: |


### PR DESCRIPTION
## Description

Two fixes to the chart-sync steps I added to `auto-release.yml`'s `assemble` job. Both were flagged during review of how the next release would behave; neither affects the app release path's outcome, only its robustness and the accuracy of what the chart advertises.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Other (please describe):

## Related Issue

Closes #

## Changes Made

**1. Chart sync can no longer abort an app release.** `Setup Helm`, `Sync chart appVersion`, and `Regenerate chart README` download Helm and helm-docs and query GHCR — three network operations on the critical path *before* the Docker build. A transient failure in any of them would have failed `assemble` and aborted the release over chart bookkeeping. All three are now `continue-on-error`, with a `::warning::` annotation naming which step was skipped and pointing at the Helm Release workflow to publish the chart afterwards. The app is what's shipping; chart sync is a convenience.

**2. Auto-bumped chart versions no longer inherit stale release notes.** `artifacthub.io/changes` was never updated by the sync, so a version whose only change was an `appVersion` bump would carry the previous chart PR's notes — e.g. chart `1.1.2` telling ArtifactHub it "added the chart logo", which actually landed in `1.1.1`. The notes are now replaced with an accurate `Updated to CHouse UI vX.Y.Z` entry — but **only when the version was auto-bumped**. A version pending from a chart PR keeps the notes its author deliberately wrote, so `.rules/HELM_CHART.md`'s "update `changes` in every chart PR" rule still holds.

## Testing

- [x] I have tested this locally
- [ ] I have added/updated tests
- [x] All existing tests pass

### Test Steps

Rather than eyeballing the YAML, I extracted the step's `run` script straight out of the workflow with a YAML parser and executed it against a real copy of `Chart.yaml`, exercising both branches:

- **Auto-bump path** (current version already published): `1.1.1 → 1.1.2`, `appVersion → 3.12.0`, `artifacthub.io/images → v3.12.0`, and `changes` reset to `Updated to CHouse UI v3.12.0`.
- **Pending-version path** (version not yet published): version and `changes` both left untouched, `appVersion` still updated.

Also confirmed `helm show chart` against the public OCI repo works unauthenticated (exit 0), which is what the auto-bump branch depends on.

## Screenshots

N/A.

## Changelog Fragment

- [ ] Added `changelogs/unreleased/<pr-number>-<slug>.md`

Skipped — release-pipeline plumbing, not user-visible.

## Checklist

- [x] My code follows the project's code style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have checked for breaking changes and documented them (if applicable)
- [x] I have tested the changes in the relevant environment (development/production)

## Additional Notes

The annotation rewrite uses a short inline Python block (`python3` is present on GitHub-hosted runners). Its indentation inside the YAML block scalar is load-bearing, which is why I validated it by running the extracted script rather than by reading it — the heredoc body dedents to column 0 exactly as Python requires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)