### PR TITLE
Fix SSO config example that promised env interpolation

### DIFF
--- a/.config.example.yaml
+++ b/.config.example.yaml
@@ -118,6 +118,21 @@ scheduled_queries:
 # SSO (OIDC / OAuth2) — optional
 # ============================================
 # Register this redirect URI at your IdP: <base_url>/auth/sso/callback
+#
+# Keeping secrets out of this file
+# --------------------------------
+# Values here are loaded VERBATIM — there is no "${VAR}" expansion. A value
+# like "${GOOGLE_CLIENT_SECRET}" is passed to the IdP as that literal string
+# and authentication fails with a confusing error.
+#
+# To keep a secret out of the file, simply omit its key: the loader only
+# overrides environment variables for keys that appear in this YAML, so
+# anything left out keeps whatever the environment supplies. Each key maps to
+# an upper-snake-case env var (nesting joined by underscores), e.g.
+#   auth.sso.providers.google.client_secret
+#     -> AUTH_SSO_PROVIDERS_GOOGLE_CLIENT_SECRET
+# The reverse is also true: a key set here WINS over the same env var, so
+# don't set a secret in both places and expect the env one to apply.
 auth:
   sso:
     enabled: true
@@ -140,8 +155,10 @@ auth:
         type: oidc                                      # OIDC: auto-discovers endpoints from issuer
         display_name: "Google"
         issuer: https://accounts.google.com
-        client_id: "${GOOGLE_CLIENT_ID}"               # set GOOGLE_CLIENT_ID in env or replace here
-        client_secret: "${GOOGLE_CLIENT_SECRET}"       # set GOOGLE_CLIENT_SECRET in env or replace here
+        client_id: "1234567890-abcdefg.apps.googleusercontent.com"
+        # client_secret is deliberately NOT set here — see the note below on
+        # keeping secrets out of this file. Provide it as an env var:
+        #   AUTH_SSO_PROVIDERS_GOOGLE_CLIENT_SECRET=...
         scopes: "openid profile email"
         # Optional (OIDC): override individual auto-discovered endpoints if the
         # discovery document is wrong or unreachable. Leave unset to use discovery.

--- a/.env.example
+++ b/.env.example
@@ -124,6 +124,10 @@ CHOUSE_HA=false
 # Enable SSO login. Providers are configured per-id:
 #   AUTH_SSO_PROVIDERS_<ID>_<FIELD>
 # See .config.example.yaml for the equivalent YAML structure.
+# Tip: if you use CHOUSE_CONFIG_PATH, keep client secrets here rather than in
+# the YAML — that file is loaded verbatim (no "${VAR}" expansion) and any key
+# it defines overrides the same env var. Keys omitted from the YAML keep
+# whatever the environment provides.
 # Register this redirect URI at your IdP:
 #   <base_url>/auth/sso/callback
 AUTH_SSO_ENABLED=false


### PR DESCRIPTION
## Description

`.config.example.yaml` documented SSO credentials as `"${GOOGLE_CLIENT_ID}"` / `"${GOOGLE_CLIENT_SECRET}"` with the comment *"set GOOGLE_CLIENT_ID in env or replace here"* — but the config loader has no interpolation. It parses the YAML, flattens it, and assigns each value to `process.env` verbatim. Anyone following the example sends the literal string `${GOOGLE_CLIENT_SECRET}` to their IdP and gets an opaque authentication failure.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Other (please describe):

## Related Issue

Closes #

## Changes Made

- The Google provider example now uses a realistic `client_id` and **deliberately omits** `client_secret`, with a comment naming the env var to set instead (`AUTH_SSO_PROVIDERS_GOOGLE_CLIENT_SECRET`).
- Added a "Keeping secrets out of this file" note to the SSO section explaining the two rules that matter: values load verbatim (no `${VAR}` expansion), and a key present in the YAML **overrides** the same env var — so a key you want to come from the environment must be left out entirely. Includes the key → env-var mapping.
- Matching tip in `.env.example` for people combining both.

No code change: the loader's behaviour is reasonable, the documentation simply described something it never did.

## Testing

- [x] I have tested this locally
- [ ] I have added/updated tests
- [x] All existing tests pass

### Test Steps

Verified against the real loader rather than by reading it:

1. **Reproduced the bug** — loaded a config containing `client_secret: "${MY_SECRET}"` with `MY_SECRET=actual-secret-value` exported. Result: `AUTH_SSO_PROVIDERS_GOOGLE_CLIENT_SECRET = "${MY_SECRET}"` — the literal placeholder.
2. **Verified the documented fix** — loaded the corrected `.config.example.yaml` with both env vars set. The omitted `client_secret` kept its env value (`"from-env"`), while the YAML-present `client_id` overrode the environment. Both claims in the new note hold.
3. `.config.example.yaml` still parses as valid YAML; `configLoader` unit tests pass (4/4), plus `src/lib` suite (54/54).

## Screenshots

N/A.

## Changelog Fragment

- [ ] Added `changelogs/unreleased/<pr-number>-<slug>.md`

Skipped — example/docs only, no runtime change.

## Checklist

- [x] My code follows the project's code style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have checked for breaking changes and documented them (if applicable)
- [x] I have tested the changes in the relevant environment (development/production)

## Additional Notes

An alternative fix would be to *implement* `${VAR}` expansion in `configLoader.ts` so the original example works as written. That's a defensible feature (it's what people expect from config files), but it changes runtime behaviour for anyone with a literal `${...}` in their config and deserves its own PR with tests. Happy to do it if you'd prefer that direction — this PR just stops the documentation from lying.

🤖 Generated with [Claude Code](https://claude.com/claude-code)