### PR TITLE
fix: store PAT scopes as JSONB on PostgreSQL

### DIFF
--- a/changelogs/unreleased/342-pat-postgres-scopes.md
+++ b/changelogs/unreleased/342-pat-postgres-scopes.md
@@ -1,0 +1,4 @@
+type: patch
+
+### Fixed
+- **Personal access tokens on PostgreSQL** — token creation failed with a 500 because `rbac_api_keys.scopes` was created as `TEXT[]` while the server maps it as JSONB. Migration `1.52.0` converts the column to JSONB (existing installs) and the snapshot now creates it correctly (fresh installs).

--- a/packages/server/src/rbac/db/migrations.test.ts
+++ b/packages/server/src/rbac/db/migrations.test.ts
@@ -299,6 +299,25 @@ const VERSION_CHECKS: Record<string, () => Promise<void>> = {
     expect(await h.indexExists("api_keys_hash_idx")).toBe(true);
     expect(await h.indexExists("api_keys_prefix_idx")).toBe(true);
   },
+  "1.52.0": async () => {
+    // PAT hotfix: scopes must store a JSON array on both dialects (PostgreSQL
+    // regressed to TEXT[] and rejected every insert). Functional round-trip
+    // with a probe row, cleaned up afterwards.
+    const userId = await insertUser(`pat-scopes-probe-${randomUUID().slice(0, 8)}`);
+    const probeId = randomUUID();
+    await h.rawRun(sql`INSERT INTO rbac_api_keys (id, user_id, name, key_hash, key_prefix, scopes)
+      VALUES (${probeId}, ${userId}, 'probe', ${`probe-hash-${probeId}`}, 'probe', ${'["table:select"]'})`);
+    try {
+      const rows = await h.rawAll(sql`SELECT scopes FROM rbac_api_keys WHERE id = ${probeId}`);
+      expect(rows.length).toBe(1);
+      // postgres-js parses jsonb to an array, sqlite returns the raw text.
+      const scopes = rows[0].scopes;
+      const text = Array.isArray(scopes) ? JSON.stringify(scopes) : String(scopes);
+      expect(text).toContain("table:select");
+    } finally {
+      await h.rawRun(sql`DELETE FROM rbac_api_keys WHERE id = ${probeId}`);
+    }
+  },
 };
 
 // ---------------------------------------------------------------------------

--- a/packages/server/src/rbac/db/migrations.ts
+++ b/packages/server/src/rbac/db/migrations.ts
@@ -45,7 +45,7 @@ export interface MigrationResult {
 // Current App Version
 // ============================================
 
-export const APP_VERSION = '1.51.0';
+export const APP_VERSION = '1.52.0';
 
 // ============================================
 // Error Helpers
@@ -4684,7 +4684,7 @@ export const MIGRATIONS: Migration[] = [
             name VARCHAR(100) NOT NULL,
             key_hash VARCHAR(255) NOT NULL UNIQUE,
             key_prefix VARCHAR(20) NOT NULL,
-            scopes TEXT[] NOT NULL DEFAULT '{}',
+            scopes JSONB NOT NULL DEFAULT '[]'::jsonb,
             expires_at TIMESTAMP WITH TIME ZONE,
             last_used_at TIMESTAMP WITH TIME ZONE,
             created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
@@ -4696,6 +4696,32 @@ export const MIGRATIONS: Migration[] = [
         await (db as PostgresDb).execute(sql`CREATE INDEX IF NOT EXISTS api_keys_prefix_idx ON rbac_api_keys(key_prefix)`);
       }
       logger.info({ module: 'RBAC', phase: 'migration' }, `[Migration 1.51.0] Ensured rbac_api_keys table (${dbType})`);
+    },
+    down: async () => { /* forward-only */ },
+  },
+  {
+    version: '1.52.0',
+    name: 'pat_api_keys_scopes_jsonb',
+    description: 'ADR 0011 hotfix — align the PostgreSQL rbac_api_keys.scopes column with the Drizzle schema (JSONB). The snapshot and 1.51.0 created it as TEXT[], so every PAT insert failed on PostgreSQL with a malformed-array error. No-op on SQLite (TEXT already matches the json-mode mapping).',
+    up: async (db) => {
+      const dbType = getDatabaseType();
+      if (dbType === 'sqlite') {
+        logger.info({ module: 'RBAC', phase: 'migration' }, '[Migration 1.52.0] SQLite scopes column already matches (no-op)');
+        return;
+      }
+      // The table can only contain the TEXT[] default ('{}') — PAT inserts never
+      // succeeded on PostgreSQL before this fix, so no real array data can exist.
+      await (db as PostgresDb).execute(sql`
+        ALTER TABLE rbac_api_keys ALTER COLUMN scopes DROP DEFAULT
+      `);
+      await (db as PostgresDb).execute(sql`
+        ALTER TABLE rbac_api_keys ALTER COLUMN scopes TYPE JSONB
+        USING (CASE WHEN scopes::text = '{}' THEN '[]'::jsonb ELSE scopes::text::jsonb END)
+      `);
+      await (db as PostgresDb).execute(sql`
+        ALTER TABLE rbac_api_keys ALTER COLUMN scopes SET DEFAULT '[]'::jsonb
+      `);
+      logger.info({ module: 'RBAC', phase: 'migration' }, `[Migration 1.52.0] Converted rbac_api_keys.scopes to JSONB (${dbType})`);
     },
     down: async () => { /* forward-only */ },
   },
