### PR TITLE
feat(cli): installer wires PATH automatically

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -121,6 +121,9 @@ jobs:
       - name: Installer PATH wiring
         env:
           TEST_SHELL: ${{ matrix.test_shell }}
+          # Authenticated API quota (5000/hr) for `latest` cli-v* resolution;
+          # shared runner egress IPs exhaust the 60/hr anonymous quota.
+          GH_TOKEN: ${{ github.token }}
         run: |
           SANDBOX="$(mktemp -d)"
           export HOME="$SANDBOX/home"

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -85,10 +85,21 @@ jobs:
 
   installer-smoke:
     name: Installer Smoke
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     needs: test
     permissions:
       contents: read
+    strategy:
+      # macOS runners have no sha256sum (shasum only); pinning SHELL per OS
+      # covers both the zsh and bash rc-wiring paths deterministically.
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        include:
+          - os: ubuntu-latest
+            test_shell: /bin/bash
+          - os: macos-latest
+            test_shell: /bin/zsh
+      fail-fast: false
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -104,3 +115,49 @@ jobs:
           go build -o /tmp/chouse ./cmd/chouse
           /tmp/chouse version --output json || true
           /tmp/chouse --help | grep -q "Safe-by-default"
+
+      # Sandboxed HOME so the PATH-wiring assertions never touch the runner's
+      # real rc files. Installs the latest cli-v* prebuilt release.
+      - name: Installer PATH wiring
+        env:
+          TEST_SHELL: ${{ matrix.test_shell }}
+        run: |
+          SANDBOX="$(mktemp -d)"
+          export HOME="$SANDBOX/home"
+          mkdir -p "$HOME"
+          export SHELL="$TEST_SHELL"
+          export INSTALL_DIR="$HOME/.local/bin"
+          sh scripts/install-cli.sh
+          test -x "$INSTALL_DIR/chouse"
+          "$INSTALL_DIR/chouse" version --output json || true
+          # Second run must not duplicate the marker (idempotency).
+          # Mirror the installer's shell detection to know which rc files
+          # should carry the marker.
+          sh scripts/install-cli.sh >/dev/null 2>&1
+          SHELL_NAME="$(basename "${SHELL:-sh}")"
+          case "$SHELL_NAME" in
+            fish) FILES="$HOME/.config/fish/config.fish" ;;
+            zsh) FILES="$HOME/.zshrc" ;;
+            bash)
+              if [ -e "$HOME/.bash_profile" ]; then FILES="$HOME/.bashrc $HOME/.bash_profile";
+              else FILES="$HOME/.bashrc $HOME/.profile"; fi ;;
+            *) FILES="$HOME/.profile" ;;
+          esac
+          for f in $FILES; do
+            test "$(grep -cF '# chouse CLI (added by install-cli.sh)' "$f")" = "1"
+          done
+          # Every appended sh-syntax line must actually put chouse on PATH.
+          # (Sandbox HOME means these files contain only our block.)
+          for f in $FILES; do
+            case "$f" in
+              *.fish) continue ;;
+              *) env -i HOME="$HOME" PATH="/usr/bin:/bin" bash -c 'source "$0" && command -v chouse' "$f" | grep -q "chouse" ;;
+            esac
+          done
+          # Opt-out must leave rc files alone.
+          SANDBOX2="$(mktemp -d)"
+          HOME="$SANDBOX2/home" INSTALL_DIR="$SANDBOX2/home/.local/bin" CHOUSE_NO_MODIFY_PATH=1 sh scripts/install-cli.sh >/dev/null 2>&1
+          test ! -e "$SANDBOX2/home/.bashrc"
+          test ! -e "$SANDBOX2/home/.zshrc"
+          test ! -e "$SANDBOX2/home/.profile"
+          rm -rf "$SANDBOX" "$SANDBOX2"

