### PR TITLE
CLI correctness pass: honest flags, safe dry-run, consistent output

### DIFF
--- a/changelogs/cli/unreleased/346-cli-correctness-pass.md
+++ b/changelogs/cli/unreleased/346-cli-correctness-pass.md
@@ -1,0 +1,12 @@
+type: minor
+
+### Fixed
+- **CLI flags work as advertised everywhere** — `--dry-run` previews standalone and fails fast where unsupported (it can no longer silently execute with `--yes`); `-c`/`--connection` is one flag on all commands; `auth login`/`logout` honor `-o`; `--timeout` applies above 60s; confirm prompts go to stderr.
+- **CLI table output contract** — nested values render as compact JSON cells; maps with scalar or nested `data` fields keep all columns; `-q` means machine (JSON) mode.
+
+### Removed
+- **CLI `--no-color`** — it never controlled anything (output is always plain); passing it now errors like any unknown flag.
+
+### Changed
+- **CLI `ai optimize` and `connection use` now need `--yes`** outside a TTY (LLM spend and server-side state change, matching every other mutation).
+- **CLI `auth login` prints machine-readable `{profile, server}`** on stdout honoring `-o` (human note stays on stderr).

--- a/changelogs/cli/unreleased/346-cli-help.md
+++ b/changelogs/cli/unreleased/346-cli-help.md
@@ -1,0 +1,4 @@
+type: minor
+
+### Added
+- **CLI `--help` guidance everywhere** — all 83 commands now carry a Long description plus runnable real-world examples (`system.numbers` queries, proven flag combos, fake ids that 404 instead of destroying). A completeness test fails the build if any future command ships without them.

--- a/changelogs/unreleased/346-query-max-rows.md
+++ b/changelogs/unreleased/346-query-max-rows.md
@@ -1,0 +1,4 @@
+type: patch
+
+### Fixed
+- **Query row cap honored everywhere** — `POST /query/table/select` dropped the validated `maxResultRows` field, so `--limit` had no effect on the default read path. The cap is now passed through and additionally enforced server-side (truncation), since recent ClickHouse builds ignore small `max_result_rows` values.

