### PR TITLE
fix(explorer): stop the sidebar clipping its own controls

### DIFF
--- a/changelogs/unreleased/324-explorer-sidebar-clipping.md
+++ b/changelogs/unreleased/324-explorer-sidebar-clipping.md
@@ -1,0 +1,5 @@
+type: patch
+
+### Fixed
+- **Explorer sidebar clipped its own controls** — Radix's scroll area wraps its content in a shrink-to-fit `display: table` element, so a single long query in the History tab stretched the panel to the width of that query and everything past the sidebar edge was clipped: the status filter, the Clear button, and the per-row delete buttons all disappeared, and query text never truncated. The scroll area's content wrapper now uses block layout, so list rows stay at viewport width in every sidebar tab (horizontal scroll areas are unaffected).
+- **Explorer sidebar tab strip overflowed** — the five sidebar tabs did not fit at the default sidebar width, pushing Queries out of view. Tab labels now collapse to icons for inactive tabs when the sidebar is narrow, and every tab carries an accessible name and tooltip.

--- a/src/components/ui/scroll-area.tsx
+++ b/src/components/ui/scroll-area.tsx
@@ -12,7 +12,15 @@ const ScrollArea = React.forwardRef<
     className={cn("relative overflow-hidden", className)}
     {...props}
   >
-    <ScrollAreaPrimitive.Viewport className="h-full w-full rounded-[inherit]">
+    {/*
+      Radix wraps the viewport content in a `display: table` element, which is
+      shrink-to-fit: `truncate` / `flex-1` children then size to their intrinsic
+      width instead of the viewport's, and anything past the viewport is clipped
+      by `overflow-x: hidden`. Forcing block layout keeps children at viewport
+      width; horizontal scroll areas still scroll because the viewport itself
+      overflows.
+    */}
+    <ScrollAreaPrimitive.Viewport className="h-full w-full rounded-[inherit] [&>div]:block!">
       {children}
     </ScrollAreaPrimitive.Viewport>
     <ScrollBar />

