### PR TITLE
fix: send X-Connection-Id from every client, not just the API client

### DIFF
--- a/src/api/client.test.ts
+++ b/src/api/client.test.ts
@@ -1,6 +1,6 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach, beforeAll, afterAll } from 'vitest';
-import { ApiClient, setRbacTokens, clearRbacTokens, setSessionId, clearSession } from './client';
+import { ApiClient, setRbacTokens, clearRbacTokens, setSessionId, clearSession, clearConnectionId, connectionIdentityHeaders } from './client';
 import { server } from '../test/mocks/server';
 
 // Stop MSW integration for this test suite as we want to mock fetch directly
@@ -164,5 +164,59 @@ describe('ApiClient', () => {
         // Check logout dispatch
         expect(dispatchEventMock).toHaveBeenCalledWith(expect.any(CustomEvent));
         expect(dispatchEventMock.mock.calls[0][0].type).toBe('auth:unauthorized');
+    });
+});
+
+/**
+ * ADR 0010 regression.
+ *
+ * The server fails closed on a request that names a session but no connection.
+ * Several call sites build their own headers (this client, `rbacFetch`, the
+ * query streaming fetch, the import upload); when one of them sent only
+ * `X-Session-ID`, every request it made returned 409 CONNECTION_CONTEXT_STALE
+ * with no way to recover by reloading. They all go through
+ * `connectionIdentityHeaders` now — these tests pin its contract.
+ */
+describe('connectionIdentityHeaders (ADR 0010)', () => {
+    beforeEach(() => {
+        localStorageMock.getItem.mockReset();
+        sessionStorageMock.getItem.mockReset();
+        clearConnectionId();
+        clearSession();
+        localStorageMock.removeItem.mockReset();
+    });
+
+    it('sends the connection id when one is stored', () => {
+        localStorageMock.getItem.mockImplementation((key: string) =>
+            key === 'ch_connection_id' ? 'conn-1' : null);
+        expect(connectionIdentityHeaders()['X-Connection-Id']).toBe('conn-1');
+    });
+
+    it('never sends a session id without a connection id', () => {
+        // The exact combination the server rejects. If a connection id is
+        // resolvable at all, it must accompany the session id.
+        localStorageMock.getItem.mockImplementation((key: string) =>
+            key === 'ch_connection_id' ? 'conn-1' : null);
+        sessionStorageMock.getItem.mockReturnValue('sess-1');
+        const headers = connectionIdentityHeaders();
+        expect(headers['X-Session-ID']).toBe('sess-1');
+        expect(headers['X-Connection-Id']).toBe('conn-1');
+    });
+
+    it('adopts activeConnectionId from a pre-upgrade persisted store', () => {
+        localStorageMock.getItem.mockImplementation((key: string) => {
+            if (key === 'ch_connection_id') return null;
+            if (key === 'connection-info-storage') {
+                return JSON.stringify({ state: { activeConnectionId: 'conn-legacy' }, version: 0 });
+            }
+            return null;
+        });
+        expect(connectionIdentityHeaders()['X-Connection-Id']).toBe('conn-legacy');
+    });
+
+    it('sends nothing when neither is known (JWT-only consumer)', () => {
+        localStorageMock.getItem.mockReturnValue(null);
+        sessionStorageMock.getItem.mockReturnValue(null);
+        expect(connectionIdentityHeaders()).toEqual({});
     });
 });

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -134,6 +134,24 @@ export function setConnectionId(id: string): void {
   }
 }
 
