### PR TITLE
revert: "fix: send X-Connection-Id from every client" (bypassed CI)

### DIFF
--- a/src/api/client.test.ts
+++ b/src/api/client.test.ts
@@ -1,6 +1,6 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach, beforeAll, afterAll } from 'vitest';
-import { ApiClient, setRbacTokens, clearRbacTokens, setSessionId, clearSession, clearConnectionId, connectionIdentityHeaders } from './client';
+import { ApiClient, setRbacTokens, clearRbacTokens, setSessionId, clearSession } from './client';
 import { server } from '../test/mocks/server';
 
 // Stop MSW integration for this test suite as we want to mock fetch directly
@@ -164,59 +164,5 @@ describe('ApiClient', () => {
         // Check logout dispatch
         expect(dispatchEventMock).toHaveBeenCalledWith(expect.any(CustomEvent));
         expect(dispatchEventMock.mock.calls[0][0].type).toBe('auth:unauthorized');
-    });
-});
-
-/**
- * ADR 0010 regression.
- *
- * The server fails closed on a request that names a session but no connection.
- * Several call sites build their own headers (this client, `rbacFetch`, the
- * query streaming fetch, the import upload); when one of them sent only
- * `X-Session-ID`, every request it made returned 409 CONNECTION_CONTEXT_STALE
- * with no way to recover by reloading. They all go through
- * `connectionIdentityHeaders` now — these tests pin its contract.
- */
-describe('connectionIdentityHeaders (ADR 0010)', () => {
-    beforeEach(() => {
-        localStorageMock.getItem.mockReset();
-        sessionStorageMock.getItem.mockReset();
-        clearConnectionId();
-        clearSession();
-        localStorageMock.removeItem.mockReset();
-    });
-
-    it('sends the connection id when one is stored', () => {
-        localStorageMock.getItem.mockImplementation((key: string) =>
-            key === 'ch_connection_id' ? 'conn-1' : null);
-        expect(connectionIdentityHeaders()['X-Connection-Id']).toBe('conn-1');
-    });
-
-    it('never sends a session id without a connection id', () => {
-        // The exact combination the server rejects. If a connection id is
-        // resolvable at all, it must accompany the session id.
-        localStorageMock.getItem.mockImplementation((key: string) =>
-            key === 'ch_connection_id' ? 'conn-1' : null);
-        sessionStorageMock.getItem.mockReturnValue('sess-1');
-        const headers = connectionIdentityHeaders();
-        expect(headers['X-Session-ID']).toBe('sess-1');
-        expect(headers['X-Connection-Id']).toBe('conn-1');
-    });
-
-    it('adopts activeConnectionId from a pre-upgrade persisted store', () => {
-        localStorageMock.getItem.mockImplementation((key: string) => {
-            if (key === 'ch_connection_id') return null;
-            if (key === 'connection-info-storage') {
-                return JSON.stringify({ state: { activeConnectionId: 'conn-legacy' }, version: 0 });
-            }
-            return null;
-        });
-        expect(connectionIdentityHeaders()['X-Connection-Id']).toBe('conn-legacy');
-    });
-
-    it('sends nothing when neither is known (JWT-only consumer)', () => {
-        localStorageMock.getItem.mockReturnValue(null);
-        sessionStorageMock.getItem.mockReturnValue(null);
-        expect(connectionIdentityHeaders()).toEqual({});
     });
 });

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -134,24 +134,6 @@ export function setConnectionId(id: string): void {
   }
 }
 