--- a/cli/internal/cli/alert_ai.go
+++ b/cli/internal/cli/alert_ai.go
@@ -7,12 +7,24 @@ import (
 )
 
 func newAlertCmd() *cobra.Command {
-	cmd := &cobra.Command{Use: "alert", Short: "Alert channels, rules, events (reads; writes guarded)"}
+	cmd := &cobra.Command{
+		Use:   "alert",
+		Short: "Alert channels, rules, events (reads; writes guarded)",
+		Long: `Inspect alerting configuration and history. Listing is free;
+sending a test delivery is a side effect and needs --yes.`,
+		Example: `  chouse alert channels
+  chouse alert rules -o json
+  chouse alert events --limit 5
+  chouse alert test ch_abc123 --yes`,
+	}
 	var limit int
 
 	channels := &cobra.Command{
 		Use:   "channels",
 		Short: "List notification channels (secrets masked)",
+		Long:  `List notification channels. Secrets stay masked server-side — safe to print anywhere.`,
+		Example: `  chouse alert channels
+  chouse alert channels -o json`,
 		Run: func(_ *cobra.Command, _ []string) {
 			c, resolved := mustClient(true)
 			ctx, cancel := ctxWithTimeout()
@@ -27,6 +39,9 @@ func newAlertCmd() *cobra.Command {
 	rules := &cobra.Command{
 		Use:   "rules",
 		Short: "List alert rules",
+		Long:  `List alert rules with their conditions and targets. Read-only — rule edits stay in the browser.`,
+		Example: `  chouse alert rules
+  chouse alert rules -o json`,
 		Run: func(_ *cobra.Command, _ []string) {
 			c, resolved := mustClient(true)
 			ctx, cancel := ctxWithTimeout()
@@ -41,6 +56,9 @@ func newAlertCmd() *cobra.Command {
 	events := &cobra.Command{
 		Use:   "events",
 		Short: "List alert events",
+		Long:  `List recent alert deliveries, newest first, capped at --limit. Start here when a notification didn't arrive.`,
+		Example: `  chouse alert events --limit 5
+  chouse alert events -o json`,
 		Run: func(_ *cobra.Command, _ []string) {
 			c, resolved := mustClient(true)
 			ctx, cancel := ctxWithTimeout()
@@ -60,7 +78,12 @@ func newAlertCmd() *cobra.Command {
 	test := &cobra.Command{
 		Use:   "test <channelId>",
 		Short: "Send a test delivery (side-effect)",
-		Args:  cobra.ExactArgs(1),
+		Long: `Send a real test delivery through a channel. People get paged —
+needs --yes outside a TTY like any side effect. Verify the channel id with
+alert channels first.`,
+		Example: `  chouse alert channels
+  chouse alert test ch_abc123 --yes`,
+		Args: cobra.ExactArgs(1),
 		Run: func(_ *cobra.Command, args []string) {
 			rejectDryRun("alert test")
 			confirmDestructive("alert.test", args[0])
@@ -80,13 +103,28 @@ func newAlertCmd() *cobra.Command {
 }
 
 func newAICmd() *cobra.Command {
-	cmd := &cobra.Command{Use: "ai", Short: "Read-only AI analysis (LLM cost applies)"}
+	cmd := &cobra.Command{
+		Use:   "ai",
+		Short: "Read-only AI analysis (LLM cost applies)",
+		Long: `LLM-powered SQL analysis: optimize or diagnose statements, list
+capabilities and models. Reading lists is free; optimize invokes a model
+(LLM spend) and needs --yes like any costly action. Feed SQL as args, -f,
+or --stdin.`,
+		Example: `  chouse ai capabilities
+  chouse ai optimize -f slow.sql --yes
+  echo "SELECT * FROM big" | chouse ai optimize --stdin --yes -o json`,
+	}
 	var file, model, capability string
 	var stdin bool
 
 	optimize := &cobra.Command{
-		Use:   "optimize",
+		Use:   "optimize [sql]",
 		Short: "Optimize or diagnose SQL (advisory only, LLM cost applies)",
+		Long: `Ask the model to optimize or diagnose SQL. Advisory only — it
+prints suggestions, never executes. Invokes a model (LLM spend), so it needs
+--yes outside a TTY. Feed SQL as args, -f file, or --stdin.`,
+		Example: `  chouse ai optimize "SELECT * FROM big WHERE day = today()" --yes
+  chouse ai optimize -f slow.sql --model m_abc --yes -o json`,
 		Run: func(_ *cobra.Command, args []string) {
 			rejectDryRun("ai optimize")
 			confirmDestructive("ai.optimize", "sql")
@@ -113,6 +151,9 @@ func newAICmd() *cobra.Command {
 	caps := &cobra.Command{
 		Use:   "capabilities",
 		Short: "List AI capabilities and your access",
+		Long:  `List what the AI backend can do for your token (optimize-query, debug-query, …). Free and read-only.`,
+		Example: `  chouse ai capabilities
+  chouse ai capabilities -o json`,
 		Run: func(_ *cobra.Command, _ []string) {
 			c, resolved := mustClient(true)
 			ctx, cancel := ctxWithTimeout()
@@ -127,6 +168,9 @@ func newAICmd() *cobra.Command {
 	models := &cobra.Command{
 		Use:   "models",
 		Short: "List active AI models (no secrets)",
+		Long:  `List active AI models and the default. No secrets, free to call — pick an id for optimize --model.`,
+		Example: `  chouse ai models
+  chouse ai models -o json`,
 		Run: func(_ *cobra.Command, _ []string) {
 			c, resolved := mustClient(true)
 			ctx, cancel := ctxWithTimeout()

--- a/cli/internal/cli/alert_ai.go
+++ b/cli/internal/cli/alert_ai.go
@@ -62,6 +62,7 @@ func newAlertCmd() *cobra.Command {
 		Short: "Send a test delivery (side-effect)",
 		Args:  cobra.ExactArgs(1),
 		Run: func(_ *cobra.Command, args []string) {
+			rejectDryRun("alert test")
 			confirmDestructive("alert.test", args[0])
 			c, resolved := mustClient(true)
 			ctx, cancel := ctxWithTimeout()
@@ -85,8 +86,10 @@ func newAICmd() *cobra.Command {
 
 	optimize := &cobra.Command{
 		Use:   "optimize",
-		Short: "Optimize or diagnose SQL (advisory only)",
+		Short: "Optimize or diagnose SQL (advisory only, LLM cost applies)",
 		Run: func(_ *cobra.Command, args []string) {
+			rejectDryRun("ai optimize")
+			confirmDestructive("ai.optimize", "sql")
 			c, resolved := mustClient(true)
 			sql := readSQLInput(file, stdin, args)
 			ctx, cancel := ctxWithTimeout()

--- a/cli/internal/cli/auth.go
+++ b/cli/internal/cli/auth.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -30,6 +31,7 @@ func newAuthCmd() *cobra.Command {
 				fail(api.ExitUsage, "pass --token ch_pat_… or set CH_HOUSE_PAT (mint once in the UI: Preferences → Personal access tokens)")
 			}
 			c := api.New(resolved.Server, token, resolved.Connection)
+			c.HTTP.Timeout = time.Duration(timeoutSecs()) * time.Second
 			ctx, cancel := ctxWithTimeout()
 			defer cancel()
 			if _, err := c.Validate(ctx); err != nil {
@@ -44,7 +46,10 @@ func newAuthCmd() *cobra.Command {
 			if err := config.SaveProfile(resolved.Profile, flagServer, flagProfile != ""); err != nil {
 				fail(api.ExitUsage, err.Error())
 			}
-			fmt.Fprintf(os.Stderr, "stored PAT for profile %q (masked %s)\n", resolved.Profile, config.MaskToken(token))
+			if !flagQuiet {
+				fmt.Fprintf(os.Stderr, "stored PAT for profile %q (masked %s)\n", resolved.Profile, config.MaskToken(token))
+			}
+			render(resolved, map[string]any{"profile": resolved.Profile, "server": resolved.Server})
 		},
 	}
 	login.Flags().StringVar(&tokenFlag, "token", "", "PAT value (or CH_HOUSE_PAT)")
@@ -93,7 +98,10 @@ func newAuthCmd() *cobra.Command {
 			if err := config.DeleteCredentials(resolved.Profile); err != nil {
 				fail(api.ExitServer, err.Error())
 			}
-			fmt.Fprintf(os.Stderr, "removed PAT for profile %q\n", resolved.Profile)
+			if !flagQuiet {
+				fmt.Fprintf(os.Stderr, "removed PAT for profile %q\n", resolved.Profile)
+			}
+			render(resolved, map[string]any{"profile": resolved.Profile, "removed": true})
 		},
 	}
 

--- a/cli/internal/cli/auth.go
+++ b/cli/internal/cli/auth.go
@@ -12,12 +12,27 @@ import (
 )
 
 func newAuthCmd() *cobra.Command {
-	cmd := &cobra.Command{Use: "auth", Short: "Authenticate with a personal access token"}
+	cmd := &cobra.Command{
+		Use:   "auth",
+		Short: "Authenticate with a personal access token",
+		Long: `Manage the personal access token (PAT) this CLI uses. Tokens are
+stored 0600 in ~/.config/chouse/credentials.yaml and never printed (only a
+masked form). Log in once per profile; every other command then just works.`,
+		Example: `  chouse auth login --server https://chouse.corp:5521 --token ch_pat_…
+  chouse auth status
+  chouse auth whoami -o json`,
+	}
 	var tokenFlag, patAlias string
 
 	login := &cobra.Command{
 		Use:   "login",
 		Short: "Store a PAT locally (0600)",
+		Long: `Validate a personal access token against the server and store it
+for the profile, remembering --server (and --profile as current) so later
+commands need no flags. Prints a machine result honoring -o. Mint the token
+once in the UI: Preferences → Personal access tokens.`,
+		Example: `  chouse auth login --server https://chouse.corp:5521 --token ch_pat_…
+  chouse auth login --server https://chouse.corp:5521 --token ch_pat_… --profile prod -o json`,
 		Run: func(_ *cobra.Command, _ []string) {
 			_, resolved := mustClient(false)
 			token := tokenFlag
@@ -59,6 +74,10 @@ func newAuthCmd() *cobra.Command {
 	status := &cobra.Command{
 		Use:   "status",
 		Short: "Show effective profile without printing secrets",
+		Long: `Show the resolved profile, server, connection, and masked token —
+fully offline, safe to run any time to check what later commands will use.`,
+		Example: `  chouse auth status
+  chouse auth status -o json`,
 		Run: func(_ *cobra.Command, _ []string) {
 			resolved := mustConfig()
 			server := resolved.Server
@@ -78,6 +97,11 @@ func newAuthCmd() *cobra.Command {
 	whoami := &cobra.Command{
 		Use:   "whoami",
 		Short: "Show live user, roles, and permissions",
+		Long: `Ask the server who the configured token belongs to, including
+roles and data-access rules. Needs a server and a token; fails closed
+otherwise.`,
+		Example: `  chouse auth whoami
+  chouse auth whoami -o json`,
 		Run: func(_ *cobra.Command, _ []string) {
 			c, resolved := mustClient(true)
 			ctx, cancel := ctxWithTimeout()
@@ -93,6 +117,10 @@ func newAuthCmd() *cobra.Command {
 	logout := &cobra.Command{
 		Use:   "logout",
 		Short: "Remove the locally stored PAT",
+		Long: `Delete the stored token for the profile from this machine only.
+The server-side token stays valid — revoke it in the UI to fully retire it.`,
+		Example: `  chouse auth logout
+  chouse auth logout --profile prod -o json`,
 		Run: func(_ *cobra.Command, _ []string) {
 			resolved := mustConfig()
 			if err := config.DeleteCredentials(resolved.Profile); err != nil {

--- a/cli/internal/cli/connection.go
+++ b/cli/internal/cli/connection.go
@@ -65,6 +65,8 @@ func newConnectionCmd() *cobra.Command {
 		Short: "Verify access to a connection (prints correlation session)",
 		Args:  cobra.ExactArgs(1),
 		Run: func(_ *cobra.Command, args []string) {
+			rejectDryRun("connection use")
+			confirmDestructive("connection.use", args[0])
 			c, resolved := mustClient(true)
 			ctx, cancel := ctxWithTimeout()
 			defer cancel()

--- a/cli/internal/cli/connection.go
+++ b/cli/internal/cli/connection.go
@@ -5,13 +5,28 @@ import (
 )
 
 func newConnectionCmd() *cobra.Command {
-	cmd := &cobra.Command{Use: "connection", Aliases: []string{"conn", "connections"}, Short: "List, inspect, test, and select ClickHouse connections"}
+	cmd := &cobra.Command{
+		Use:     "connection",
+		Aliases: []string{"conn", "connections"},
+		Short:   "List, inspect, test, and select ClickHouse connections",
+		Long: `Work with saved ClickHouse connections. List and inspect are
+read-only; use verifies access; can-i checks what you may touch. Creating,
+deleting, and ad-hoc credential tests stay in the browser. Pass -c (or set
+it once via login) to scope commands to one connection.`,
+		Example: `  chouse connection list
+  chouse connection list --search prod --limit 5 -o json
+  chouse connection can-i analytics events`,
+	}
 	var search string
 	var limit int
 
 	list := &cobra.Command{
 		Use:   "list",
 		Short: "List accessible connections (passwords never returned)",
+		Long: `List the connections your token may see, with metadata only.
+Filter by name/host substring; grab an id for -c, can-i, or use.`,
+		Example: `  chouse connection list
+  chouse connection list --search prod -o json`,
 		Run: func(_ *cobra.Command, _ []string) {
 			c, resolved := mustClient(true)
 			ctx, cancel := ctxWithTimeout()
@@ -27,9 +42,11 @@ func newConnectionCmd() *cobra.Command {
 	list.Flags().IntVar(&limit, "limit", 50, "max rows")
 
 	get := &cobra.Command{
-		Use:   "get <id>",
-		Short: "Show one connection (metadata only)",
-		Args:  cobra.ExactArgs(1),
+		Use:     "get <id>",
+		Short:   "Show one connection (metadata only)",
+		Long:    `Show one connection's metadata (host, port, database, flags). Passwords are never returned — that is also why create stays in the UI.`,
+		Example: `  chouse connection get 57c2b5bf-0081-4880-9a05-057d1ec3b098 -o json`,
+		Args:    cobra.ExactArgs(1),
 		Run: func(_ *cobra.Command, args []string) {
 			c, resolved := mustClient(true)
 			ctx, cancel := ctxWithTimeout()
@@ -45,6 +62,10 @@ func newConnectionCmd() *cobra.Command {
 	test := &cobra.Command{
 		Use:   "test <id>",
 		Short: "Probe a saved connection without saving anything",
+		Long: `Dial a saved connection and report reachability plus the
+databases visible through it. Read-only probe — nothing is stored or
+changed. Without an id, ad-hoc credential tests stay in the browser.`,
+		Example: `  chouse connection test 57c2b5bf-0081-4880-9a05-057d1ec3b098 -o json`,
 		Run: func(_ *cobra.Command, args []string) {
 			c, resolved := mustClient(true)
 			ctx, cancel := ctxWithTimeout()
@@ -63,7 +84,11 @@ func newConnectionCmd() *cobra.Command {
 	use := &cobra.Command{
 		Use:   "use <id>",
 		Short: "Verify access to a connection (prints correlation session)",
-		Args:  cobra.ExactArgs(1),
+		Long: `Verify access to a connection and print the correlation session.
+Server-side state change, so it needs --yes outside a TTY like every other
+mutation. Point later commands at it with -c.`,
+		Example: `  chouse connection use 57c2b5bf-0081-4880-9a05-057d1ec3b098 --yes -o json`,
+		Args:    cobra.ExactArgs(1),
 		Run: func(_ *cobra.Command, args []string) {
 			rejectDryRun("connection use")
 			confirmDestructive("connection.use", args[0])
@@ -82,7 +107,12 @@ func newConnectionCmd() *cobra.Command {
 	cani := &cobra.Command{
 		Use:   "can-i <database> [table]",
 		Short: "Check data-access for a database/table",
-		Args:  cobra.RangeArgs(1, 2),
+		Long: `Ask the server whether your token may read a database (or a
+specific table) on the scoped connection. Read-only preflight — run it
+before scripting anything that assumes access.`,
+		Example: `  chouse connection can-i analytics
+  chouse connection can-i analytics events -c 57c2b5bf-0081-4880-9a05-057d1ec3b098 -o json`,
+		Args: cobra.RangeArgs(1, 2),
 		Run: func(_ *cobra.Command, args []string) {
 			c, resolved := mustClient(true)
 			ctx, cancel := ctxWithTimeout()
@@ -105,6 +135,11 @@ func newConnectionCmd() *cobra.Command {
 	create := &cobra.Command{
 		Use:   "create",
 		Short: "Create a connection (UI-only in v1)",
+		Long: `Creating a connection stores secrets, so it stays behind UI
+review in v1. Use Connections → New connection in the browser, then come
+back here to list, test, and use it.`,
+		Example: `  chouse connection create
+  # → hint pointing at Connections → New connection`,
 		Run: func(_ *cobra.Command, _ []string) {
 			uiOnly("connection create (stores secrets)", "Connections → New connection")
 		},
@@ -112,6 +147,10 @@ func newConnectionCmd() *cobra.Command {
 	remove := &cobra.Command{
 		Use:   "delete",
 		Short: "Delete a connection (UI-only in v1)",
+		Long: `Deleting a connection affects every profile using it, so it
+stays behind UI review in v1. Use Connections → Delete in the browser.`,
+		Example: `  chouse connection delete
+  # → hint pointing at Connections → Delete`,
 		Run: func(_ *cobra.Command, _ []string) {
 			uiOnly("connection delete", "Connections → Delete")
 		},

--- a/cli/internal/cli/explorer.go
+++ b/cli/internal/cli/explorer.go
@@ -58,7 +58,6 @@ func newTableCmd() *cobra.Command {
 		Use:   "create",
 		Short: "Create database/table (guarded; prefer UI for schema design)",
 		Run: func(_ *cobra.Command, _ []string) {
-			confirmDestructive("ddl-create", "database/table")
 			uiOnly("interactive DDL builder", "Explorer → New database/table (CLI accepts explicit SQL via: chouse query --raw --yes)")
 		},
 	}
@@ -71,12 +70,13 @@ func newTableCmd() *cobra.Command {
 			if len(args) == 2 {
 				target += "." + args[1]
 			}
-			confirmDestructive("drop", target)
+			// Preview first: fully offline plan, never needs --yes.
 			if flagDryRun {
-				_, resolved := mustClient(true)
+				resolved := mustConfig()
 				render(resolved, map[string]any{"dry_run": true, "action": "drop", "target": target})
 				return
 			}
+			confirmDestructive("drop", target)
 			uiOnly("drop "+target, "Explorer → Drop (CLI executes explicit SQL via: chouse query --raw --yes \"DROP TABLE "+target+"\")")
 		},
 	}

--- a/cli/internal/cli/explorer.go
+++ b/cli/internal/cli/explorer.go
@@ -5,12 +5,26 @@ import (
 )
 
 func newTableCmd() *cobra.Command {
-	cmd := &cobra.Command{Use: "table", Aliases: []string{"explorer"}, Short: "Databases, schemas, and samples (reads); DDL stays guarded"}
+	cmd := &cobra.Command{
+		Use:     "table",
+		Aliases: []string{"explorer"},
+		Short:   "Databases, schemas, and samples (reads); DDL stays guarded",
+		Long: `Explore databases, table schemas, and row samples — all reads.
+Schema changes stay guarded: create/drop either point at the UI or need
+explicit SQL with --yes. Prefer table sample over SELECT * when eyeballing
+data.`,
+		Example: `  chouse table list
+  chouse table schema analytics events
+  chouse table sample analytics events --limit 20 -o json`,
+	}
 	var limit int
 
 	list := &cobra.Command{
 		Use:   "list",
 		Short: "List databases and tables",
+		Long:  `List every database and table visible to your token on the scoped connection. Start here when you don't know what's available.`,
+		Example: `  chouse table list
+  chouse table list -c 57c2b5bf-0081-4880-9a05-057d1ec3b098 -o json`,
 		Run: func(_ *cobra.Command, _ []string) {
 			c, resolved := mustClient(true)
 			ctx, cancel := ctxWithTimeout()
@@ -25,7 +39,10 @@ func newTableCmd() *cobra.Command {
 	schema := &cobra.Command{
 		Use:   "schema <db> <table>",
 		Short: "Show engine, columns, and CREATE statement",
-		Args:  cobra.ExactArgs(2),
+		Long:  `Show a table's engine, columns, and full CREATE statement. Read-only — the safe way to learn a schema before writing queries.`,
+		Example: `  chouse table schema analytics events
+  chouse table schema system numbers -o json`,
+		Args: cobra.ExactArgs(2),
 		Run: func(_ *cobra.Command, args []string) {
 			c, resolved := mustClient(true)
 			ctx, cancel := ctxWithTimeout()
@@ -40,7 +57,10 @@ func newTableCmd() *cobra.Command {
 	sample := &cobra.Command{
 		Use:   "sample <db> <table>",
 		Short: "Sample rows (read-only)",
-		Args:  cobra.ExactArgs(2),
+		Long:  `Fetch up to --limit sample rows (max 1000). The quickest way to eyeball data without writing a query.`,
+		Example: `  chouse table sample analytics events --limit 20
+  chouse table sample system numbers --limit 2 -o json`,
+		Args: cobra.ExactArgs(2),
 		Run: func(_ *cobra.Command, args []string) {
 			c, resolved := mustClient(true)
 			ctx, cancel := ctxWithTimeout()
@@ -57,6 +77,10 @@ func newTableCmd() *cobra.Command {
 	create := &cobra.Command{
 		Use:   "create",
 		Short: "Create database/table (guarded; prefer UI for schema design)",
+		Long: `Schema design stays in the browser, so this command only prints
+the pointer. For scripted DDL, use explicit SQL: chouse query --raw --yes.`,
+		Example: `  chouse explorer create
+  # → hint pointing at Explorer → New database/table`,
 		Run: func(_ *cobra.Command, _ []string) {
 			uiOnly("interactive DDL builder", "Explorer → New database/table (CLI accepts explicit SQL via: chouse query --raw --yes)")
 		},
@@ -64,7 +88,12 @@ func newTableCmd() *cobra.Command {
 	drop := &cobra.Command{
 		Use:   "drop <db> [table]",
 		Short: "Drop a database or table (destructive)",
-		Args:  cobra.RangeArgs(1, 2),
+		Long: `Preview or drop a database (one arg) or a single table (two
+args). --dry-run prints the plan without touching anything and needs no
+confirmation; the real thing only runs as explicit SQL with --yes.`,
+		Example: `  chouse table drop analytics events --dry-run
+  chouse query --raw --yes "DROP TABLE analytics.events"`,
+		Args: cobra.RangeArgs(1, 2),
 		Run: func(_ *cobra.Command, args []string) {
 			target := args[0]
 			if len(args) == 2 {

--- a/cli/internal/cli/fleet.go
+++ b/cli/internal/cli/fleet.go
@@ -89,6 +89,7 @@ func newDoctorCmd() *cobra.Command {
 			if !flagQuiet {
 				printlnStderr("warning: doctor scan consumes LLM budget and writes a report row")
 			}
+			rejectDryRun("doctor scan")
 			confirmDestructive("doctor.scan", "fleet")
 			c, resolved := mustClient(true)
 			ctx, cancel := ctxWithTimeout()

--- a/cli/internal/cli/fleet.go
+++ b/cli/internal/cli/fleet.go
@@ -7,13 +7,24 @@ import (
 )
 
 func newFleetCmd() *cobra.Command {
-	cmd := &cobra.Command{Use: "fleet", Short: "Every cluster at once (read-only snapshots)"}
+	cmd := &cobra.Command{
+		Use:   "fleet",
+		Short: "Every cluster at once (read-only snapshots)",
+		Long: `Fleet-wide snapshots, history, and fixed server-side metrics —
+one view across all clusters. Everything here reads; metric names are fixed
+server-side, so there is no ad-hoc SQL to get wrong.`,
+		Example: `  chouse fleet list
+  chouse fleet history --metric summary --limit 5 -o json`,
+	}
 	var from, to, metric string
 	var limit int
 
 	list := &cobra.Command{
 		Use:   "list",
 		Short: "Cached per-cluster snapshots (fast)",
+		Long:  `Cached per-cluster snapshots — the fastest fleet overview. For fresh numbers, use history or query instead.`,
+		Example: `  chouse fleet list
+  chouse fleet list -o json`,
 		Run: func(_ *cobra.Command, _ []string) {
 			c, resolved := mustClient(true)
 			ctx, cancel := ctxWithTimeout()
@@ -28,6 +39,9 @@ func newFleetCmd() *cobra.Command {
 	history := &cobra.Command{
 		Use:   "history",
 		Short: "Fleet history window",
+		Long:  `Fleet metric history over an RFC3339 window (--from/--to), one metric at a time. Defaults cover the recent summary window.`,
+		Example: `  chouse fleet history --limit 5
+  chouse fleet history --metric summary --from 2026-09-01T00:00:00Z -o json`,
 		Run: func(_ *cobra.Command, _ []string) {
 			c, resolved := mustClient(true)
 			ctx, cancel := ctxWithTimeout()
@@ -58,9 +72,11 @@ func newFleetCmd() *cobra.Command {
 	history.Flags().IntVar(&limit, "limit", 100, "max rows")
 
 	query := &cobra.Command{
-		Use:   "query <connectionId> <metric>",
-		Short: "Fixed server-side metric (no ad-hoc SQL)",
-		Args:  cobra.ExactArgs(2),
+		Use:     "query <connectionId> <metric>",
+		Short:   "Fixed server-side metric (no ad-hoc SQL)",
+		Long:    `Fetch one fixed server-side metric for one connection. Metric names are allow-listed server-side — list them via doctor reports or fleet history first.`,
+		Example: `  chouse fleet query 57c2b5bf-0081-4880-9a05-057d1ec3b098 summary -o json`,
+		Args:    cobra.ExactArgs(2),
 		Run: func(_ *cobra.Command, args []string) {
 			c, resolved := mustClient(true)
 			ctx, cancel := ctxWithTimeout()
@@ -77,7 +93,16 @@ func newFleetCmd() *cobra.Command {
 }
 
 func newDoctorCmd() *cobra.Command {
-	cmd := &cobra.Command{Use: "doctor", Short: "Autonomous read-only AI SRE (LLM cost on scan)"}
+	cmd := &cobra.Command{
+		Use:   "doctor",
+		Short: "Autonomous read-only AI SRE (LLM cost on scan)",
+		Long: `Read past AI SRE reports for free; a fresh scan costs LLM budget
+and writes a report row, so scan needs --yes like any mutation. Never
+mutates data — advisory only.`,
+		Example: `  chouse doctor reports
+  chouse doctor get rpt_abc123 -o json
+  chouse doctor scan --hours 24 --yes`,
+	}
 	var model string
 	var hours int
 	var connections []string
@@ -85,6 +110,11 @@ func newDoctorCmd() *cobra.Command {
 	scan := &cobra.Command{
 		Use:   "scan",
 		Short: "Run a fleet scan (advisory only, never mutates)",
+		Long: `Run a fresh AI SRE scan over --hours of fleet history (optionally
+one --model and a --connections subset). Consumes LLM budget and writes a
+report row — hence --yes. For past results without spending, see reports.`,
+		Example: `  chouse doctor scan --yes
+  chouse doctor scan --hours 12 --model m_abc --yes -o json`,
 		Run: func(_ *cobra.Command, _ []string) {
 			if !flagQuiet {
 				printlnStderr("warning: doctor scan consumes LLM budget and writes a report row")
@@ -116,6 +146,9 @@ func newDoctorCmd() *cobra.Command {
 	reports := &cobra.Command{
 		Use:   "reports",
 		Short: "List persisted reports",
+		Long:  `List persisted AI SRE reports — free to read, no scan cost. Grab an id for get.`,
+		Example: `  chouse doctor reports
+  chouse doctor reports -o json`,
 		Run: func(_ *cobra.Command, _ []string) {
 			c, resolved := mustClient(true)
 			ctx, cancel := ctxWithTimeout()
@@ -130,7 +163,10 @@ func newDoctorCmd() *cobra.Command {
 	get := &cobra.Command{
 		Use:   "get <reportId>",
 		Short: "Show one report",
-		Args:  cobra.ExactArgs(1),
+		Long:  `Show one persisted AI SRE report in full. Free to read — only scan spends budget.`,
+		Example: `  chouse doctor get rpt_abc123
+  chouse doctor get rpt_abc123 -o json`,
+		Args: cobra.ExactArgs(1),
 		Run: func(_ *cobra.Command, args []string) {
 			c, resolved := mustClient(true)
 			ctx, cancel := ctxWithTimeout()
@@ -145,6 +181,9 @@ func newDoctorCmd() *cobra.Command {
 	schedule := &cobra.Command{
 		Use:   "schedule",
 		Short: "Show doctor schedule",
+		Long:  `Show the AI SRE scan schedule (cadence, enabled flag, next run). Read-only.`,
+		Example: `  chouse doctor schedule
+  chouse doctor schedule -o json`,
 		Run: func(_ *cobra.Command, _ []string) {
 			c, resolved := mustClient(true)
 			ctx, cancel := ctxWithTimeout()

--- a/cli/internal/cli/helpers_test.go
+++ b/cli/internal/cli/helpers_test.go
@@ -1,0 +1,26 @@
+package cli
+
+import (
+	"testing"
+)
+
+func TestTimeoutSecsClamp(t *testing.T) {
+	old := flagTimeout
+	defer func() { flagTimeout = old }()
+	for _, tc := range []struct {
+		in   int
+		want int
+	}{
+		{-5, 60},
+		{0, 60},
+		{1, 1},
+		{30, 30},
+		{600, 600},
+		{601, 60},
+	} {
+		flagTimeout = tc.in
+		if got := timeoutSecs(); got != tc.want {
+			t.Errorf("timeoutSecs(%d) = %d, want %d", tc.in, got, tc.want)
+		}
+	}
+}

--- a/cli/internal/cli/metrics.go
+++ b/cli/internal/cli/metrics.go
@@ -122,6 +122,7 @@ func newLiveCmd() *cobra.Command {
 		Short: "KILL a running query (destructive)",
 		Args:  cobra.ExactArgs(1),
 		Run: func(_ *cobra.Command, args []string) {
+			rejectDryRun("live kill")
 			confirmDestructive("live.kill", args[0])
 			c, resolved := mustClient(true)
 			ctx, cancel := ctxWithTimeout()

--- a/cli/internal/cli/metrics.go
+++ b/cli/internal/cli/metrics.go
@@ -8,7 +8,16 @@ import (
 )
 
 func newMetricsCmd() *cobra.Command {
-	cmd := &cobra.Command{Use: "metrics", Short: "ClickHouse-native observability (read-only)"}
+	cmd := &cobra.Command{
+		Use:   "metrics",
+		Short: "ClickHouse-native observability (read-only)",
+		Long: `Cluster stats, top tables, error views, custom SELECT metrics,
+and ALTER impact simulation. Everything here reads; simulate never executes
+— the safe way to sanity-check a mutation before running it for real.`,
+		Example: `  chouse metrics overview
+  chouse metrics top-tables --limit 5 -o json
+  chouse metrics simulate "ALTER TABLE t UPDATE x = 1 WHERE id = 2"`,
+	}
 	var interval, limit int
 	var query string
 
@@ -35,13 +44,43 @@ func newMetricsCmd() *cobra.Command {
 		}
 	}
 
-	overview := &cobra.Command{Use: "overview", Short: "System stats + resources", Run: get("/api/metrics/stats", nil)}
-	top := &cobra.Command{Use: "top-tables", Short: "Top tables by size", Run: get("/api/metrics/top-tables", nil)}
-	errs := &cobra.Command{Use: "errors", Short: "Server errors over interval", Run: get("/api/metrics/errors", nil)}
-	parts := &cobra.Command{Use: "parts-pressure", Short: "Merge/part pressure", Run: get("/api/metrics/parts-pressure", nil)}
+	overview := &cobra.Command{
+		Use:   "overview",
+		Short: "System stats + resources",
+		Long:  `Cluster-wide stats and resource pressure over --interval minutes. First stop when something feels slow.`,
+		Example: `  chouse metrics overview
+  chouse metrics overview --interval 5 -o json`,
+		Run: get("/api/metrics/stats", nil),
+	}
+	top := &cobra.Command{
+		Use:   "top-tables",
+		Short: "Top tables by size",
+		Long:  `Largest tables by bytes on disk. Use it to find disk hogs before reaching for TTLs or drops.`,
+		Example: `  chouse metrics top-tables
+  chouse metrics top-tables --limit 5 -o json`,
+		Run: get("/api/metrics/top-tables", nil),
+	}
+	errs := &cobra.Command{
+		Use:   "errors",
+		Short: "Server errors over interval",
+		Long:  `Recent server-side errors with samples and counts. Needs system.query_log on the cluster.`,
+		Example: `  chouse metrics errors
+  chouse metrics errors --interval 60 -o json`,
+		Run: get("/api/metrics/errors", nil),
+	}
+	parts := &cobra.Command{
+		Use:   "parts-pressure",
+		Short: "Merge/part pressure",
+		Long:  `Merge and part pressure across the cluster. Sustained pressure here explains slow inserts before disks fill.`,
+		Example: `  chouse metrics parts-pressure
+  chouse metrics parts-pressure -o json`,
+		Run: get("/api/metrics/parts-pressure", nil),
+	}
 	custom := &cobra.Command{
-		Use:   "custom",
-		Short: "Run a SELECT-only custom metric query",
+		Use:     "custom",
+		Short:   "Run a SELECT-only custom metric query",
+		Long:    `Run your own SELECT as a metric query (--query required). Anything non-SELECT is refused client-side.`,
+		Example: `  chouse metrics custom --query "SELECT count() FROM system.query_log" -o json`,
 		Run: get("/api/metrics/custom", func(q url.Values) {
 			q.Set("query", query)
 		}),
@@ -52,7 +91,12 @@ func newMetricsCmd() *cobra.Command {
 	simulate := &cobra.Command{
 		Use:   "simulate <ALTER …>",
 		Short: "Estimate ALTER UPDATE/DELETE impact (never executes)",
-		Args:  cobra.MinimumNArgs(1),
+		Long: `Estimate how many rows an ALTER UPDATE/DELETE would touch without
+executing it. Always safe — pair it with query --raw --dry-run when planning
+a mutation.`,
+		Example: `  chouse metrics simulate "ALTER TABLE t UPDATE x = 1 WHERE id = 2"
+  chouse metrics simulate "ALTER TABLE analytics.events DELETE WHERE day < today() - 30" -o json`,
+		Args: cobra.MinimumNArgs(1),
 		Run: func(_ *cobra.Command, args []string) {
 			c, resolved := mustClient(true)
 			ctx, cancel := ctxWithTimeout()
@@ -72,12 +116,21 @@ func newMetricsCmd() *cobra.Command {
 }
 
 func newLogsCmd() *cobra.Command {
-	cmd := &cobra.Command{Use: "logs", Short: "Query-log views (read-only)"}
+	cmd := &cobra.Command{
+		Use:   "logs",
+		Short: "Query-log views (read-only)",
+		Long: `Canned views over system.query_log: slow/error queries, patterns,
+per-table activity, and a histogram. Tune --window/--limit; all read-only.`,
+		Example: `  chouse logs queries --limit 5
+  chouse logs patterns --window 60 -o json`,
+	}
 	var window, limit int
 	mk := func(view string) *cobra.Command {
 		return &cobra.Command{
-			Use:   view,
-			Short: "Show " + view,
+			Use:     view,
+			Short:   "Show " + view,
+			Long:    "Show the " + view + " query-log view over --window minutes, capped at --limit rows. Read-only.",
+			Example: "  chouse logs " + view + " --limit 5\n  chouse logs " + view + " --window 30 -o json",
 			Run: func(_ *cobra.Command, _ []string) {
 				c, resolved := mustClient(true)
 				ctx, cancel := ctxWithTimeout()
@@ -102,10 +155,21 @@ func newLogsCmd() *cobra.Command {
 }
 
 func newLiveCmd() *cobra.Command {
-	cmd := &cobra.Command{Use: "live", Short: "Running queries: list, then kill with --yes"}
+	cmd := &cobra.Command{
+		Use:   "live",
+		Short: "Running queries: list, then kill with --yes",
+		Long: `See what's running right now and kill runaways. Listing is
+read-only; kill is destructive and needs --yes outside a TTY. Find the
+query_id in list output first — never guess it.`,
+		Example: `  chouse live list -o json
+  chouse live kill q_abc123 --yes`,
+	}
 	list := &cobra.Command{
 		Use:   "list",
 		Short: "List running queries (own scope unless kill_all)",
+		Long:  `List running queries with ids, users, and runtimes. Your scope covers your own queries unless you hold kill_all.`,
+		Example: `  chouse live list
+  chouse live list -o json`,
 		Run: func(_ *cobra.Command, _ []string) {
 			c, resolved := mustClient(true)
 			ctx, cancel := ctxWithTimeout()
@@ -120,7 +184,12 @@ func newLiveCmd() *cobra.Command {
 	kill := &cobra.Command{
 		Use:   "kill <queryId>",
 		Short: "KILL a running query (destructive)",
-		Args:  cobra.ExactArgs(1),
+		Long: `Kill one running query by id. Destructive and immediate — needs
+--yes outside a TTY, and --dry-run is rejected (there is nothing safe to
+preview). Copy the id from live list; a wrong id just 404s.`,
+		Example: `  chouse live list -o json
+  chouse live kill q_abc123 --yes`,
+		Args: cobra.ExactArgs(1),
 		Run: func(_ *cobra.Command, args []string) {
 			rejectDryRun("live kill")
 			confirmDestructive("live.kill", args[0])

--- a/cli/internal/cli/query.go
+++ b/cli/internal/cli/query.go
@@ -20,7 +20,9 @@ func newQueryCmd() *cobra.Command {
 	var explain string
 
 	run := func(_ *cobra.Command, args []string) {
-		c, resolved := mustClient(true)
+		if file != "" && stdin {
+			fail(api.ExitUsage, "use either -f file.sql or --stdin, not both")
+		}
 		sql := strings.Join(args, " ")
 		if file != "" {
 			rawBytes, err := os.ReadFile(file)
@@ -40,6 +42,7 @@ func newQueryCmd() *cobra.Command {
 			fail(api.ExitUsage, "provide SQL as args, -f file.sql, or --stdin")
 		}
 		if explain != "" {
+			c, resolved := mustClient(true)
 			ctx, cancel := ctxWithTimeout()
 			defer cancel()
 			got, err := c.QueryExplain(ctx, sql, explain)
@@ -53,22 +56,25 @@ func newQueryCmd() *cobra.Command {
 		if intent != safety.IntentRead && !raw {
 			fail(api.ExitUsage, "refusing non-SELECT via default path: use --raw with --yes, or run a typed read (table sample, show, system)")
 		}
-		if intent != safety.IntentRead {
-			confirmDestructive("execute-sql", summarizeSQL(sql))
-			if flagDryRun {
-				ctx, cancel := ctxWithTimeout()
-				defer cancel()
-				// Best-effort dry-run: DDL simulate for ALTER UPDATE/DELETE,
-				// otherwise echo the classified plan without executing.
-				if sim, err := c.DDLSimulate(ctx, sql); err == nil {
-					render(resolved, map[string]any{"dry_run": true, "intent": "write", "simulate": sim})
-					return
-				}
-				render(resolved, map[string]any{"dry_run": true, "intent": "write", "sql": sql})
+		// Preview first: --dry-run never needs --yes and never executes.
+		// Best-effort server simulation when configured, plain plan offline.
+		if intent != safety.IntentRead && flagDryRun {
+			resolved := mustConfig()
+			c := api.New(resolved.Server, resolved.Token, resolved.Connection)
+			ctx, cancel := ctxWithTimeout()
+			defer cancel()
+			if sim, err := c.DDLSimulate(ctx, sql); err == nil {
+				render(resolved, map[string]any{"dry_run": true, "intent": "write", "simulate": sim})
 				return
 			}
+			render(resolved, map[string]any{"dry_run": true, "intent": "write", "sql": sql})
+			return
+		}
+		if intent != safety.IntentRead {
+			confirmDestructive("execute-sql", summarizeSQL(sql))
 			auditLine("query.execute", summarizeSQL(sql), "query/table/database per statement")
 		}
+		c, resolved := mustClient(true)
 		ctx, cancel := ctxWithTimeout()
 		defer cancel()
 		var got map[string]any
@@ -86,7 +92,7 @@ func newQueryCmd() *cobra.Command {
 
 	cmd.Run = run
 	cmd.Flags().StringVarP(&file, "file", "f", "", "read SQL from file")
-	cmd.Flags().StringVar(&format, "format", "JSON", "result format JSON|JSONEachRow|CSV|TabSeparated")
+	cmd.Flags().StringVar(&format, "format", "JSON", "server result format JSON|JSONEachRow|CSV|TabSeparated (display: -o/--output)")
 	cmd.Flags().IntVar(&limit, "limit", 1000, "max result rows (0..100000)")
 	cmd.Flags().BoolVar(&stdin, "stdin", false, "read SQL from stdin")
 	cmd.Flags().BoolVar(&raw, "raw", false, "allow arbitrary SQL via /execute (writes need --yes)")

--- a/cli/internal/cli/query.go
+++ b/cli/internal/cli/query.go
@@ -12,7 +12,21 @@ import (
 )
 
 func newQueryCmd() *cobra.Command {
-	cmd := &cobra.Command{Use: "query", Short: "Run read-only queries safely; writes need --yes"}
+	cmd := &cobra.Command{
+		Use:   "query [sql]",
+		Short: "Run read-only queries safely; writes need --yes",
+		Long: `Run SQL against the scoped connection. Plain SELECT/SHOW go
+straight through; anything else needs --raw plus --yes, and --dry-run
+previews the classified plan without executing. Feed SQL as args, -f file,
+or --stdin (pick one). --format picks the server result format while -o
+controls how this CLI presents it.`,
+		Example: `  chouse query "SELECT number FROM system.numbers LIMIT 5"
+  chouse query "SELECT number FROM system.numbers LIMIT 5" --limit 2 -o json
+  chouse query --explain plan "SELECT * FROM big WHERE day = today()"
+  echo "SELECT 1" | chouse query --stdin -o json
+  chouse query --raw --dry-run "ALTER TABLE t UPDATE x = 1 WHERE id = 2"
+  chouse query --raw --yes "ALTER TABLE t UPDATE x = 1 WHERE id = 2"`,
+	}
 	var file, format string
 	var limit int
 	var stdin bool

--- a/cli/internal/cli/root.go
+++ b/cli/internal/cli/root.go
@@ -23,7 +23,6 @@ var (
 	flagConnection string
 	flagOutput     string
 	flagQuiet      bool
-	flagNoColor    bool
 	flagTimeout    int
 	flagYes        bool
 	flagDryRun     bool
@@ -47,7 +46,6 @@ offer --dry-run previews.`,
 	root.PersistentFlags().StringVarP(&flagConnection, "connection", "c", "", "ClickHouse connection ID (env CHOUSE_CONNECTION)")
 	root.PersistentFlags().StringVarP(&flagOutput, "output", "o", "", "table|json|yaml|csv (env CHOUSE_OUTPUT)")
 	root.PersistentFlags().BoolVarP(&flagQuiet, "quiet", "q", false, "minimal output for scripts")
-	root.PersistentFlags().BoolVar(&flagNoColor, "no-color", false, "disable colors")
 	root.PersistentFlags().IntVar(&flagTimeout, "timeout", 60, "request timeout in seconds")
 	root.PersistentFlags().BoolVar(&flagYes, "yes", false, "approve destructive actions (required in non-TTY)")
 	root.PersistentFlags().BoolVar(&flagDryRun, "dry-run", false, "preview without executing where supported")
@@ -77,12 +75,18 @@ offer --dry-run previews.`,
 }
 
 // ctxWithTimeout bounds every request.
-func ctxWithTimeout() (context.Context, context.CancelFunc) {
-	secs := flagTimeout
-	if secs <= 0 || secs > 600 {
-		secs = 60
+// timeoutSecs normalizes --timeout with the same clamp everywhere so the
+// context deadline and the HTTP client cap never disagree (an uncapped
+// --timeout above 60 used to be silently cut by the client).
+func timeoutSecs() int {
+	if flagTimeout <= 0 || flagTimeout > 600 {
+		return 60
 	}
-	return context.WithTimeout(context.Background(), time.Duration(secs)*time.Second)
+	return flagTimeout
+}
+
+func ctxWithTimeout() (context.Context, context.CancelFunc) {
+	return context.WithTimeout(context.Background(), time.Duration(timeoutSecs())*time.Second)
 }
 
 // mustClient resolves config and builds an authenticated client. Every
@@ -101,6 +105,7 @@ func mustClient(requireAuth bool) (*api.Client, config.Resolved) {
 	}
 	c := api.New(resolved.Server, resolved.Token, resolved.Connection)
 	c.UserAgent = "chouse-cli/1"
+	c.HTTP.Timeout = time.Duration(timeoutSecs()) * time.Second
 	if flagOutput != "" {
 		resolved.Output = flagOutput
 	}
@@ -152,6 +157,14 @@ func failErr(err error) {
 		fail(apiErr.ExitCode(), apiErr.Error())
 	}
 	fail(api.ExitServer, err.Error())
+}
+
+// rejectDryRun fails fast for mutations with no preview support. Without it,
+// --dry-run --yes would silently execute. Call before confirmDestructive.
+func rejectDryRun(what string) {
+	if flagDryRun {
+		fail(api.ExitUsage, fmt.Sprintf("--dry-run is not supported for %s (it always executes; omit --dry-run or use a preview command)", what))
+	}
 }
 
 // confirmDestructive enforces safe-by-default gating.

--- a/cli/internal/cli/root.go
+++ b/cli/internal/cli/root.go
@@ -37,6 +37,16 @@ func NewRoot(version, commit, date string) *cobra.Command {
 run the AI doctor, and manage scheduled work — authenticated with a personal
 access token (ch_pat_…). Safe-by-default: destructive commands need --yes and
 offer --dry-run previews.`,
+		Example: `  # First run: point at a server and store a token (server is remembered)
+  chouse auth login --server https://chouse.corp:5521 --token ch_pat_…
+
+  # Everyday reads (never prompt, never mutate)
+  chouse status
+  chouse query "SELECT number FROM system.numbers LIMIT 5" -o json
+
+  # Guarded writes: preview first, then approve explicitly
+  chouse query --raw --dry-run "ALTER TABLE t UPDATE x = 1 WHERE id = 2"
+  chouse live kill q_abc123 --yes`,
 		SilenceUsage:  true,
 		SilenceErrors: true,
 	}

--- a/cli/internal/cli/root_test.go
+++ b/cli/internal/cli/root_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 )
 
 func commandNames(root *cobra.Command) []string {
@@ -42,6 +43,59 @@ func TestGlobalSafetyFlagsExist(t *testing.T) {
 	}
 }
 
+func TestNoColorFlagRemoved(t *testing.T) {
+	// --no-color was dead (nothing emits color); it must stay gone so the
+	// flag set never re-grows a misleading no-op.
+	root := NewRoot("test", "", "")
+	if root.PersistentFlags().Lookup("no-color") != nil {
+		t.Error("--no-color must not exist (removed: output is always plain)")
+	}
+}
+
+func TestNoShorthandCollisions(t *testing.T) {
+	// A local shorthand must never shadow a persistent one: on commands
+	// declaring their own --connection, `-c` errored instead of working.
+	// (LocalFlags() includes persistent flags, so skip anything owned by
+	// this command's or an ancestor's PersistentFlags.)
+	root := NewRoot("test", "", "")
+	persistent := map[string]string{}
+	root.PersistentFlags().VisitAll(func(f *pflag.Flag) {
+		if f.Shorthand != "" {
+			persistent[f.Shorthand] = f.Name
+		}
+	})
+	isPersistent := func(c *cobra.Command, name string) bool {
+		for p := c; p != nil; p = p.Parent() {
+			if p.PersistentFlags().Lookup(name) != nil {
+				return true
+			}
+		}
+		return false
+	}
+	var walk func(c *cobra.Command)
+	walk = func(c *cobra.Command) {
+		seen := map[string]string{}
+		c.LocalFlags().VisitAll(func(f *pflag.Flag) {
+			if isPersistent(c, f.Name) {
+				return
+			}
+			if f.Shorthand != "" {
+				if prev, dup := seen[f.Shorthand]; dup {
+					t.Errorf("%s: duplicate local shorthand -%s (%s vs %s)", c.Name(), f.Shorthand, prev, f.Name)
+				}
+				seen[f.Shorthand] = f.Name
+				if global, shadow := persistent[f.Shorthand]; shadow {
+					t.Errorf("%s: local -%s (%s) shadows persistent --%s", c.Name(), f.Shorthand, f.Name, global)
+				}
+			}
+		})
+		for _, sub := range c.Commands() {
+			walk(sub)
+		}
+	}
+	walk(root)
+}
+
 func TestTokenFlagSingleCanonicalName(t *testing.T) {
 	root := NewRoot("test", "", "")
 	auth, _, err := root.Find([]string{"auth", "login"})
@@ -65,10 +119,13 @@ func TestScheduledPreviewNeedsConnectionFlag(t *testing.T) {
 	if err != nil || sched == nil || sched.Name() != "preview" {
 		t.Fatalf("scheduled preview not found: %v", err)
 	}
-	for _, f := range []string{"connection", "query"} {
-		if sched.Flags().Lookup(f) == nil {
-			t.Errorf("scheduled preview must accept --%s (server requires connectionId)", f)
-		}
+	// --connection is the single global flag (inherited): a command-local
+	// duplicate used to shadow it, breaking `-c`.
+	if sched.InheritedFlags().Lookup("connection") == nil {
+		t.Error("scheduled preview must inherit global --connection (server requires connectionId)")
+	}
+	if sched.Flags().Lookup("query") == nil {
+		t.Error("scheduled preview must accept --query (SELECT to validate)")
 	}
 }
 

--- a/cli/internal/cli/root_test.go
+++ b/cli/internal/cli/root_test.go
@@ -140,3 +140,34 @@ func TestHelpMentionsSafety(t *testing.T) {
 		t.Error("root Long must document safe-by-default")
 	}
 }
+
+func TestHelpCompleteness(t *testing.T) {
+	// Every helpable command must carry guidance (Long) and runnable
+	// examples (Example). Only cobra-generated help/completion are exempt —
+	// walking the tree (not a roster) forces future commands to comply too.
+	root := NewRoot("test", "", "")
+	exempt := map[string]bool{"help": true, "completion": true, "bash": true, "fish": true, "powershell": true, "zsh": true}
+	count := 0
+	var walk func(c *cobra.Command, path string)
+	walk = func(c *cobra.Command, path string) {
+		name := path + " " + c.Name()
+		if !exempt[c.Name()] {
+			count++
+			if strings.TrimSpace(c.Long) == "" {
+				t.Errorf("%s: missing Long guidance", strings.TrimSpace(name))
+			}
+			if strings.TrimSpace(c.Example) == "" {
+				t.Errorf("%s: missing Example", strings.TrimSpace(name))
+			} else if !strings.Contains(c.Example, "chouse ") {
+				t.Errorf("%s: Example must show real invocations", strings.TrimSpace(name))
+			}
+		}
+		for _, sub := range c.Commands() {
+			walk(sub, name)
+		}
+	}
+	walk(root, "")
+	if count < 80 {
+		t.Errorf("walked only %d commands, tree shrank unexpectedly", count)
+	}
+}

--- a/cli/internal/cli/saved.go
+++ b/cli/internal/cli/saved.go
@@ -7,7 +7,17 @@ import (
 )
 
 func newSavedCmd() *cobra.Command {
-	cmd := &cobra.Command{Use: "saved", Short: "Saved queries (metadata only, safe)"}
+	cmd := &cobra.Command{
+		Use:   "saved",
+		Short: "Saved queries (metadata only, safe)",
+		Long: `Store, list, and re-run named queries. Saving is metadata-only;
+running reuses the read-only query path, and deleting one needs --yes like
+any destructive action.`,
+		Example: `  chouse saved list
+  chouse saved create --name six-seven --query "SELECT 6*7 AS x"
+  chouse saved run abc123 -o json
+  chouse saved delete abc123 --yes`,
+	}
 	var name, query, desc string
 	var public bool
 	var limit int
@@ -15,6 +25,9 @@ func newSavedCmd() *cobra.Command {
 	list := &cobra.Command{
 		Use:   "list",
 		Short: "List saved queries",
+		Long:  `List saved queries visible to your token, optionally filtered by connection. Pair with run to execute one read-only.`,
+		Example: `  chouse saved list
+  chouse saved list --limit 5 -o json`,
 		Run: func(_ *cobra.Command, _ []string) {
 			c, resolved := mustClient(true)
 			ctx, cancel := ctxWithTimeout()
@@ -33,9 +46,11 @@ func newSavedCmd() *cobra.Command {
 	list.Flags().IntVar(&limit, "limit", 50, "max rows (client-side)")
 
 	get := &cobra.Command{
-		Use:   "get <id>",
-		Short: "Show one saved query",
-		Args:  cobra.ExactArgs(1),
+		Use:     "get <id>",
+		Short:   "Show one saved query",
+		Long:    `Show one saved query's metadata and SQL without executing it. Use run to execute it read-only.`,
+		Example: `  chouse saved get abc123 -o json`,
+		Args:    cobra.ExactArgs(1),
 		Run: func(_ *cobra.Command, args []string) {
 			c, resolved := mustClient(true)
 			ctx, cancel := ctxWithTimeout()
@@ -51,6 +66,11 @@ func newSavedCmd() *cobra.Command {
 	create := &cobra.Command{
 		Use:   "create",
 		Short: "Create a saved query",
+		Long: `Save a named query (name and SQL required). Metadata-only and
+instantly listable; mark it --public to share with the team, or scope it
+with --connection.`,
+		Example: `  chouse saved create --name six-seven --query "SELECT 6*7 AS x"
+  chouse saved create --name ev --query "SELECT * FROM analytics.events LIMIT 5" --desc "recent events" -o json`,
 		Run: func(_ *cobra.Command, _ []string) {
 			c, resolved := mustClient(true)
 			ctx, cancel := ctxWithTimeout()
@@ -77,7 +97,10 @@ func newSavedCmd() *cobra.Command {
 	run := &cobra.Command{
 		Use:   "run <id>",
 		Short: "Fetch a saved query and execute it read-only",
-		Args:  cobra.ExactArgs(1),
+		Long:  `Fetch a saved query by id and execute it through the read-only query path. Writes stored in a saved query are refused — use query --raw for those.`,
+		Example: `  chouse saved run abc123
+  chouse saved run abc123 -o json`,
+		Args: cobra.ExactArgs(1),
 		Run: func(_ *cobra.Command, args []string) {
 			c, resolved := mustClient(true)
 			ctx, cancel := ctxWithTimeout()
@@ -99,9 +122,11 @@ func newSavedCmd() *cobra.Command {
 	}
 
 	remove := &cobra.Command{
-		Use:   "delete <id>",
-		Short: "Delete a saved query",
-		Args:  cobra.ExactArgs(1),
+		Use:     "delete <id>",
+		Short:   "Delete a saved query",
+		Long:    `Delete a saved query by id. Destructive, so it needs --yes outside a TTY like every other mutation.`,
+		Example: `  chouse saved delete abc123 --yes`,
+		Args:    cobra.ExactArgs(1),
 		Run: func(_ *cobra.Command, args []string) {
 			rejectDryRun("saved delete")
 			confirmDestructive("saved.delete", args[0])

--- a/cli/internal/cli/saved.go
+++ b/cli/internal/cli/saved.go
@@ -8,7 +8,7 @@ import (
 
 func newSavedCmd() *cobra.Command {
 	cmd := &cobra.Command{Use: "saved", Short: "Saved queries (metadata only, safe)"}
-	var connection, name, query, desc string
+	var name, query, desc string
 	var public bool
 	var limit int
 
@@ -20,8 +20,8 @@ func newSavedCmd() *cobra.Command {
 			ctx, cancel := ctxWithTimeout()
 			defer cancel()
 			q := url.Values{}
-			if connection != "" {
-				q.Set("connectionId", connection)
+			if resolved.Connection != "" {
+				q.Set("connectionId", resolved.Connection)
 			}
 			got, err := c.Get(ctx, "/api/saved-queries", q)
 			if err != nil {
@@ -30,7 +30,6 @@ func newSavedCmd() *cobra.Command {
 			render(resolved, got)
 		},
 	}
-	list.Flags().StringVar(&connection, "connection", "", "filter by connection ID")
 	list.Flags().IntVar(&limit, "limit", 50, "max rows (client-side)")
 
 	get := &cobra.Command{
@@ -57,8 +56,8 @@ func newSavedCmd() *cobra.Command {
 			ctx, cancel := ctxWithTimeout()
 			defer cancel()
 			body := map[string]any{"name": name, "query": query, "description": desc, "isPublic": public}
-			if connection != "" {
-				body["connectionId"] = connection
+			if resolved.Connection != "" {
+				body["connectionId"] = resolved.Connection
 			}
 			got, err := c.Post(ctx, "/api/saved-queries", body)
 			if err != nil {
@@ -104,6 +103,7 @@ func newSavedCmd() *cobra.Command {
 		Short: "Delete a saved query",
 		Args:  cobra.ExactArgs(1),
 		Run: func(_ *cobra.Command, args []string) {
+			rejectDryRun("saved delete")
 			confirmDestructive("saved.delete", args[0])
 			c, resolved := mustClient(true)
 			ctx, cancel := ctxWithTimeout()

--- a/cli/internal/cli/scheduled.go
+++ b/cli/internal/cli/scheduled.go
@@ -9,8 +9,7 @@ import (
 
 func newScheduledCmd() *cobra.Command {
 	cmd := &cobra.Command{Use: "scheduled", Short: "Scheduled queries (preview before create/run)"}
-	var connection string
-	var previewConnection, previewQuery string
+	var previewQuery string
 	var limit int
 
 	list := &cobra.Command{
@@ -21,8 +20,8 @@ func newScheduledCmd() *cobra.Command {
 			ctx, cancel := ctxWithTimeout()
 			defer cancel()
 			q := url.Values{}
-			if connection != "" {
-				q.Set("connectionId", connection)
+			if resolved.Connection != "" {
+				q.Set("connectionId", resolved.Connection)
 			}
 			got, err := c.Get(ctx, "/api/scheduled-queries", q)
 			if err != nil {
@@ -31,7 +30,6 @@ func newScheduledCmd() *cobra.Command {
 			render(resolved, got)
 		},
 	}
-	list.Flags().StringVar(&connection, "connection", "", "filter by connection ID")
 
 	get := &cobra.Command{
 		Use:   "get <id>",
@@ -74,11 +72,7 @@ func newScheduledCmd() *cobra.Command {
 		Short: "Validate a job body without creating (dry-run)",
 		Run: func(_ *cobra.Command, _ []string) {
 			c, resolved := mustClient(true)
-			conn := previewConnection
-			if conn == "" {
-				conn = resolved.Connection
-			}
-			if conn == "" {
+			if resolved.Connection == "" {
 				fail(2, "preview needs a connection: pass --connection <id> (or -c / CHOUSE_CONNECTION)")
 			}
 			ctx, cancel := ctxWithTimeout()
@@ -86,7 +80,7 @@ func newScheduledCmd() *cobra.Command {
 			got, err := c.Post(ctx, "/api/scheduled-queries/preview", map[string]any{
 				"query":        previewQuery,
 				"frequency":    "manual",
-				"connectionId": conn,
+				"connectionId": resolved.Connection,
 			})
 			if err != nil {
 				failErr(err)
@@ -94,13 +88,13 @@ func newScheduledCmd() *cobra.Command {
 			render(resolved, got)
 		},
 	}
-	preview.Flags().StringVar(&previewConnection, "connection", "", "connection ID (default: configured connection)")
 	preview.Flags().StringVar(&previewQuery, "query", "SELECT 1", "SELECT to validate")
 	runNow := &cobra.Command{
 		Use:   "run <id>",
 		Short: "Execute a job now (action)",
 		Args:  cobra.ExactArgs(1),
 		Run: func(_ *cobra.Command, args []string) {
+			rejectDryRun("scheduled run")
 			confirmDestructive("scheduled.run", args[0])
 			c, resolved := mustClient(true)
 			ctx, cancel := ctxWithTimeout()
@@ -118,6 +112,7 @@ func newScheduledCmd() *cobra.Command {
 		Short: "Delete a job (destructive)",
 		Args:  cobra.ExactArgs(1),
 		Run: func(_ *cobra.Command, args []string) {
+			rejectDryRun("scheduled delete")
 			confirmDestructive("scheduled.delete", args[0])
 			c, resolved := mustClient(true)
 			ctx, cancel := ctxWithTimeout()
@@ -136,7 +131,6 @@ func newScheduledCmd() *cobra.Command {
 
 func newHealthCmd() *cobra.Command {
 	cmd := &cobra.Command{Use: "health", Short: "Data-health promises and incidents"}
-	var connection string
 	var limit int
 	list := &cobra.Command{
 		Use:   "list",
@@ -146,8 +140,8 @@ func newHealthCmd() *cobra.Command {
 			ctx, cancel := ctxWithTimeout()
 			defer cancel()
 			q := url.Values{}
-			if connection != "" {
-				q.Set("connectionId", connection)
+			if resolved.Connection != "" {
+				q.Set("connectionId", resolved.Connection)
 			}
 			got, err := c.Get(ctx, "/api/data-health", q)
 			if err != nil {
@@ -156,7 +150,6 @@ func newHealthCmd() *cobra.Command {
 			render(resolved, got)
 		},
 	}
-	list.Flags().StringVar(&connection, "connection", "", "filter by connection ID")
 	incidents := &cobra.Command{
 		Use:   "incidents",
 		Short: "List incidents",
@@ -165,17 +158,26 @@ func newHealthCmd() *cobra.Command {
 			ctx, cancel := ctxWithTimeout()
 			defer cancel()
 			q := url.Values{}
-			if connection != "" {
-				q.Set("connectionId", connection)
+			if resolved.Connection != "" {
+				q.Set("connectionId", resolved.Connection)
 			}
 			got, err := c.Get(ctx, "/api/data-health/incidents", q)
 			if err != nil {
 				failErr(err)
 			}
+			// The endpoint takes no limit param: truncate client-side so
+			// --limit is honest (same pattern as saved list).
+			if limit > 0 {
+				if m, ok := got.(map[string]any); ok {
+					if arr, ok := m["incidents"].([]any); ok && len(arr) > limit {
+						m["incidents"] = arr[:limit]
+					}
+				}
+			}
 			render(resolved, got)
 		},
 	}
-	incidents.Flags().StringVar(&connection, "connection", "", "filter by connection ID")
+	incidents.Flags().IntVar(&limit, "limit", 50, "max rows (client-side)")
 	timeline := &cobra.Command{
 		Use:   "timeline <promiseId>",
 		Short: "Show promise timeline",
@@ -201,6 +203,7 @@ func newHealthCmd() *cobra.Command {
 		Short: "Execute checks now (action)",
 		Args:  cobra.ExactArgs(1),
 		Run: func(_ *cobra.Command, args []string) {
+			rejectDryRun("health run")
 			confirmDestructive("health.run", args[0])
 			c, resolved := mustClient(true)
 			ctx, cancel := ctxWithTimeout()
@@ -218,6 +221,7 @@ func newHealthCmd() *cobra.Command {
 		Short: "Acknowledge an incident",
 		Args:  cobra.ExactArgs(1),
 		Run: func(_ *cobra.Command, args []string) {
+			rejectDryRun("health ack")
 			confirmDestructive("health.ack", args[0])
 			c, resolved := mustClient(true)
 			ctx, cancel := ctxWithTimeout()

--- a/cli/internal/cli/scheduled.go
+++ b/cli/internal/cli/scheduled.go
@@ -8,13 +8,25 @@ import (
 )
 
 func newScheduledCmd() *cobra.Command {
-	cmd := &cobra.Command{Use: "scheduled", Short: "Scheduled queries (preview before create/run)"}
+	cmd := &cobra.Command{
+		Use:   "scheduled",
+		Short: "Scheduled queries (preview before create/run)",
+		Long: `Inspect scheduled query jobs, their run history, and validate
+new job bodies before creating them. Listing and previewing are free;
+run and delete are actions and need --yes.`,
+		Example: `  chouse scheduled list
+  chouse scheduled preview --connection 57c2b5bf-0081-4880-9a05-057d1ec3b098 --query "SELECT 1"
+  chouse scheduled run job_abc123 --yes`,
+	}
 	var previewQuery string
 	var limit int
 
 	list := &cobra.Command{
 		Use:   "list",
 		Short: "List jobs",
+		Long:  `List scheduled query jobs, optionally scoped with -c. Pair with runs or preview before touching anything.`,
+		Example: `  chouse scheduled list
+  chouse scheduled list -o json`,
 		Run: func(_ *cobra.Command, _ []string) {
 			c, resolved := mustClient(true)
 			ctx, cancel := ctxWithTimeout()
@@ -32,9 +44,11 @@ func newScheduledCmd() *cobra.Command {
 	}
 
 	get := &cobra.Command{
-		Use:   "get <id>",
-		Short: "Show one job",
-		Args:  cobra.ExactArgs(1),
+		Use:     "get <id>",
+		Short:   "Show one job",
+		Long:    `Show one scheduled job's definition (query, frequency, connection) without running it.`,
+		Example: `  chouse scheduled get job_abc123 -o json`,
+		Args:    cobra.ExactArgs(1),
 		Run: func(_ *cobra.Command, args []string) {
 			c, resolved := mustClient(true)
 			ctx, cancel := ctxWithTimeout()
@@ -49,7 +63,10 @@ func newScheduledCmd() *cobra.Command {
 	runs := &cobra.Command{
 		Use:   "runs <id>",
 		Short: "Show run history",
-		Args:  cobra.ExactArgs(1),
+		Long:  `Show a job's past runs (newest first, capped at --limit) to check health before running it again.`,
+		Example: `  chouse scheduled runs job_abc123 --limit 5
+  chouse scheduled runs job_abc123 -o json`,
+		Args: cobra.ExactArgs(1),
 		Run: func(_ *cobra.Command, args []string) {
 			c, resolved := mustClient(true)
 			ctx, cancel := ctxWithTimeout()
@@ -70,6 +87,11 @@ func newScheduledCmd() *cobra.Command {
 	preview := &cobra.Command{
 		Use:   "preview",
 		Short: "Validate a job body without creating (dry-run)",
+		Long: `Validate a SELECT against a connection without creating any job:
+checks access, read-only-ness, and tokens. Needs a connection via
+--connection, -c, or CHOUSE_CONNECTION. Always safe.`,
+		Example: `  chouse scheduled preview --connection 57c2b5bf-0081-4880-9a05-057d1ec3b098 --query "SELECT 1"
+  chouse scheduled preview -c 57c2b5bf-0081-4880-9a05-057d1ec3b098 --query "SELECT count() FROM analytics.events" -o json`,
 		Run: func(_ *cobra.Command, _ []string) {
 			c, resolved := mustClient(true)
 			if resolved.Connection == "" {
@@ -92,7 +114,11 @@ func newScheduledCmd() *cobra.Command {
 	runNow := &cobra.Command{
 		Use:   "run <id>",
 		Short: "Execute a job now (action)",
-		Args:  cobra.ExactArgs(1),
+		Long: `Execute a scheduled job immediately, outside its timetable. An
+action like any mutation — needs --yes outside a TTY. Check runs first.`,
+		Example: `  chouse scheduled runs job_abc123 --limit 3
+  chouse scheduled run job_abc123 --yes`,
+		Args: cobra.ExactArgs(1),
 		Run: func(_ *cobra.Command, args []string) {
 			rejectDryRun("scheduled run")
 			confirmDestructive("scheduled.run", args[0])
@@ -108,9 +134,11 @@ func newScheduledCmd() *cobra.Command {
 		},
 	}
 	remove := &cobra.Command{
-		Use:   "delete <id>",
-		Short: "Delete a job (destructive)",
-		Args:  cobra.ExactArgs(1),
+		Use:     "delete <id>",
+		Short:   "Delete a job (destructive)",
+		Long:    `Delete a scheduled job permanently. Destructive — needs --yes outside a TTY. Double-check runs first.`,
+		Example: `  chouse scheduled delete job_abc123 --yes`,
+		Args:    cobra.ExactArgs(1),
 		Run: func(_ *cobra.Command, args []string) {
 			rejectDryRun("scheduled delete")
 			confirmDestructive("scheduled.delete", args[0])
@@ -130,11 +158,23 @@ func newScheduledCmd() *cobra.Command {
 }
 
 func newHealthCmd() *cobra.Command {
-	cmd := &cobra.Command{Use: "health", Short: "Data-health promises and incidents"}
+	cmd := &cobra.Command{
+		Use:   "health",
+		Short: "Data-health promises and incidents",
+		Long: `Data-health promises, their incidents, and timelines — plus the
+actions to re-run checks or acknowledge incidents. Reads are free; run and
+ack are actions needing --yes.`,
+		Example: `  chouse health list
+  chouse health incidents --limit 5 -o json
+  chouse health ack inc_abc123 --yes`,
+	}
 	var limit int
 	list := &cobra.Command{
 		Use:   "list",
 		Short: "List promises",
+		Long:  `List data-health promises and their current state. Start here, then drill into incidents or a timeline.`,
+		Example: `  chouse health list
+  chouse health list -o json`,
 		Run: func(_ *cobra.Command, _ []string) {
 			c, resolved := mustClient(true)
 			ctx, cancel := ctxWithTimeout()
@@ -153,6 +193,9 @@ func newHealthCmd() *cobra.Command {
 	incidents := &cobra.Command{
 		Use:   "incidents",
 		Short: "List incidents",
+		Long:  `List data-health incidents, newest first, capped at --limit (client-side). Acknowledge one with health ack.`,
+		Example: `  chouse health incidents --limit 5
+  chouse health incidents -o json`,
 		Run: func(_ *cobra.Command, _ []string) {
 			c, resolved := mustClient(true)
 			ctx, cancel := ctxWithTimeout()
@@ -181,7 +224,10 @@ func newHealthCmd() *cobra.Command {
 	timeline := &cobra.Command{
 		Use:   "timeline <promiseId>",
 		Short: "Show promise timeline",
-		Args:  cobra.ExactArgs(1),
+		Long:  `Show one promise's check timeline (newest samples first, capped at --limit). Read-only history for post-mortems.`,
+		Example: `  chouse health timeline prom_abc123 --limit 10
+  chouse health timeline prom_abc123 -o json`,
+		Args: cobra.ExactArgs(1),
 		Run: func(_ *cobra.Command, args []string) {
 			c, resolved := mustClient(true)
 			ctx, cancel := ctxWithTimeout()
@@ -199,9 +245,11 @@ func newHealthCmd() *cobra.Command {
 	}
 	timeline.Flags().IntVar(&limit, "limit", 50, "max samples")
 	run := &cobra.Command{
-		Use:   "run <promiseId>",
-		Short: "Execute checks now (action)",
-		Args:  cobra.ExactArgs(1),
+		Use:     "run <promiseId>",
+		Short:   "Execute checks now (action)",
+		Long:    `Execute a promise's checks immediately instead of waiting for the schedule. An action — needs --yes outside a TTY.`,
+		Example: `  chouse health run prom_abc123 --yes`,
+		Args:    cobra.ExactArgs(1),
 		Run: func(_ *cobra.Command, args []string) {
 			rejectDryRun("health run")
 			confirmDestructive("health.run", args[0])
@@ -217,9 +265,11 @@ func newHealthCmd() *cobra.Command {
 		},
 	}
 	ack := &cobra.Command{
-		Use:   "ack <incidentId>",
-		Short: "Acknowledge an incident",
-		Args:  cobra.ExactArgs(1),
+		Use:     "ack <incidentId>",
+		Short:   "Acknowledge an incident",
+		Long:    `Acknowledge an incident so on-call knows it's handled. An action — needs --yes outside a TTY.`,
+		Example: `  chouse health ack inc_abc123 --yes`,
+		Args:    cobra.ExactArgs(1),
 		Run: func(_ *cobra.Command, args []string) {
 			rejectDryRun("health ack")
 			confirmDestructive("health.ack", args[0])

--- a/cli/internal/cli/status.go
+++ b/cli/internal/cli/status.go
@@ -8,6 +8,12 @@ func newStatusCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "status",
 		Short: "Server health, version, and migration status",
+		Long: `Probe the configured server: public health plus, when logged in,
+version and migration state. This is the command that answers "is the server
+OK and current" — use it before debugging anything else.`,
+		Example: `  chouse status
+  chouse status -o json
+  chouse status --server https://chouse.corp:5521`,
 		Run: func(_ *cobra.Command, _ []string) {
 			c, resolved := mustClient(false)
 			ctx, cancel := ctxWithTimeout()

--- a/cli/internal/cli/upload_audit.go
+++ b/cli/internal/cli/upload_audit.go
@@ -30,7 +30,7 @@ func newUploadCmd() *cobra.Command {
 		},
 	}
 	preview.Flags().StringVar(&file, "file", "", "path (required)")
-	preview.Flags().StringVar(&format, "format", "CSV", "CSV|TSV|JSON")
+	preview.Flags().StringVar(&format, "format", "CSV", "upload file format CSV|TSV|JSON")
 	preview.Flags().BoolVar(&hasHeader, "header", true, "first row is header")
 	_ = preview.MarkFlagRequired("file")
 
@@ -39,7 +39,8 @@ func newUploadCmd() *cobra.Command {
 		Short: "Stream a file into database.table (destructive INSERT)",
 		Run: func(_ *cobra.Command, _ []string) {
 			target := database + "." + table
-			confirmDestructive("upload.into", target)
+			// Preview first: --dry-run never needs --yes (file parsing is
+			// server-side but never stores anything).
 			if flagDryRun {
 				c, resolved := mustClient(true)
 				ctx, cancel := ctxWithTimeout()
@@ -51,11 +52,12 @@ func newUploadCmd() *cobra.Command {
 				render(resolved, map[string]any{"dry_run": true, "target": target, "preview": got})
 				return
 			}
+			confirmDestructive("upload.into", target)
 			uiOnly("upload into "+target, "Explorer → Upload (CLI streaming lands in a follow-up; preview above is the safe plan)")
 		},
 	}
 	into.Flags().StringVar(&file, "file", "", "path (required)")
-	into.Flags().StringVar(&format, "format", "CSV", "CSV|TSV|JSON")
+	into.Flags().StringVar(&format, "format", "CSV", "upload file format CSV|TSV|JSON")
 	into.Flags().StringVar(&database, "db", "", "database (required)")
 	into.Flags().StringVar(&table, "table", "", "table (required)")
 	into.Flags().StringVar(&columns, "columns", "", "optional column list")

--- a/cli/internal/cli/upload_audit.go
+++ b/cli/internal/cli/upload_audit.go
@@ -11,13 +11,27 @@ import (
 )
 
 func newUploadCmd() *cobra.Command {
-	cmd := &cobra.Command{Use: "upload", Short: "CSV/TSV/JSON import (preview first, into needs --yes)"}
+	cmd := &cobra.Command{
+		Use:   "upload",
+		Short: "CSV/TSV/JSON import (preview first, into needs --yes)",
+		Long: `Import local files into a table. Always preview first: it infers
+columns from a small slice and stores nothing. The full streaming import
+lands in a follow-up — today into only previews, then points at the UI.`,
+		Example: `  chouse upload preview --file rows.csv
+  chouse upload preview --file rows.tsv --format TSV --header=false -o json
+  chouse upload into --file rows.csv --db analytics --table events --dry-run`,
+	}
 	var file, format, database, table, columns string
 	var hasHeader bool
 
 	preview := &cobra.Command{
 		Use:   "preview",
 		Short: "Infer columns from a file slice (1 MB, local)",
+		Long: `Send a small slice of a local file for column inference (types,
+nullability, samples). Stores nothing — the safe first step before any
+import. Needs --file; --format picks the file layout.`,
+		Example: `  chouse upload preview --file rows.csv
+  chouse upload preview --file rows.json --format JSON -o json`,
 		Run: func(_ *cobra.Command, _ []string) {
 			c, resolved := mustClient(true)
 			ctx, cancel := ctxWithTimeout()
@@ -37,6 +51,11 @@ func newUploadCmd() *cobra.Command {
 	into := &cobra.Command{
 		Use:   "into",
 		Short: "Stream a file into database.table (destructive INSERT)",
+		Long: `Preview how a file would land in database.table: same inference
+as preview plus the target. --dry-run needs no confirmation; anything real
+currently hands off to Explorer → Upload in the browser.`,
+		Example: `  chouse upload into --file rows.csv --db analytics --table events --dry-run
+  chouse upload into --file rows.csv --db analytics --table events --dry-run -o json`,
 		Run: func(_ *cobra.Command, _ []string) {
 			target := database + "." + table
 			// Preview first: --dry-run never needs --yes (file parsing is
@@ -71,13 +90,27 @@ func newUploadCmd() *cobra.Command {
 }
 
 func newAuditCmd() *cobra.Command {
-	cmd := &cobra.Command{Use: "audit", Short: "Audit trail (list/export; prune stays UI-only)"}
+	cmd := &cobra.Command{
+		Use:   "audit",
+		Short: "Audit trail (list/export; prune stays UI-only)",
+		Long: `Read the audit trail: who did what, when, from where. Listing
+and CSV export are read-only; pruning history stays in the browser. Entries
+appear as actions happen — run a command, then check here.`,
+		Example: `  chouse audit list --limit 5
+  chouse audit list --action clickhouse.query_execute -o json
+  chouse audit export --limit 100 > audit.csv`,
+	}
 	var limit int
 	var action, status, user string
 
 	list := &cobra.Command{
 		Use:   "list",
 		Short: "List audit entries (own scope unless audit:view)",
+		Long: `List audit entries, newest first. You see your own actions
+unless you hold audit:view. Filter by action, status, or user id; cap with
+--limit.`,
+		Example: `  chouse audit list --limit 5
+  chouse audit list --action clickhouse.query_execute --status success -o json`,
 		Run: func(_ *cobra.Command, _ []string) {
 			c, resolved := mustClient(true)
 			ctx, cancel := ctxWithTimeout()
@@ -97,6 +130,11 @@ func newAuditCmd() *cobra.Command {
 	export := &cobra.Command{
 		Use:   "export",
 		Short: "Export audit CSV (up to 10000 rows)",
+		Long: `Export audit entries as raw CSV bytes to stdout — redirect to a
+file. Same filters as list; bypasses -o (bytes, not a document). Pruning
+stays in the browser.`,
+		Example: `  chouse audit export --limit 100 > audit.csv
+  chouse audit export --action clickhouse.query_execute --limit 1000 > queries.csv`,
 		Run: func(_ *cobra.Command, _ []string) {
 			c, resolved := mustClient(true)
 			ctx, cancel := ctxWithTimeout()
@@ -125,11 +163,25 @@ func newAuditCmd() *cobra.Command {
 }
 
 func newConfigCmd() *cobra.Command {
-	cmd := &cobra.Command{Use: "config", Short: "Profiles and local settings"}
+	cmd := &cobra.Command{
+		Use:   "config",
+		Short: "Profiles and local settings",
+		Long: `Inspect and switch local profiles (~/.config/chouse/config.yaml).
+Profiles hold non-secret defaults (server, connection); tokens live
+separately in credentials.yaml. Most users set everything via auth login.`,
+		Example: `  chouse auth status
+  chouse config use-profile prod`,
+	}
 	use := &cobra.Command{
 		Use:   "use-profile <name>",
 		Short: "Switch profile (writes config.yaml, no secrets)",
-		Args:  cobra.ExactArgs(1),
+		Long: `Switch the current profile. Currently a guided stub: edit
+~/.config/chouse/config.yaml and set current_profile, keeping secrets out
+of the file (tokens stay in credentials.yaml).`,
+		Example: `  # in ~/.config/chouse/config.yaml, set:
+  # current_profile: prod
+  chouse auth status --profile prod`,
+		Args: cobra.ExactArgs(1),
 		Run: func(_ *cobra.Command, args []string) {
 			uiOnly("profile switch helper", "edit ~/.config/chouse/config.yaml (profile "+args[0]+")")
 		},

--- a/cli/internal/cli/version.go
+++ b/cli/internal/cli/version.go
@@ -11,6 +11,11 @@ func newVersionCmd(version, commit, date string) *cobra.Command {
 	return &cobra.Command{
 		Use:   "version",
 		Short: "Print CLI version (server info: chouse status)",
+		Long: `Print the CLI binary version, build commit, and date. Always
+offline and instant — it never contacts a server, so it doubles as the
+install check. For the server side, see chouse status.`,
+		Example: `  chouse version
+  chouse version -o json`,
 		// Deliberately offline: version is the install-verification command
 		// and must never block on (or require) a configured server.
 		Run: func(_ *cobra.Command, _ []string) {

--- a/cli/internal/output/output.go
+++ b/cli/internal/output/output.go
@@ -119,15 +119,26 @@ func toRows(value any) []map[string]string {
 	if value == nil {
 		return nil
 	}
-	// Unwrap {data: …} and QueryResult {meta,data}.
+	// Unwrap {data: …} envelopes — but only when data is itself a container.
+	// A scalar "data" field (or a map without its own "data" key) is a
+	// regular payload field: unwrapping it would silently drop siblings and
+	// rename the column (JSON output renders the raw map, so table/CSV must
+	// not reshape it either). Single-key {"data": X} wrappers keep their
+	// legacy unwrap since nothing is lost.
 	if m, ok := value.(map[string]any); ok {
 		if d, ok := m["data"]; ok {
 			if dm, ok := d.(map[string]any); ok {
 				if rows, ok := dm["data"]; ok {
 					return rowsFrom(rows, dm["meta"])
 				}
+				if len(m) == 1 {
+					return toRows(d)
+				}
+			} else if _, isSlice := d.([]any); isSlice {
+				return toRows(d)
+			} else if len(m) == 1 {
+				return toRows(d)
 			}
-			return toRows(d)
 		}
 		return []map[string]string{stringifyMap(m)}
 	}

--- a/cli/internal/output/output_test.go
+++ b/cli/internal/output/output_test.go
@@ -56,3 +56,70 @@ func TestPrintUnknownFormat(t *testing.T) {
 		t.Fatal("expected error for unknown format")
 	}
 }
+
+func TestToRowsScalarDataPreserved(t *testing.T) {
+	// A scalar "data" field next to siblings must render all columns —
+	// unwrapping it would silently drop siblings (JSON renders the raw map).
+	payload := map[string]any{"id": 1, "data": "x"}
+	var buf bytes.Buffer
+	if err := Print(&buf, "table", payload); err != nil {
+		t.Fatal(err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "id") || !strings.Contains(out, "x") {
+		t.Fatalf("siblings lost: %s", out)
+	}
+	if strings.Contains(out, "value") {
+		t.Fatalf("scalar data must not collapse to value column: %s", out)
+	}
+}
+
+func TestToRowsNestedDataPreserved(t *testing.T) {
+	payload := map[string]any{"id": 1, "data": map[string]any{"x": 1}}
+	var buf bytes.Buffer
+	if err := Print(&buf, "table", payload); err != nil {
+		t.Fatal(err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "id") || !strings.Contains(out, `{"x":1}`) {
+		t.Fatalf("nested data must render whole map with compact cell: %s", out)
+	}
+}
+
+func TestNestedCellsCompact(t *testing.T) {
+	payload := map[string]any{"arr": []any{1, 2}, "obj": map[string]any{"b": 1, "a": 2}, "s": "plain"}
+	var buf bytes.Buffer
+	if err := Print(&buf, "table", payload); err != nil {
+		t.Fatal(err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "[1,2]") || !strings.Contains(out, `{"a":2,"b":1}`) {
+		t.Fatalf("nested cells must be compact sorted JSON: %s", out)
+	}
+	if strings.Contains(out, "{\n") {
+		t.Fatalf("table must never embed a pretty JSON document: %s", out)
+	}
+}
+
+func TestSingleKeyDataUnwrapUnchanged(t *testing.T) {
+	// Legacy single-key wrapper keeps its historic shape.
+	var buf bytes.Buffer
+	if err := Print(&buf, "table", map[string]any{"data": "x"}); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(buf.String(), "value") {
+		t.Fatalf("single-key data wrapper changed shape: %s", buf.String())
+	}
+}
+
+func TestNestedCellsCSVQuoted(t *testing.T) {
+	payload := []map[string]any{{"id": 1, "tags": []any{"a", "b"}}}
+	var buf bytes.Buffer
+	if err := Print(&buf, "csv", payload); err != nil {
+		t.Fatal(err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, `"[""a"",""b""]"`) {
+		t.Fatalf("nested CSV cell must be RFC-quoted JSON: %s", out)
+	}
+}

--- a/cli/internal/safety/safety.go
+++ b/cli/internal/safety/safety.go
@@ -74,7 +74,7 @@ func RequireConfirm(opts ConfirmOptions) error {
 	if !isTTY(opts.In) {
 		return fmt.Errorf("refusing %s on %q without --yes in non-interactive mode (pass --yes to approve, --dry-run to preview)", opts.Action, opts.Target)
 	}
-	fmt.Printf("%s %q? This may mutate data. Type 'yes' to continue: ", opts.Action, opts.Target)
+	fmt.Fprintf(os.Stderr, "%s %q? This may mutate data. Type 'yes' to continue: ", opts.Action, opts.Target)
 	reader := bufio.NewReader(stdin(opts.In))
 	line, err := reader.ReadString('\n')
 	if err != nil {

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -73,6 +73,31 @@ chouse ai optimize -f slow.sql
 Machine use: `--output json|yaml|csv|table`, `--quiet`, `--stdin`/`-f -`,
 exit codes `0/2/3/4/5/6`, no spinners when piped.
 
+## Global flags
+
+Available on every command: `--server`, `--token`, `--profile`,
+`-c/--connection`, `-o/--output`, `-q/--quiet`, `--timeout`,
+`--yes`, `--dry-run`.
+
+- `-o/--output` selects presentation (`table|json|yaml|csv`); `query --format`
+  instead selects the *server* result format, and `upload --format` the upload
+  file format — independent knobs.
+- `-q/--quiet` means machine mode: table output becomes JSON, and human
+  diagnostics stay on stderr so stdout pipes cleanly.
+- `-c/--connection` scopes the invocation to one connection (header +
+  filter); it is the same flag everywhere, including list commands.
+- `--timeout` bounds every request (context deadline and client cap alike).
+- `--dry-run` previews without executing where supported (`query --raw`
+  writes, `upload into`, `explorer drop`); elsewhere it fails fast instead
+  of silently executing.
+
+## Output contract
+
+`-o table` always renders the table: nested values appear as compact JSON in
+their cell (same bytes, RFC-quoted, in CSV). `audit export` streams raw bytes
+and bypasses `-o`. `auth login`/`logout` print a machine result honoring `-o`
+with the human note on stderr.
+
 ## Safety
 
 Reads never prompt. Mutations need TTY confirm and `--yes` in CI:

--- a/packages/server/src/routes/query.test.ts
+++ b/packages/server/src/routes/query.test.ts
@@ -155,6 +155,19 @@ describe("Query Routes", () => {
             const body = await res.json();
             expect(body.error.message).toBe("Restricted table");
         });
+
+        it("should pass maxResultRows through to the query service", async () => {
+            mockExecuteQuery.mockResolvedValue({ data: [] });
+
+            const res = await app.request("/query/table/select", {
+                method: "POST",
+                headers: { "Content-Type": "application/json", "Authorization": "Bearer token" },
+                body: JSON.stringify({ query: "SELECT * FROM t1", maxResultRows: 25 })
+            });
+
+            expect(res.status).toBe(200);
+            expect(mockExecuteQuery).toHaveBeenCalledWith("SELECT * FROM t1", "JSON", undefined, 25);
+        });
     });
 
     describe("POST /query/table/create", () => {

--- a/packages/server/src/routes/query.ts
+++ b/packages/server/src/routes/query.ts
@@ -269,8 +269,8 @@ const QueryRequestSchemaWithType = z.object({
   format: z.enum(["JSON", "JSONEachRow", "CSV", "TabSeparated"]).optional().default("JSON"),
   queryId: z.string().optional(),
   /**
-   * User-configured row cap.  0 = unlimited.  Absent = use server default.
-   * Validated server-side: must be 0 (unlimited) or in [100, 100_000].
+   * User-configured row cap. 0 = unlimited. Absent = use server default.
+   * Small values are honored (truncation + ClickHouse max_result_rows).
    */
   maxResultRows: z.number().int().min(0).max(100_000).optional(),
 });
@@ -514,7 +514,7 @@ const databaseRouter = new Hono<{ Variables: Variables }>();
  * Permission: QUERY_EXECUTE or TABLE_SELECT
  */
 tableRouter.post("/select", zValidator("json", QueryRequestSchemaWithType), async (c) => {
-  const { query: sql, format, queryId } = c.req.valid("json");
+  const { query: sql, format, queryId, maxResultRows } = c.req.valid("json");
   const rbacUserId = c.get("rbacUserId");
   const rbacPermissions = c.get("rbacPermissions");
   const isRbacAdmin = c.get("isRbacAdmin");
@@ -538,7 +538,7 @@ tableRouter.post("/select", zValidator("json", QueryRequestSchemaWithType), asyn
     }
   }
 
-  return executeQueryWithValidation(c, sql, format, 'SELECT', queryId);
+  return executeQueryWithValidation(c, sql, format, 'SELECT', queryId, maxResultRows);
 });
 
 /**

--- a/packages/server/src/services/clickhouse.test.ts
+++ b/packages/server/src/services/clickhouse.test.ts
@@ -71,6 +71,33 @@ describe("ClickHouse Service", () => {
             // The service wraps the error but preserves the message if available
             expect(service.executeQuery("SELECT *")).rejects.toThrow("DB Error");
         });
+
+        it("should truncate to maxResultRows regardless of engine behavior", async () => {
+            const ten = Array.from({ length: 10 }, (_, i) => ({ n: i }));
+            mockJsonFn.mockResolvedValueOnce({
+                data: ten,
+                meta: [{ name: "n", type: "UInt64" }],
+                statistics: { elapsed: 0.1, rows_read: 10, bytes_read: 80 }
+            });
+
+            const result = await service.executeQuery("SELECT n FROM t", "JSON", undefined, 2);
+
+            expect(result.data).toHaveLength(2);
+            expect(result.rows).toBe(2);
+        });
+
+        it("should leave data untouched without a cap (or cap 0)", async () => {
+            const ten = Array.from({ length: 10 }, (_, i) => ({ n: i }));
+            for (const cap of [undefined, 0] as const) {
+                mockJsonFn.mockResolvedValueOnce({
+                    data: ten,
+                    meta: [{ name: "n", type: "UInt64" }],
+                    statistics: { elapsed: 0.1, rows_read: 10, bytes_read: 80 }
+                });
+                const result = await service.executeQuery("SELECT n FROM t", "JSON", undefined, cap);
+                expect(result.data).toHaveLength(10);
+            }
+        });
     });
 
     describe("streamQueryRows ON CLUSTER (issue #336)", () => {

--- a/packages/server/src/services/clickhouse.ts
+++ b/packages/server/src/services/clickhouse.ts
@@ -240,11 +240,22 @@ export class ClickHouseService {
         rows?: number;
       };
 
+      // Enforce an explicit caller cap here instead of trusting ClickHouse
+      // alone: recent server builds ignore small max_result_rows values, so
+      // the API contract (0 = unlimited, otherwise truncate) holds regardless
+      // of engine behavior. Uncapped paths are untouched.
+      let data = jsonResult.data || [];
+      let rows = jsonResult.rows || (jsonResult.data?.length ?? 0);
+      if (maxResultRows !== undefined && maxResultRows > 0 && data.length > maxResultRows) {
+        data = data.slice(0, maxResultRows);
+        rows = data.length;
+      }
+
       return {
         meta: jsonResult.meta || [],
-        data: jsonResult.data || [],
+        data,
         statistics: jsonResult.statistics || { elapsed: 0, rows_read: 0, bytes_read: 0 },
-        rows: jsonResult.rows || (jsonResult.data?.length ?? 0),
+        rows,
         queryId: result.query_id,
         error: null,
       };

--- a/scripts/e2e-cli-check.py
+++ b/scripts/e2e-cli-check.py
@@ -382,6 +382,49 @@ def t_login_persists_server():
     assert "admin" in out, out[-300:]
 
 
+def t_dry_run_standalone():
+    # --dry-run previews without --yes (the refusal message promises this).
+    p = cli("query", "--raw", "--dry-run",
+            "CREATE TABLE dryrun_t (id UInt32) ENGINE = MergeTree() ORDER BY id",
+            "--output", "json")
+    assert p.returncode == 0, f"dry-run without --yes must work, got {p.returncode}: {p.stderr[-300:]}"
+    assert "dry_run" in p.stdout, p.stdout[-500:]
+
+
+def t_dry_run_unsupported():
+    # Mutations with no preview support must fail fast, never execute.
+    for args in (["live", "kill", "nope"], ["saved", "delete", "nope"]):
+        p = cli(*args, "--dry-run", "--yes")
+        assert p.returncode == 2, f"{args} must exit 2, got {p.returncode}"
+        assert "not supported" in p.stderr, p.stderr[-300:]
+
+
+def t_connection_spelling():
+    # --connection and -c are one flag: identical results either way.
+    a = need(cli("saved", "list", "--connection", STATE["connection_id"], "--output", "json"))
+    b = need(cli("saved", "list", "-c", STATE["connection_id"], "--output", "json"))
+    assert a == b, f"spelling divergence:\n{a[-300:]}\n{b[-300:]}"
+
+
+def t_login_output_json():
+    # login honors -o: machine result on stdout, human note on stderr.
+    import tempfile as _tf  # noqa: E402
+    home = _tf.mkdtemp(prefix="chouse-e2e-login-json-")
+    p = cli_scrubbed("auth", "login", "--server", BASE, "--token",
+                     STATE["pat"], "-o", "json", home=home)
+    assert p.returncode == 0, f"login exit={p.returncode}: {p.stderr[-300:]}"
+    data = json.loads(p.stdout)
+    assert data["server"] == BASE, p.stdout[-300:]
+    assert STATE["pat"] not in p.stdout, "raw PAT must never render"
+
+
+def t_ai_optimize_guarded():
+    # LLM spend needs --yes even though nothing mutates: refusal costs nothing.
+    p = cli("ai", "optimize", "SELECT 1")
+    assert p.returncode == 2, f"optimize without --yes must refuse, got {p.returncode}"
+    assert "ai.optimize" in p.stderr, p.stderr[-300:]
+
+
 def t_cleanup_writes():
     need(cli("query", "--raw", "--yes", f"DROP TABLE IF EXISTS {DB}.t"))
     need(cli("query", "--raw", "--yes", f"DROP DATABASE IF EXISTS {DB}"))
@@ -435,6 +478,11 @@ def main():
         ("cli-no-server-fail-fast", t_no_server_fail_fast),
         ("cli-auth-status-unconfigured", t_auth_status_unconfigured),
         ("cli-login-persists-server", t_login_persists_server),
+        ("cli-dry-run-standalone", t_dry_run_standalone),
+        ("cli-dry-run-unsupported", t_dry_run_unsupported),
+        ("cli-connection-spelling", t_connection_spelling),
+        ("cli-login-output-json", t_login_output_json),
+        ("cli-ai-optimize-guarded", t_ai_optimize_guarded),
         ("cli-cleanup-writes", t_cleanup_writes),
         ("cli-cleanup-identity", t_cleanup_identity),
     ]:


### PR DESCRIPTION
## Description

Follow-up to the live flag audit: every global flag now works as advertised on every command, `--dry-run` can no longer silently execute, and table output follows a documented contract.

## Type of Change

- [x] Bug fix (dry-run execution hole, -c shadowing, timeout cap, toRows field loss)
- [x] New feature (login/logout machine output, incidents --limit, saved create --connection)
- [x] Breaking change (--no-color removed; ai optimize/connection use now gated; login stdout now JSON)
- [x] Documentation update

## Related Issue

Closes #

## Changes Made

- P0 safety: `rejectDryRun()` guard on all non-preview mutations (saved delete, live kill, scheduled run/delete, health run/ack, alert test, doctor scan); `confirmDestructive` added to `connection use` and `ai optimize`.
- P1 promises: dry-run-first preview in query/upload/explorer; single global `-c/--connection` (locals removed); login/logout render machine output; `timeoutSecs()` unifies ctx + HTTP client caps; confirm prompt moved to stderr.
- P2 hygiene: `--no-color` removed; `explorer create` uiOnly-first; query rejects `--file`+--stdin`; `--format` help disambiguated; `health incidents --limit` (client-side); `toRows` preserves scalar/nested data fields.
- Tests: helpers/root/output unit tests (incl. shorthand-collision sweep, no-color absence lock); 6 new e2e checks.

## Testing

- [x] I have tested this locally
- [x] I have added/updated tests
- [x] All existing tests pass

### Test Steps

- `gofmt -l` clean, `go vet`, `go test -count=1 ./...` in `cli/` (-race via CI).
- Local install of branch build + full 73-case matrix re-run with real credentials (results below).
- Full `./scripts/e2e-cli.sh` DinD run incl. new checks (results below).

## Screenshots

N/A.

## Changelog Fragment

- [ ] Added `changelogs/cli/unreleased/<pr-number>-cli-correctness-pass.md` (after PR number known)

## Checklist

- [x] My code follows the project's code style guidelines
- [x] I have performed a self-review (`.rules/CODE_REVIEWER.md`)
- [x] Changes generate no new warnings or errors
- [x] Breaking changes documented above
- [x] Touched files scanned for dead code (`.rules/DEAD_CODE.md`)

## Additional Notes

Validates the audit findings F1-F14 end to end. `saved create` intentionally left unguarded (metadata-only, e2e depends on it).

---

## Update: server-side `--limit` fix (F12 root cause)

Live investigation showed the CLI faithfully sent `maxResultRows`, but `POST /query/table/select` destructured it out and never passed it on (`query.ts:517/541`). Worse, ClickHouse 26.8 ignores small `max_result_rows` values entirely (proven: cap=2 returned 65409 rows direct), so the fix has two layers:

- Route passes `maxResultRows` through (one line + stale `[100, 100_000]` comment corrected).
- `ClickHouseService.executeQuery` truncates server-side when an explicit cap is set (uncapped paths byte-identical; internal callers pass `undefined` and are unaffected).
- Tests: route passthrough test + service truncation/unlimited tests (`bun test` per-file green; combined multi-file `mock.module` pollution is pre-existing on clean tree, CI runs per-file).
- Live proof in DinD (server rebuilt from tree): `--limit 2` → 2 rows, `--limit 0` → 10 rows.
- App fragment `changelogs/unreleased/346-query-max-rows.md` (patch) since the code change rides the app release line.


---

## Update 2: user-friendly `--help` everywhere

Previously zero commands had `Long`/`Example` (only root had `Long`). Now all 83 helpable nodes carry guidance + runnable real examples each (`system.numbers`, validated flag combos, fake ids, masked tokens only); `Use:` lines normalized (`query [sql]`, `ai optimize [sql]`); root `Long` extended (kept `Safe-by-default` verbatim for the CI grep).

- `root_test.go: TestHelpCompleteness` walks the tree and fails the build on any node missing Long/Example (exempt: auto-generated `help`, `completion/*`) — future commands can't regress silently.
- Verified: 89-node `--help` sweep green, spot-checked full texts; `gofmt`/`vet`/`test` green.
- Fragment `changelogs/cli/unreleased/346-cli-help.md` (minor, Added).
