### PR TITLE
fix(cli): auth login persists server to profile

### DIFF
--- a/changelogs/cli/unreleased/345-login-persists-server.md
+++ b/changelogs/cli/unreleased/345-login-persists-server.md
@@ -1,0 +1,4 @@
+type: patch
+
+### Fixed
+- **CLI `auth login` remembers the server** — `--server` is now saved to your profile (`~/.config/chouse/config.yaml`), so `auth status` and all commands work in fresh shells with no environment set. Env-provided values stay session-scoped and are never written to disk; `--profile` also switches the current profile.

--- a/cli/internal/cli/auth.go
+++ b/cli/internal/cli/auth.go
@@ -38,6 +38,12 @@ func newAuthCmd() *cobra.Command {
 			if err := config.SaveCredentials(resolved.Profile, token); err != nil {
 				fail(api.ExitServer, err.Error())
 			}
+			// Remember explicitly-passed setup: the server for this profile, and
+			// the profile itself as current. Env-derived values stay
+			// session-scoped and are never written to disk.
+			if err := config.SaveProfile(resolved.Profile, flagServer, flagProfile != ""); err != nil {
+				fail(api.ExitUsage, err.Error())
+			}
 			fmt.Fprintf(os.Stderr, "stored PAT for profile %q (masked %s)\n", resolved.Profile, config.MaskToken(token))
 		},
 	}

--- a/cli/internal/config/config.go
+++ b/cli/internal/config/config.go
@@ -157,6 +157,37 @@ func SaveCredentials(profile, token string) error {
 	return os.WriteFile(filepath.Join(dir, "credentials.yaml"), raw, 0o600)
 }
 