+/**
+ * The identity headers every request to a connection-scoped route must carry.
+ *
+ * There are several HTTP call sites in this app (this client, `rbacFetch`, the
+ * query streaming fetch, the import upload). They must agree, because the server
+ * fails closed on a request that names a session but no connection — so a call
+ * site that sets only `X-Session-ID` gets a 409 on every request. Build the
+ * headers here rather than hand-rolling them per call site.
+ */
+export function connectionIdentityHeaders(): Record<string, string> {
+  const headers: Record<string, string> = {};
+  const currentConnectionId = getConnectionId();
+  if (currentConnectionId) headers['X-Connection-Id'] = currentConnectionId;
+  const currentSessionId = getSessionId();
+  if (currentSessionId) headers['X-Session-ID'] = currentSessionId;
+  return headers;
+}
+
 export function clearConnectionId(): void {
   connectionId = null;
   try {
@@ -264,18 +282,9 @@ class ApiClient {
         ...customHeaders,
       };
 
-      // Add session ID if available
-      const currentSessionId = getSessionId();
-      if (currentSessionId) {
-        (headers as Record<string, string>)['X-Session-ID'] = currentSessionId;
-      }
-
-      // Which ClickHouse connection this request is for (ADR 0010). The server
-      // resolves and authorises it per request, so any replica can serve it.
-      const currentConnectionId = getConnectionId();
-      if (currentConnectionId) {
-        (headers as Record<string, string>)['X-Connection-Id'] = currentConnectionId;
-      }
+      // Which ClickHouse connection this request is for, plus the legacy
+      // session id (ADR 0010). Shared with every other call site.
+      Object.assign(headers as Record<string, string>, connectionIdentityHeaders());
 
       // Add RBAC access token if available
       const rbacToken = getRbacAccessToken();

--- a/src/api/query.ts
+++ b/src/api/query.ts
@@ -2,7 +2,7 @@
  * Query API
  */
 
-import { api, getSessionId, getRbacAccessToken } from './client';
+import { api, connectionIdentityHeaders, getRbacAccessToken } from './client';
 import { invokeAI, type QueryOptimization } from './ai';
 
 // ============================================
@@ -398,8 +398,7 @@ export async function executeQueryStream(
     "X-Requested-With": "XMLHttpRequest",
   };
 
-  const sessionId = getSessionId();
-  if (sessionId) headers["X-Session-ID"] = sessionId;
+  Object.assign(headers, connectionIdentityHeaders());
 
   const token = getRbacAccessToken();
   if (token) headers["Authorization"] = `Bearer ${token}`;

--- a/src/api/rbac.ts
+++ b/src/api/rbac.ts
@@ -7,6 +7,7 @@
 import {
   ApiError,
   getSessionId,
+  connectionIdentityHeaders,
   clearSession,
   setRbacTokens,
   getRbacAccessToken,
@@ -344,8 +345,10 @@ async function rbacFetch<T>(
 
   // Add session ID if available (for ClickHouse operations)
   // Only add if not already provided in options.headers
-  if (sessionId && !headers['X-Session-ID']) {
-    headers['X-Session-ID'] = sessionId;
+  // ADR 0010: name the connection as well as the session, or connection-scoped
+  // routes fail closed with 409 CONNECTION_CONTEXT_STALE.
+  for (const [key, value] of Object.entries(connectionIdentityHeaders())) {
+    if (!headers[key]) headers[key] = value;
   }
 
   const fetchOptions: RequestInit = {

--- a/src/features/admin/components/clickhouse/useChReconnect.ts
+++ b/src/features/admin/components/clickhouse/useChReconnect.ts
@@ -1,15 +1,18 @@
 /**
  * useChReconnect
  *
- * The ClickHouse management pages talk to the active ClickHouse session
- * (X-Session-ID). That session lives in server memory, so it's lost whenever the
- * backend restarts or the session expires — after which every request fails with
- * "ClickHouse session not found. Please reconnect." (code NO_SESSION). The stored
- * session id on the client is now stale, so simply re-fetching (the refresh
- * button) keeps failing.
+ * The ClickHouse management pages act on the connection the client names
+ * (X-Connection-Id). Since ADR 0010 the server holds no session for it — the
+ * connection is resolved and authorised from the database on every request — so
+ * a backend restart no longer invalidates anything.
  *
- * This hook re-activates the last-used connection, which mints a fresh server
- * session and updates the client's X-Session-ID — the real recovery.
+ * What can still fail: the stored connection id no longer resolves (the
+ * connection was deleted, deactivated, or the user's access to it was revoked),
+ * which the server reports as CONNECTION_CONTEXT_STALE rather than silently
+ * answering from a different connection.
+ *
+ * This hook re-activates the last-used connection, which re-validates it and
+ * refreshes the client's stored connection id — the real recovery.
  */
 
 import { useCallback } from "react";

--- a/src/features/explorer/components/ImportWizard/ImportWizard.tsx
+++ b/src/features/explorer/components/ImportWizard/ImportWizard.tsx
@@ -1,4 +1,4 @@
-import { getSessionId, api } from '@/api/client';
+import { connectionIdentityHeaders, api } from '@/api/client';
 import React, { useState, useEffect } from 'react';
 import { DialogHeader, DialogTitle, DialogFooter } from '@/components/ui/dialog';
 import { ResponsiveDraggableDialog } from '@/components/common/ResponsiveDraggableDialog';
@@ -289,17 +289,14 @@ export function ImportWizard({ isOpen, onClose, database }: ImportWizardProps) {
                 }
             }
 
-            const session = getSessionId();
             const rbacToken = localStorage.getItem('rbac_access_token');
 
+            // ADR 0010: /api/upload/create resolves its connection from these
+            // headers now; the old x-clickhouse-session-id header is gone.
             const uploadHeaders: Record<string, string> = {
-                'X-Requested-With': 'XMLHttpRequest'
+                'X-Requested-With': 'XMLHttpRequest',
+                ...connectionIdentityHeaders(),
             };
-
-            if (session) {
-                uploadHeaders['x-clickhouse-session-id'] = session;
-                uploadHeaders['X-Session-ID'] = session;
-            }
 
             if (rbacToken) {
                 uploadHeaders['Authorization'] = `Bearer ${rbacToken}`;


### PR DESCRIPTION
## Description

Re-land of the client fix that #328 reverts, this time through a PR so the 8 required checks actually run.

**Stacked on `revert/connection-id-all-clients` (#328).** Merge #328 first; GitHub will retarget this to `preview` automatically. The diff shown here is the fix alone.

### The bug

ADR 0010 made the server fail closed on a request that names a session but no connection. The original PR (#327) updated only `src/api/client.ts` — three other call sites kept sending `X-Session-ID` alone:

| Call site | What broke |
|---|---|
| [`src/api/query.ts`](src/api/query.ts) | streaming query execution |
| [`src/api/rbac.ts`](src/api/rbac.ts) (`rbacFetch`) | every RBAC endpoint |
| [`ImportWizard.tsx`](src/features/explorer/components/ImportWizard/ImportWizard.tsx) | upload; also still sent the now-dead `x-clickhouse-session-id` |

Every request from those paths returned `409 CONNECTION_CONTEXT_STALE`. And because none of them has a 409 retry arm, **reloading never recovered** — the fail-closed path was only self-healing for the one client that had been updated. Reported symptom: "in explorer it makes me got `Your connection session is no longer valid on this server. Reconnecting…` always. Refresh doesn't work."

### Root cause of the miss

I audited the *server* consumers exhaustively and assumed a single frontend client. A `grep -rn "X-Session-ID" src` would have shown all four in seconds. That grep is now effectively encoded in the design: there is one helper, and the tests pin it.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issue

Closes #

## Changes Made

- New `connectionIdentityHeaders()` in `src/api/client.ts` — the single place that decides what identity headers a request carries. All four call sites use it.
- `rbacFetch` merges them without clobbering explicitly-passed headers, so `disconnect(sessionId)` / `getSessionStatus(sessionId)` keep their overrides and still gain the connection id.
- `ImportWizard` drops `x-clickhouse-session-id`; the server stopped reading it in #327.
- `useChReconnect`'s doc comment corrected — it still described the server-memory session #327 removed.

## Testing

- [x] I have tested this locally
- [x] I have added/updated tests
- [x] All existing tests pass

Reproduced and verified against a running instance (`bun run dev`, real ClickHouse), before and after:

```
/api/explorer/databases
  session only (what query.ts sent)  -> 409 CONNECTION_CONTEXT_STALE
  connection only                    -> 200 OK
  both (shared helper)               -> 200 OK
  neither (JWT-only consumer)        -> 200 OK

/api/query/execute-stream
  session only                       -> 409 CONNECTION_CONTEXT_STALE
  both (shared helper)               -> 200 OK
```

Explorer confirmed loading clean in the browser afterwards (4 DB / 172 TBL, tree populated, no error toast, all `/api/*` requests 200).

| Suite | Result |
|---|---|
| `bun run typecheck` | clean |
| `bun run lint` | clean |
| `vitest run --dir src` | 60 files / **566** tests pass (4 new) |

New tests in `src/api/client.test.ts` pin the helper's contract: sends the connection id when stored; never sends a session id without one when a connection id is resolvable; adopts `activeConnectionId` from a pre-upgrade persisted store; sends nothing when neither is known.

### Still outstanding from #327

The **PostgreSQL leg of the migration tests has never run** — Docker's VM is out of disk locally. It is unrelated to this diff, but it means #327's migrations reached `preview` without that coverage. Worth confirming CI exercised it.

### Test Steps

1. Open Explorer — the tree should populate with no error toast.
2. Run a query (exercises `query.ts` streaming, the worst-affected path).
3. Import a file via the Import Wizard (exercises the upload path).

## Changelog Fragment

- [ ] Not added — this fixes a regression in #327, which is unreleased. Its fragment (`327-multi-replica-pod-local-state.md`) already covers the feature; a separate entry would describe a bug users never saw in a release.

## Checklist

- [x] My code follows the project's code style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have checked for breaking changes and documented them (if applicable)
- [x] I have tested the changes in the relevant environment (development/production)

## Additional Notes

The one thing this episode argues *for*: the fail-closed design surfaced my bug in a day, as a specific error naming the exact condition. The behaviour it replaced would have quietly served the default connection's data instead — the original bug, undetected for months.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
