### PR TITLE
Stop shipping build-time cruft in the container image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,8 +31,13 @@ RUN bun run build:web
 # ============================================
 FROM oven/bun:1-alpine AS production
 
-# Install CA certificates for HTTPS connections and wget for healthcheck
-RUN apk add --no-cache ca-certificates wget && update-ca-certificates
+# Patch base-image packages (the upstream tag lags Alpine security updates) and
+# install CA certificates for HTTPS connections.
+# The HEALTHCHECK uses busybox's built-in wget, so GNU wget is deliberately not
+# installed — it ships unfixed CVEs and adds nothing busybox doesn't cover.
+RUN apk upgrade --no-cache && \
+    apk add --no-cache ca-certificates && \
+    update-ca-certificates
 
 # Re-declare build arguments for labels
 ARG VERSION=dev
@@ -49,12 +54,20 @@ COPY --from=build /app/packages/server/package.json ./packages/server/
 COPY --from=build /app/packages/server/src ./packages/server/src
 COPY --from=build /app/packages/server/tsconfig.json ./packages/server/
 
-# Copy root package.json for workspace resolution (if needed)
-COPY --from=build /app/package.json ./
+# The root package.json is deliberately NOT copied. Its presence makes Bun treat
+# /app as a workspace root and also install the *frontend's* runtime dependencies
+# (~735 MB) — which the runtime never loads, because the frontend is served as the
+# pre-built static bundle in /app/dist. Leaving it out keeps the install to the
+# server's own 227 packages and off the vulnerability scanners' radar.
 
-# Install server production dependencies only
+# Install server production dependencies only.
+# Bun's global install cache is populated during resolution and holds the *whole*
+# dependency tree, dev included (~1 GB of prebuilt binaries such as old esbuild
+# releases). It is build-time scratch, so drop it in the same layer — otherwise it
+# ships in the image and gets scanned as if it were part of the runtime.
 WORKDIR /app/packages/server
-RUN bun install --production
+RUN bun install --production && \
+    rm -rf /root/.bun/install/cache
 
 # Back to app root
 WORKDIR /app
@@ -112,8 +125,10 @@ EXPOSE 5521
 USER ch-user
 
 # Health check - verify both API and static serving work
+# Flags are busybox-wget compatible (no --no-verbose/--tries); -T caps the request
+# so a hung server fails the check instead of stalling it.
 HEALTHCHECK --interval=30s --timeout=10s --start-period=15s --retries=3 \
-    CMD wget --no-verbose --tries=1 --spider http://localhost:5521/api/health || exit 1
+    CMD wget -q -T 5 --spider http://localhost:5521/api/health || exit 1
 
 # Start the server
 CMD ["bun", "run", "packages/server/src/index.ts"]

--- a/changelogs/unreleased/318-bundled-eval-databases.md
+++ b/changelogs/unreleased/318-bundled-eval-databases.md
@@ -1,4 +1,0 @@
-type: minor
-
-### Added
-- **Bundled evaluation databases in the Helm chart** — `postgresql.enabled` and `clickhouse.enabled` stand up PostgreSQL and a single-node ClickHouse alongside CHouse UI, with the connection form pre-filled, so a Kubernetes install can be tried end to end without provisioning anything first. Disabled by default and intended for evaluation and CI only; production installs should continue to use a managed PostgreSQL and a ClickHouse operator (ADR 0009).

--- a/changelogs/unreleased/322-container-image-vulnerabilities.md
+++ b/changelogs/unreleased/322-container-image-vulnerabilities.md
@@ -1,0 +1,7 @@
+type: patch
+
+### Fixed
+- **Container image vulnerabilities** — the published image shipped Bun's global install cache (~1 GB), which held the entire dependency tree including dev-only prebuilt binaries such as esbuild 0.18.20 and 0.19.12; scanners reported those stale binaries as part of the runtime. The cache is now dropped in the same layer it is created in. The base image's Alpine packages are also patched at build time (`apk upgrade`), picking up OpenSSL 3.5.7-r0, and GNU `wget` — which carried unfixed CVEs and was installed only for the healthcheck — is replaced by busybox's built-in `wget`.
+
+### Changed
+- **Smaller runtime image** — the frontend's runtime dependencies (~735 MB) are no longer installed into the production image. They were pulled in only because the root `package.json` made Bun treat `/app` as a workspace root; the server never loads them, since the frontend is served as the pre-built static bundle in `/app/dist`.


### PR DESCRIPTION
## Description

The ArtifactHub security report for `ghcr.io/daun-gatal/chouse-ui:v3.11.0` rated the image **F**, flagging "high severity fixable vulnerabilities older than 2 years old". The two `F`-rated targets were not real dependencies — the image was shipping **Bun's global install cache** (~978 MB, 2311 entries).