@@ -5257,7 +5283,7 @@ async function createPostgresSchemaFromDrizzle(db: PostgresDb): Promise<void> {
     )
   `);
 
-  // API Keys table
+  // API Keys table (scopes is JSONB to match the Drizzle schema mapping)
   await db.execute(sql`
     CREATE TABLE IF NOT EXISTS rbac_api_keys (
       id TEXT PRIMARY KEY NOT NULL,
@@ -5265,7 +5291,7 @@ async function createPostgresSchemaFromDrizzle(db: PostgresDb): Promise<void> {
       name VARCHAR(100) NOT NULL,
       key_hash VARCHAR(255) NOT NULL UNIQUE,
       key_prefix VARCHAR(20) NOT NULL,
-      scopes TEXT[] NOT NULL DEFAULT '{}',
+      scopes JSONB NOT NULL DEFAULT '[]'::jsonb,
       expires_at TIMESTAMP WITH TIME ZONE,
       last_used_at TIMESTAMP WITH TIME ZONE,
       created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),


### PR DESCRIPTION
## Description

Hotfix for a 500 on `POST /api/rbac/pats` in production (PostgreSQL): `rbac_api_keys.scopes` was created as `TEXT[]` (snapshot helper + migration 1.51.0) while the Drizzle schema maps it as `jsonb`, so every PAT insert failed with a malformed-array-literal error. SQLite was unaffected (TEXT matches the json-mode mapping).

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issue

Production log: `createPat: token insert failed` → `Failed query: insert into "rbac_api_keys" … scopes … params: …"[\"users:view\",…]"` (JSON string into a `TEXT[]` column).

## Changes Made

- Migration `1.52.0 pat_api_keys_scopes_jsonb`: converts existing PG columns `TEXT[] → JSONB` (`USING CASE` maps the legacy `'{}'` default to `'[]'`; table was previously uninsertable on PG so no real array data can exist). No-op on SQLite. `APP_VERSION` → `1.52.0`.
- Snapshot helper + 1.51.0 PG branch now create `scopes JSONB DEFAULT '[]'::jsonb` (fresh installs correct going forward).
- `VERSION_CHECKS["1.52.0"]`: functional probe round-trip (insert JSON-array scopes → read back → delete) on both dialects.

## Testing

- [x] I have tested this locally
- [x] I have added/updated tests
- [x] All existing tests pass

### Test Steps
- `tsc --noEmit` + `eslint --max-warnings 0` clean
- Migration suite: 83 pass on SQLite incl. new 1.52.0 check on fresh/stepwise/skip paths (8 PG failures are the pre-existing DinD-localhost env limitation, identical on pristine tree)
- PAT unit tests: 25/25
- PG ALTERs executed verbatim against real `postgres:16-alpine`: legacy `TEXT[]` table converts (`'{}' → []`), JSON array inserts work, and the statements are safe no-ops when the column is already JSONB
- Post-merge verification in PRD: create a PAT via Preferences → expect 201 + one-time secret (previously 500)

## Screenshots

N/A

## Changelog Fragment

- [x] Added `changelogs/unreleased/342-pat-postgres-scopes.md`

## Checklist

- [x] My code follows the project's code style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have checked for breaking changes and documented them (forward-only migration; no API/shape changes)
- [x] I have tested the changes in the relevant environment (development/production)

## Additional Notes

- No data repair needed in PRD: PG inserts always failed, so affected tables are empty; 1.52.0 converts the type in place.
- If this merges with a different PR number, I will rename the changelog fragment accordingly.