+// SaveProfile merges non-secret profile settings into config.yaml without
+// touching stored tokens (those live in credentials.yaml). Empty server
+// leaves any existing value alone — it never clears. makeCurrent switches
+// CurrentProfile (used when --profile was explicitly passed at login).
+func SaveProfile(profile, server string, makeCurrent bool) error {
+	if strings.TrimSpace(profile) == "" {
+		return errors.New("profile must not be empty")
+	}
+	dir, err := Dir(true)
+	if err != nil {
+		return err
+	}
+	cfg, err := LoadFile()
+	if err != nil {
+		return err
+	}
+	p := cfg.Profiles[profile]
+	if strings.TrimSpace(server) != "" {
+		p.Server = strings.TrimRight(strings.TrimSpace(server), "/")
+	}
+	cfg.Profiles[profile] = p
+	if makeCurrent {
+		cfg.CurrentProfile = profile
+	}
+	raw, err := yaml.Marshal(cfg)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(dir, "config.yaml"), raw, 0o600)
+}
+
 // DeleteCredentials removes the stored token for a profile.
 func DeleteCredentials(profile string) error {
 	creds, err := LoadCredentials()

--- a/cli/internal/config/config_test.go
+++ b/cli/internal/config/config_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -99,6 +100,72 @@ func TestRequireServer(t *testing.T) {
 	r.Server = "http://host:5521"
 	if err := r.RequireServer(); err != nil {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestSaveProfile(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	// Set with makeCurrent: creates entry, switches current, 0600 file.
+	if err := SaveProfile("default", "https://host:5521/", true); err != nil {
+		t.Fatalf("SaveProfile: %v", err)
+	}
+	cfg, err := LoadFile()
+	if err != nil {
+		t.Fatalf("LoadFile: %v", err)
+	}
+	if cfg.Profiles["default"].Server != "https://host:5521" {
+		t.Fatalf("server not persisted (trailing slash must be trimmed): %+v", cfg.Profiles["default"])
+	}
+	if cfg.CurrentProfile != "default" {
+		t.Fatalf("current profile not switched: %q", cfg.CurrentProfile)
+	}
+	info, err := os.Stat(filepath.Join(home, ".config", "chouse", "config.yaml"))
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Fatalf("config file must be 0600, got %o", info.Mode().Perm())
+	}
+
+	// Merge: empty server preserves, other profiles and current untouched,
+	// tokens file untouched (secrets never land in config.yaml).
+	if err := SaveCredentials("default", "ch_pat_secret"); err != nil {
+		t.Fatalf("SaveCredentials: %v", err)
+	}
+	if err := SaveProfile("other", "https://other:5521", false); err != nil {
+		t.Fatalf("SaveProfile other: %v", err)
+	}
+	if err := SaveProfile("default", "", false); err != nil {
+		t.Fatalf("SaveProfile empty: %v", err)
+	}
+	cfg, err = LoadFile()
+	if err != nil {
+		t.Fatalf("LoadFile: %v", err)
+	}
+	if cfg.Profiles["default"].Server != "https://host:5521" {
+		t.Fatalf("empty save must preserve server: %+v", cfg.Profiles["default"])
+	}
+	if cfg.Profiles["other"].Server != "https://other:5521" {
+		t.Fatalf("other profile lost: %+v", cfg.Profiles)
+	}
+	if cfg.CurrentProfile != "default" {
+		t.Fatalf("current profile must be preserved: %q", cfg.CurrentProfile)
+	}
+	raw, err := os.ReadFile(filepath.Join(home, ".config", "chouse", "config.yaml"))
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	if strings.Contains(string(raw), "ch_pat_secret") {
+		t.Fatal("token must never be written to config.yaml")
+	}
+	creds, err := LoadCredentials()
+	if err != nil {
+		t.Fatalf("LoadCredentials: %v", err)
+	}
+	if creds.Tokens["default"] != "ch_pat_secret" {
+		t.Fatal("SaveProfile must not disturb credentials.yaml")
 	}
 }
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -45,7 +45,9 @@ chouse auth logout
 There is no implicit server default: without `--server`, `CHOUSE_SERVER`,
 or a profile server, server-bound commands fail fast telling you how to
 configure one. `chouse version` is always offline (binary version only);
-`chouse status` reports the server version.
+`chouse status` reports the server version. `auth login --server …` remembers
+the server in your profile, so you only pass it once (env stays
+session-scoped and is never written to disk).
 
 Precedence: `--token > CH_HOUSE_PAT > credentials file (0600) > --profile`.
 `--server`: flag > `CHOUSE_SERVER` > profile. `--connection/-c`: flag >

--- a/scripts/e2e-cli-check.py
+++ b/scripts/e2e-cli-check.py
@@ -74,12 +74,15 @@ def cli(*args, pat=True, env_extra=None, stdin_text=None):
     return proc
 
 
-def cli_scrubbed(*args, stdin_text=None):
-    """Run with no server/PAT/config: fresh HOME, empty server (empty string
-    resolves as unset), no token. Proves nothing talks to a phantom default.
+def cli_scrubbed(*args, home=None, stdin_text=None):
+    """Run with no server/PAT/config: fresh (or given) HOME, empty server
+    (empty string resolves as unset), no token. Proves nothing talks to a
+    phantom default. Pass home= to share state across calls (e.g. login
+    persistence); otherwise each call gets an isolated HOME.
     """
     import tempfile as _tf  # noqa: E402
-    home = _tf.mkdtemp(prefix="chouse-e2e-nohome-")
+    if home is None:
+        home = _tf.mkdtemp(prefix="chouse-e2e-nohome-")
     env = dict(os.environ)
     env["HOME"] = home
     env["CHOUSE_SERVER"] = ""
@@ -362,6 +365,22 @@ def t_auth_status_unconfigured():
     assert "(not configured)" in p.stdout, p.stdout[-300:]
 
 
+def t_login_persists_server():
+    # login --server/--token once, then everything works with zero env:
+    # server AND token both come from disk.
+    import tempfile as _tf  # noqa: E402
+    home = _tf.mkdtemp(prefix="chouse-e2e-login-")
+    out = need(cli_scrubbed("auth", "login", "--server", BASE,
+                            "--token", STATE["pat"], home=home))
+    assert "stored PAT" in out, out[-300:]
+    out = need(cli_scrubbed("auth", "status", "--output", "json", home=home))
+    data = json.loads(out)
+    assert data["server"] == BASE, out[-300:]
+    assert STATE["pat"] not in out, "raw PAT must never render"
+    out = need(cli_scrubbed("auth", "whoami", "--output", "json", home=home))
+    assert "admin" in out, out[-300:]
+
+
 def t_cleanup_writes():
     need(cli("query", "--raw", "--yes", f"DROP TABLE IF EXISTS {DB}.t"))
     need(cli("query", "--raw", "--yes", f"DROP DATABASE IF EXISTS {DB}"))
@@ -414,6 +433,7 @@ def main():
         ("cli-version-offline", t_version_offline),
         ("cli-no-server-fail-fast", t_no_server_fail_fast),
         ("cli-auth-status-unconfigured", t_auth_status_unconfigured),
+        ("cli-login-persists-server", t_login_persists_server),
         ("cli-cleanup-writes", t_cleanup_writes),
         ("cli-cleanup-identity", t_cleanup_identity),
     ]:

--- a/scripts/e2e-cli-check.py
+++ b/scripts/e2e-cli-check.py
@@ -370,9 +370,10 @@ def t_login_persists_server():
     # server AND token both come from disk.
     import tempfile as _tf  # noqa: E402
     home = _tf.mkdtemp(prefix="chouse-e2e-login-")
-    out = need(cli_scrubbed("auth", "login", "--server", BASE,
-                            "--token", STATE["pat"], home=home))
-    assert "stored PAT" in out, out[-300:]
+    p = cli_scrubbed("auth", "login", "--server", BASE,
+                     "--token", STATE["pat"], home=home)
+    need(p)
+    assert "stored PAT" in p.stderr, p.stderr[-300:]
     out = need(cli_scrubbed("auth", "status", "--output", "json", home=home))
     data = json.loads(out)
     assert data["server"] == BASE, out[-300:]


### PR DESCRIPTION
## Description

`auth login --server X --token Y` validated against X but saved only the token — every fresh shell then showed `server: (not configured)` and all commands failed. Login now persists explicitly-passed setup (`--server`, current profile on `--profile`) to `~/.config/chouse/config.yaml`.

## Type of Change

- [x] Bug fix (login setup did not stick across shells)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Related Issue

Closes #

## Changes Made

- `cli/internal/config/config.go`: new `SaveProfile()` — merges server/current-profile into `config.yaml` (0600), never clears existing values, never touches tokens.
- `cli/internal/cli/auth.go`: `login` saves profile setup post-validation (flags only; env stays session-scoped); failed logins persist nothing.
- `cli/internal/config/config_test.go`: `TestSaveProfile` (merge/preserve/perms/no-token-in-config).
- `scripts/e2e-cli-check.py`: `cli_scrubbed()` gains shared-`home`; new `t_login_persists_server` (login once with flags, then status+whoami work with zero env).
- `docs/cli.md`: server-remembered note.

## Testing

- [x] I have tested this locally
- [x] I have added/updated tests
- [x] All existing tests pass

### Test Steps

- `gofmt -l` clean, `go vet`, `go test -count=1 ./...` green (`-race` via CI).
- Scrubbed-HOME probes: bare login \u2192 exit 2 + zero files written; unreachable server \u2192 validation error + zero files written.
- Full `./scripts/e2e-cli.sh` DinD run (results below).

## Screenshots

N/A.

## Changelog Fragment

- [ ] Added `changelogs/cli/unreleased/<pr-number>-login-persists-server.md` (adding after PR number is known)

## Checklist

- [x] My code follows the project's code style guidelines
- [x] I have performed a self-review (`.rules/CODE_REVIEWER.md`)
- [x] Changes generate no new warnings or errors
- [x] No breaking changes (explicit flags/env/file behavior unchanged; only previously-discarded values now persist)
- [x] Touched files scanned for dead code (`.rules/DEAD_CODE.md`)

## Additional Notes

Follow-up to #344 (offline version, explicit server). `--connection` deliberately not persisted (discovered post-login; future `connection use`).