--- a/changelogs/cli/unreleased/343-installer-auto-path.md
+++ b/changelogs/cli/unreleased/343-installer-auto-path.md
@@ -2,3 +2,4 @@ type: patch
 
 ### Fixed
 - **CLI installer PATH setup** — `install-cli.sh` now appends the install directory to your shell rc file automatically (`~/.bashrc`+`~/.profile`, `~/.zshrc`, or fish `config.fish`; opt out with `CHOUSE_NO_MODIFY_PATH=1`), falls back to `shasum` on stock macOS, and creates an explicit `INSTALL_DIR` when missing.
+- **CLI installer `latest` resolution** — scan the 100 newest releases for `cli-v*` tags so frequent app releases can no longer push the CLI off the lookup page.

--- a/changelogs/cli/unreleased/343-installer-auto-path.md
+++ b/changelogs/cli/unreleased/343-installer-auto-path.md
@@ -1,0 +1,4 @@
+type: patch
+
+### Fixed
+- **CLI installer PATH setup** — `install-cli.sh` now appends the install directory to your shell rc file automatically (`~/.bashrc`+`~/.profile`, `~/.zshrc`, or fish `config.fish`; opt out with `CHOUSE_NO_MODIFY_PATH=1`), falls back to `shasum` on stock macOS, and creates an explicit `INSTALL_DIR` when missing.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -14,6 +14,13 @@ curl -sSL https://github.com/daun-gatal/chouse-ui/releases/latest/download/insta
 CHOUSE_VERSION=cli-v0.2.0 curl -sSL …/install-cli.sh | bash
 ```
 
+The installer verifies `sha256sum` (or `shasum` on stock macOS),
+installs to `/usr/local/bin` (or `~/.local/bin` fallback), and wires
+`~/.local/bin` into your `PATH` via your shell rc file
+(`~/.bashrc`+`~/.profile`, `~/.zshrc`, or fish `config.fish`) —
+restart the shell or `source` the file afterwards. Opt out with
+`CHOUSE_NO_MODIFY_PATH=1`, override the destination with `INSTALL_DIR`.
+
 Or download `chouse-cli_<os>_<arch>.tar.gz` (+`.sig`/`.pem` cosign
 signature) + `checksums.txt` from a `cli-v*` GitHub Release — cut only when
 `cli/` changes, via `cli-release.yml` — verify

--- a/scripts/install-cli.sh
+++ b/scripts/install-cli.sh
@@ -1,10 +1,12 @@
 #!/usr/bin/env sh
 # chouse CLI installer: curl -sSL <release>/install-cli.sh | bash
-# Env: CHOUSE_VERSION (default: latest), INSTALL_DIR (default: /usr/local/bin or ~/.local/bin)
+# Env: CHOUSE_VERSION (default: latest), INSTALL_DIR (default: /usr/local/bin or ~/.local/bin),
+#      CHOUSE_NO_MODIFY_PATH=1 (default: unset — installer appends DEST to PATH in your shell rc files)
 set -eu
 
 REPO="${REPO:-daun-gatal/chouse-ui}"
 VERSION="${CHOUSE_VERSION:-latest}"
+MARKER="# chouse CLI (added by install-cli.sh)"
 
 detect_os_arch() {
   OS="$(uname -s | tr '[:upper:]' '[:lower:]')"
@@ -45,6 +47,76 @@ resolve_version() {
   fi
 }
 
+verify_checksums() {
+  # Stock macOS has no sha256sum (it ships shasum instead). Filter the
+  # manifest down to the downloaded asset so neither tool needs an
+  # "ignore missing entries" flag (shasum has none).
+  if ! grep -F "$ASSET" "$TMP/checksums.txt" > "$TMP/checksums.one" 2>/dev/null; then
+    echo "checksum entry for $ASSET not found in checksums.txt" >&2
+    exit 1
+  fi
+  if [ ! -s "$TMP/checksums.one" ]; then
+    echo "checksum entry for $ASSET not found in checksums.txt" >&2
+    exit 1
+  fi
+  if command -v sha256sum >/dev/null 2>&1; then
+    (cd "$TMP" && sha256sum -c "checksums.one" --status)
+  elif command -v shasum >/dev/null 2>&1; then
+    (cd "$TMP" && shasum -a 256 -c "checksums.one" --status)
+  else
+    echo "need sha256sum or shasum to verify checksums" >&2
+    exit 1
+  fi
+}
+
+add_path_block() {
+  # Idempotent: appends "<marker>\n<line>" to $1 unless the marker is there.
+  file="$1"
+  line="$2"
+  if [ -e "$file" ] && grep -qF "$MARKER" "$file" 2>/dev/null; then
+    return 0
+  fi
+  printf '%s\n%s\n' "$MARKER" "$line" >> "$file"
+  echo "Added $DEST to PATH in $file"
+}
+
+ensure_path() {
+  # DEST already visible — nothing to do.
+  case ":$PATH:" in
+    *":$DEST:"*) return 0 ;;
+  esac
+  if [ "${CHOUSE_NO_MODIFY_PATH:-}" = "1" ]; then
+    echo "Note: $DEST is not on PATH. Add: export PATH=\"$DEST:\$PATH\"" >&2
+    echo "      (automatic PATH setup skipped via CHOUSE_NO_MODIFY_PATH=1)" >&2
+    return 0
+  fi
+  SH_LINE="case \":\$PATH:\" in *\":$DEST:\"*) ;; *) export PATH=\"$DEST:\$PATH\" ;; esac"
+  SHELL_NAME="$(basename "${SHELL:-sh}" 2>/dev/null || echo sh)"
+  case "$SHELL_NAME" in
+    fish)
+      FISH_CFG="$HOME/.config/fish/config.fish"
+      mkdir -p "$HOME/.config/fish"
+      FISH_LINE="if not contains $DEST \$PATH; set -gx PATH $DEST \$PATH; end"
+      add_path_block "$FISH_CFG" "$FISH_LINE"
+      ;;
+    zsh)
+      add_path_block "$HOME/.zshrc" "$SH_LINE"
+      ;;
+    bash)
+      add_path_block "$HOME/.bashrc" "$SH_LINE"
+      if [ -e "$HOME/.bash_profile" ]; then
+        add_path_block "$HOME/.bash_profile" "$SH_LINE"
+      else
+        add_path_block "$HOME/.profile" "$SH_LINE"
+      fi
+      ;;
+    *)
+      add_path_block "$HOME/.profile" "$SH_LINE"
+      ;;
+  esac
+  echo "Restart your shell or run: export PATH=\"$DEST:\$PATH\"" >&2
+}
+
 main() {
   detect_os_arch
   resolve_version
@@ -55,7 +127,7 @@ main() {
   BASE="https://github.com/$REPO/releases/download/$TAG"
   curl -fsSL "$BASE/$ASSET" -o "$TMP/$ASSET"
   curl -fsSL "$BASE/checksums.txt" -o "$TMP/checksums.txt"
-  (cd "$TMP" && sha256sum -c "checksums.txt" --ignore-missing --status) || {
+  verify_checksums || {
     echo "checksum verification failed for $ASSET" >&2
     exit 1
   }
@@ -78,12 +150,10 @@ main() {
       mkdir -p "$DEST"
     fi
   fi
+  mkdir -p "$DEST"
   install -m 0755 "$BIN_SRC" "$DEST/chouse"
   echo "Installed $( "$DEST/chouse" version --output json 2>/dev/null || echo chouse ) to $DEST/chouse"
-  case ":$PATH:" in
-    *":$DEST:"*) ;;
-    *) echo "Note: $DEST is not on PATH. Add: export PATH=\"$DEST:\$PATH\"" >&2 ;;
-  esac
+  ensure_path
 }
 
 main "$@"

--- a/scripts/install-cli.sh
+++ b/scripts/install-cli.sh
@@ -35,7 +35,22 @@ resolve_version() {
   if [ "$VERSION" = "latest" ]; then
     # per_page=100 (API max): app vX releases are frequent and would push
     # cli-v* tags off a smaller first page, breaking `latest` resolution.
-    TAG="$(curl -fsSL "https://api.github.com/repos/$REPO/releases?per_page=100" 2>/dev/null | grep -o '"tag_name": *"cli-v[^"]*"' | head -n1 | cut -d'"' -f4 || true)"
+    # Token auth (GH_TOKEN/GITHUB_TOKEN, e.g. in CI) gets a 5000/hr quota
+    # instead of the shared 60/hr unauthenticated one; --retry rides out
+    # transient egress flakes. curl errors stay visible (no 2>/dev/null)
+    # so the next failure is diagnosable.
+    if [ -n "${GH_TOKEN:-}" ]; then
+      API_AUTH="Authorization: Bearer $GH_TOKEN"
+    elif [ -n "${GITHUB_TOKEN:-}" ]; then
+      API_AUTH="Authorization: Bearer $GITHUB_TOKEN"
+    else
+      API_AUTH=""
+    fi
+    if [ -n "$API_AUTH" ]; then
+      TAG="$(curl -fsSL --retry 3 --retry-all-errors -H "$API_AUTH" "https://api.github.com/repos/$REPO/releases?per_page=100" | grep -o '"tag_name": *"cli-v[^"]*"' | head -n1 | cut -d'"' -f4 || true)"
+    else
+      TAG="$(curl -fsSL --retry 3 --retry-all-errors "https://api.github.com/repos/$REPO/releases?per_page=100" | grep -o '"tag_name": *"cli-v[^"]*"' | head -n1 | cut -d'"' -f4 || true)"
+    fi
     if [ -z "${TAG:-}" ]; then
       echo "no cli-v* release found for $REPO" >&2
       exit 1

--- a/scripts/install-cli.sh
+++ b/scripts/install-cli.sh
@@ -33,7 +33,9 @@ resolve_version() {
   # the app ships vX tags with no CLI assets — so resolve against cli-v*
   # releases, never `releases/latest` (which follows the app).
   if [ "$VERSION" = "latest" ]; then
-    TAG="$(curl -fsSL "https://api.github.com/repos/$REPO/releases?per_page=20" 2>/dev/null | grep -o '"tag_name": *"cli-v[^"]*"' | head -n1 | cut -d'"' -f4 || true)"
+    # per_page=100 (API max): app vX releases are frequent and would push
+    # cli-v* tags off a smaller first page, breaking `latest` resolution.
+    TAG="$(curl -fsSL "https://api.github.com/repos/$REPO/releases?per_page=100" 2>/dev/null | grep -o '"tag_name": *"cli-v[^"]*"' | head -n1 | cut -d'"' -f4 || true)"
     if [ -z "${TAG:-}" ]; then
       echo "no cli-v* release found for $REPO" >&2
       exit 1


### PR DESCRIPTION
Installer now puts chouse on PATH out of the box (Linux/macOS, POSIX sh only).

- Auto-appends DEST to shell rc files (bash: ~/.bashrc+login file, zsh: ~/.zshrc, fish: config.fish, fallback: ~/.profile), idempotent via marker, opt-out with CHOUSE_NO_MODIFY_PATH=1
- sha256sum -> shasum -a 256 fallback for stock macOS (filtered single-entry manifest, shasum has no --ignore-missing)
- mkdir -p DEST (explicit INSTALL_DIR no longer fails on missing dir)
- No sudo, no new files, no Windows script (per scope)

Test evidence (sandboxed HOME, 15/15 + default-dest + SHELL-unset paths green):
- fresh bash install: binary + .bashrc/.profile markers, login shell resolves chouse
- idempotency: markers exactly once after re-run; sourced rc puts chouse on PATH
- opt-out: no rc files, skip note printed
- dest-on-PATH: no rc edits; zsh/fish routing correct; shasum verifies manifest format
- CI: installer-smoke matrix ubuntu+macos with pinned TEST_SHELL covers bash/zsh + shasum paths