--- a/src/features/explorer/components/DataExplorer.tsx
+++ b/src/features/explorer/components/DataExplorer.tsx
@@ -277,16 +277,19 @@ const TabButton: React.FC<TabButtonProps> = ({ active, onClick, icon, label, cou
     type="button"
     onClick={onClick}
     className={cn(
-      "flex items-center gap-1.5 rounded-xs px-2.5 py-1.5 transition-colors",
+      "flex shrink-0 items-center gap-1.5 rounded-xs px-2.5 py-1.5 transition-colors",
       "font-mono text-[10px] uppercase tracking-[0.14em]",
       active
         ? "bg-ink-200 text-paper"
         : "text-paper-dim hover:bg-ink-200 hover:text-paper"
     )}
     aria-pressed={active}
+    aria-label={label}
+    title={label}
   >
     <span className={active ? "text-paper-muted" : "text-paper-faint"}>{icon}</span>
-    <span className="hidden sm:inline">{label}</span>
+    {/* All five labels only fit a wide sidebar; below that keep the active one */}
+    <span className={cn("hidden @[36rem]:inline", active && "inline")}>{label}</span>
     {count !== undefined && count > 0 && (
       <span
         className={cn(
@@ -581,7 +584,7 @@ const DatabaseExplorer: React.FC = () => {
   }, []);
 
   return (
-    <div className="flex h-full flex-col bg-ink-50">
+    <div className="@container flex h-full flex-col bg-ink-50">
       {/* Tab navigation */}
       <div className="flex-shrink-0 border-b border-ink-500">
         <div className="flex items-center gap-0.5 overflow-x-auto px-2 py-2">
@@ -996,7 +999,7 @@ const DatabaseExplorer: React.FC = () => {
                       setHistoryStatusFilter("all");
                     }}
                   >
-                    <SelectTrigger className="h-7 w-[104px] rounded-xs border-ink-500 bg-ink-200 font-mono text-[11px] text-paper">
+                    <SelectTrigger className="h-7 w-[116px] shrink-0 rounded-xs border-ink-500 bg-ink-200 font-mono text-[11px] text-paper">
                       <SelectValue placeholder="All status" />
                     </SelectTrigger>
                     <SelectContent>


### PR DESCRIPTION
## Description

The explorer sidebar clipped its own controls. In the History tab a single long query stretched the panel far past the sidebar edge, and everything beyond it was cut off: the status filter, the Clear button, and the per-row delete buttons all disappeared, and query text never truncated.

Root cause: Radix's `ScrollArea` wraps viewport content in a `display: table` element (`min-width: 100%`), which is shrink-to-fit — `truncate` / `flex-1` children size to their **intrinsic** width instead of the viewport's. Measured in the running app, the content wrapper was **1537px inside a 428px viewport**, and since the viewport is `overflow-x: hidden` the overflow was clipped rather than scrollable.

A second, related overflow: the five sidebar tabs need 569px and never fit the default sidebar width, so **Queries** was pushed off-screen entirely.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Other (please describe):

## Related Issue

N/A — reported directly.

## Changes Made

- **`src/components/ui/scroll-area.tsx`** — force the Radix viewport's content wrapper to block layout (`[&>div]:block!`) so children stay at viewport width and `truncate` actually truncates. Comment explains why the override exists. This fixes every sidebar tab (History, Recent, Pinned, Queries), not just History, and the same latent issue in the other vertical scroll areas (`HomeTab`, `LiveQueries`, `StepPreview`).
- **`DataExplorer.tsx`** — status filter widened to 116px and `shrink-0`, so it reads "All status" instead of "All…".
- **`DataExplorer.tsx`** — sidebar panel is now an `@container`; below 36rem inactive tabs collapse to icon + count and only the active tab keeps its label, so all five tabs fit. Every tab also gained `aria-label` / `title` — previously icon-only tabs (below the `sm` breakpoint) had no accessible name at all.

## Testing

- [x] I have tested this locally
- [ ] I have added/updated tests
- [x] All existing tests pass

`bun run lint`, `bun run typecheck`, and `bunx vitest run src/features/explorer src/components` (85 tests) all pass. No test added: this is a CSS layout fix that jsdom cannot observe — jsdom does not do layout, so the clipping is invisible to it.

### Test Steps

1. `bun run dev`, log in as `admin` / `admin123!`, open `/explorer`.
2. Run a long query (or seed one) so query history has an entry with a wide single-line query.
3. Open the **History** tab in the sidebar.
   - Before: the connection filter runs past the sidebar edge, the status filter and Clear button are missing, query text is cut off mid-line, and hovering a row shows no delete button.
   - After: both filters and Clear fit, query text truncates with an ellipsis, and the delete button appears on hover inside the panel.
4. Narrow the window (or drag the sidebar) so the sidebar is under ~576px — all five tabs stay visible, inactive ones as icon + count.
5. Open ~12 workspace tabs and confirm the top tab bar still scrolls horizontally (this is the one horizontal `ScrollArea` in the app; verified `scrollWidth 1145 / clientWidth 756` with the scrollbar rendering).

## Screenshots

Not attached. The difference is reproducible in two clicks via the test steps above: before, the History tab's status filter, Clear button and per-row delete buttons are simply absent and query text runs off the edge; after, all of them are visible and query text ends in an ellipsis.

## Changelog Fragment

- [x] Added `changelogs/unreleased/324-explorer-sidebar-clipping.md` (`type: patch`)

## Checklist

- [x] My code follows the project's code style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have checked for breaking changes and documented them (if applicable)
- [x] I have tested the changes in the relevant environment (development/production)

## Additional Notes

The `ScrollArea` change is global by design — the table-layout wrapper broke `truncate` in every scroll area, and the sidebar was just where it showed first. The only horizontal scroll area (`WorkspaceTabs`) was checked explicitly and still scrolls.

Out of scope, spotted while verifying: `SavedQueryItem` in `DataExplorer.tsx` nests a delete `<button>` inside the row `<button>`, which is invalid HTML and logs a React error on every render of the Queries tab. Left alone here; worth a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