-/**
- * The identity headers every request to a connection-scoped route must carry.
- *
- * There are several HTTP call sites in this app (this client, `rbacFetch`, the
- * query streaming fetch, the import upload). They must agree, because the server
- * fails closed on a request that names a session but no connection — so a call
- * site that sets only `X-Session-ID` gets a 409 on every request. Build the
- * headers here rather than hand-rolling them per call site.
- */
-export function connectionIdentityHeaders(): Record<string, string> {
-  const headers: Record<string, string> = {};
-  const currentConnectionId = getConnectionId();
-  if (currentConnectionId) headers['X-Connection-Id'] = currentConnectionId;
-  const currentSessionId = getSessionId();
-  if (currentSessionId) headers['X-Session-ID'] = currentSessionId;
-  return headers;
-}
-
 export function clearConnectionId(): void {
   connectionId = null;
   try {
@@ -282,9 +264,18 @@ class ApiClient {
         ...customHeaders,
       };
 
-      // Which ClickHouse connection this request is for, plus the legacy
-      // session id (ADR 0010). Shared with every other call site.
-      Object.assign(headers as Record<string, string>, connectionIdentityHeaders());
+      // Add session ID if available
+      const currentSessionId = getSessionId();
+      if (currentSessionId) {
+        (headers as Record<string, string>)['X-Session-ID'] = currentSessionId;
+      }
+
+      // Which ClickHouse connection this request is for (ADR 0010). The server
+      // resolves and authorises it per request, so any replica can serve it.
+      const currentConnectionId = getConnectionId();
+      if (currentConnectionId) {
+        (headers as Record<string, string>)['X-Connection-Id'] = currentConnectionId;
+      }
 
       // Add RBAC access token if available
       const rbacToken = getRbacAccessToken();

--- a/src/api/query.ts
+++ b/src/api/query.ts
@@ -2,7 +2,7 @@
  * Query API
  */
 
-import { api, connectionIdentityHeaders, getRbacAccessToken } from './client';
+import { api, getSessionId, getRbacAccessToken } from './client';
 import { invokeAI, type QueryOptimization } from './ai';
 
 // ============================================
@@ -398,7 +398,8 @@ export async function executeQueryStream(
     "X-Requested-With": "XMLHttpRequest",
   };
 
-  Object.assign(headers, connectionIdentityHeaders());
+  const sessionId = getSessionId();
+  if (sessionId) headers["X-Session-ID"] = sessionId;
 
   const token = getRbacAccessToken();
   if (token) headers["Authorization"] = `Bearer ${token}`;

--- a/src/api/rbac.ts
+++ b/src/api/rbac.ts
@@ -7,7 +7,6 @@
 import {
   ApiError,
   getSessionId,
-  connectionIdentityHeaders,
   clearSession,
   setRbacTokens,
   getRbacAccessToken,
@@ -345,10 +344,8 @@ async function rbacFetch<T>(
 
   // Add session ID if available (for ClickHouse operations)
   // Only add if not already provided in options.headers
-  // ADR 0010: name the connection as well as the session, or connection-scoped
-  // routes fail closed with 409 CONNECTION_CONTEXT_STALE.
-  for (const [key, value] of Object.entries(connectionIdentityHeaders())) {
-    if (!headers[key]) headers[key] = value;
+  if (sessionId && !headers['X-Session-ID']) {
+    headers['X-Session-ID'] = sessionId;
   }
 
   const fetchOptions: RequestInit = {

--- a/src/features/admin/components/clickhouse/useChReconnect.ts
+++ b/src/features/admin/components/clickhouse/useChReconnect.ts
@@ -1,18 +1,15 @@
 /**
  * useChReconnect
  *
- * The ClickHouse management pages act on the connection the client names
- * (X-Connection-Id). Since ADR 0010 the server holds no session for it — the
- * connection is resolved and authorised from the database on every request — so
- * a backend restart no longer invalidates anything.
+ * The ClickHouse management pages talk to the active ClickHouse session
+ * (X-Session-ID). That session lives in server memory, so it's lost whenever the
+ * backend restarts or the session expires — after which every request fails with
+ * "ClickHouse session not found. Please reconnect." (code NO_SESSION). The stored
+ * session id on the client is now stale, so simply re-fetching (the refresh
+ * button) keeps failing.
  *
- * What can still fail: the stored connection id no longer resolves (the
- * connection was deleted, deactivated, or the user's access to it was revoked),
- * which the server reports as CONNECTION_CONTEXT_STALE rather than silently
- * answering from a different connection.
- *
- * This hook re-activates the last-used connection, which re-validates it and
- * refreshes the client's stored connection id — the real recovery.
+ * This hook re-activates the last-used connection, which mints a fresh server
+ * session and updates the client's X-Session-ID — the real recovery.
  */
 
 import { useCallback } from "react";

--- a/src/features/explorer/components/ImportWizard/ImportWizard.tsx
+++ b/src/features/explorer/components/ImportWizard/ImportWizard.tsx
@@ -1,4 +1,4 @@
-import { connectionIdentityHeaders, api } from '@/api/client';
+import { getSessionId, api } from '@/api/client';
 import React, { useState, useEffect } from 'react';
 import { DialogHeader, DialogTitle, DialogFooter } from '@/components/ui/dialog';
 import { ResponsiveDraggableDialog } from '@/components/common/ResponsiveDraggableDialog';
@@ -289,14 +289,17 @@ export function ImportWizard({ isOpen, onClose, database }: ImportWizardProps) {
                 }
             }
 
+            const session = getSessionId();
             const rbacToken = localStorage.getItem('rbac_access_token');
 
-            // ADR 0010: /api/upload/create resolves its connection from these
-            // headers now; the old x-clickhouse-session-id header is gone.
             const uploadHeaders: Record<string, string> = {
-                'X-Requested-With': 'XMLHttpRequest',
-                ...connectionIdentityHeaders(),
+                'X-Requested-With': 'XMLHttpRequest'
             };
+
+            if (session) {
+                uploadHeaders['x-clickhouse-session-id'] = session;
+                uploadHeaders['X-Session-ID'] = session;
+            }
 
             if (rbacToken) {
                 uploadHeaders['Authorization'] = `Bearer ${rbacToken}`;


### PR DESCRIPTION
## Description

Reverts `c04ac59`, which was pushed **directly to `preview`** and so bypassed branch protection — no pull request, and none of the 8 required status checks ran.

The change itself is correct and verified locally; this revert is purely about process. It is re-landed through a proper PR in #329, which is stacked on this branch and carries the identical diff.

> ⚠️ **Merge this and the re-land PR back to back.** Between the two merges, `preview` carries the ADR 0010 server change *without* the client fix — which is the state where `src/api/query.ts`, `rbacFetch` and the import upload all return `409 CONNECTION_CONTEXT_STALE` on every request. Don't cut a release from `preview` in that window.

## Type of Change

- [x] Other: process correction (revert of a direct push)

## Related Issue

Closes #

## Changes Made

Straight `git revert` of c04ac59. No manual edits — the re-land is a revert of this revert, so the two are exactly inverse.

## Testing

- [x] All existing tests pass

Nothing to test beyond CI: this restores `preview` to the state of `9987b9e`, which is the merge commit of #327.

## Changelog Fragment

Not applicable — the reverted commit is a bug fix for an unreleased change (#327), and its fragment travels with the re-land.

## Checklist

- [x] I have performed a self-review of my code
- [x] I have checked for breaking changes and documented them (if applicable)

## Additional Notes

The direct push was mine. `preview` had been checked out after #327 merged and I committed without re-checking the branch, so the push landed on a protected branch that reported "Bypassed rule violations". Flagging it rather than leaving it in history unexplained.

🤖 Generated with [Claude Code](https://claude.com/claude-code)