`bun install --production` correctly keeps devDependencies out of `node_modules`, but Bun still populates its global cache with the whole resolved tree during install. So dev-only prebuilt binaries — esbuild `0.18.20` (via `@esbuild-kit/core-utils`) and `0.19.12` (via `drizzle-kit`) — shipped as scannable Go binaries that nothing at runtime ever loaded. They were "unaddressed for 2 years" because nothing was *using* them.

The `alpine 3.22.4` **D** rating is separate: the `oven/bun:1-alpine` tag lags Alpine's security updates and carries `libcrypto3`/`libssl3` `3.5.6-r0` while `3.5.7-r0` is already in the Alpine repos.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Performance improvement

## Related Issue

N/A — reported via the ArtifactHub package security report.

## Changes Made

All changes are confined to the production stage of `Dockerfile`:

1. **Drop Bun's install cache in the layer that creates it** — removes both `F`-rated targets and ~978 MB.
2. **`apk upgrade --no-cache`** — patches base-image packages, picking up OpenSSL `3.5.6-r0` → `3.5.7-r0` (1 critical + 8 high, across `libcrypto3` and `libssl3`).
3. **Remove GNU `wget`** — installed solely for the `HEALTHCHECK`, and carrying three highs with no upstream fix (CVE-2026-58469/58471/58472). Busybox already provides `wget` with `--spider`, so the package is dropped and the healthcheck now uses busybox-compatible flags (`-q -T 5`; busybox accepts neither `--no-verbose` nor `--tries`). `-T` also caps the request so a hung server fails the check instead of stalling it.
4. **Stop copying the root `package.json`** — its presence made Bun treat `/app` as a workspace root and install the frontend's runtime dependencies (~735 MB), which the server never loads because the frontend is served as the pre-built static bundle in `/app/dist`. The install drops to the server's own 227 packages.

Also removes the unreleased `318-bundled-eval-databases.md` changelog fragment (separate commit).

## Testing

- [x] I have tested this locally
- [ ] I have added/updated tests
- [ ] All existing tests pass

Scanned the built production stage with `grype`, before and after:

| | Total | Critical | High | Medium | Low |
|---|---|---|---|---|---|
| `v3.11.0` | 101 | 8 | 44 | 43 | 6 |
| This PR | **3** | **0** | **0** | 3 | 0 |

The 3 remaining findings are all the same busybox `CVE-2025-60876` (medium), which has **no upstream fix** — it comes from the Alpine base and cannot be resolved from our side.

Runtime verification of the rebuilt image:
- Container reaches `health=healthy` via the new busybox healthcheck.
- `GET /api/health` returns `{"success":true,"data":{"status":"healthy",...}}`.
- Confirmed in-image: `/root/.bun/install/cache` gone, GNU `wget` absent, `libcrypto3`/`libssl3` at `3.5.7-r0`.

For change 4 specifically, the module-resolution risk was verified directly: a standalone production install resolves (227 packages), the server boots fully and serves health with only `packages/server/node_modules`, no server source imports a root-only package, and nothing reads `package.json` at runtime.

> [!NOTE]
> Two caveats on the numbers. These are **grype on arm64**, while ArtifactHub uses **Trivy on amd64** — the exact counts will not match theirs, though the structure and the fixes do. And a full clean `docker build .` did not complete locally: `bun run build:web` was OOM-killed (exit 137, unrelated to these changes) and the local Docker VM's disk is exhausted in a way `prune` won't reclaim. The production stage was therefore verified by replaying it against the published image's build output rather than a from-scratch build. **CI should be treated as the authoritative build check for this PR.**

### Test Steps

```bash
docker build -t chouse-ui:local .
grype docker-archive:<(docker save chouse-ui:local) -o table
docker run --rm -d --name ch -e JWT_SECRET=... -e RBAC_ENCRYPTION_KEY=... -e RBAC_ENCRYPTION_SALT=... chouse-ui:local
docker inspect --format '{{.State.Health.Status}}' ch   # → healthy
```

## Changelog Fragment

- [x] Added `changelogs/unreleased/322-container-image-vulnerabilities.md`

## Checklist

- [x] My code follows the project's code style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have checked for breaking changes and documented them (if applicable)
- [x] I have tested the changes in the relevant environment (development/production)

## Additional Notes

**No Helm chart change required.** Per `.rules/HELM_CHART.md`, a `Dockerfile` change requires a chart update only when it touches user/uid, port, `/app/data` layout, or writable paths — none of which changed. The chart uses `httpGet` probes, so the healthcheck change does not affect it either.

Noticed but deliberately left alone: `packages/server/src` is copied wholesale into the image, including `.test.ts` files. Harmless at runtime, but they don't need to be there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
